### PR TITLE
test: rename the test properties to sample names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 target
 *.log
 *.log.*
+src/test/resources/cloudant.properties
+src/test/resources/cloudant-2.properties

--- a/README.md
+++ b/README.md
@@ -940,7 +940,12 @@ account.setGsonBuilder(builder);
 
 ## tests
 
-To run the test suite first edit the cloudant properties. Open the file `src/test/resources/cloudant.properties` and `src/test/resources/cloudant-2.properties`, provide values for the following properties  
+The test suite needs access to cloudant account(s) to run.
+To run the test suite first edit the cloudant properties.
+Copy the files `src/test/resources/cloudant-sample.properties` and
+`src/test/resources/cloudant-2-sample.properties` to
+`src/test/resources/cloudant.properties` and
+`src/test/resources/cloudant-2.properties`, and then provide values for the following properties:
 
 ~~~ java
 cloudant.account=myCloudantAccount
@@ -948,11 +953,12 @@ cloudant.username=testuser
 cloudant.password=testpassword
 ~~~
 
-Once all the required properties are provided in the properties file run `com.cloudant.test.main.CloudantTestSuite` test class.
+Once all the required properties are provided in the properties file
+run the `com.cloudant.test.main.CloudantTestSuite` test class.
 
 ## License
 
-Copyright 2014 Cloudant, an IBM company.
+Copyright 2014-2015 Cloudant, an IBM company.
 
 Licensed under the apache license, version 2.0 (the "license"); you may not use this file except in compliance with the license.  you may obtain a copy of the license at
 

--- a/src/test/resources/cloudant-2-sample.properties
+++ b/src/test/resources/cloudant-2-sample.properties
@@ -1,3 +1,5 @@
+# Rename this file to cloudant-2.properties
+# and then add your information.
 ### Required
 cloudant.account=
 cloudant.username=

--- a/src/test/resources/cloudant-sample.properties
+++ b/src/test/resources/cloudant-sample.properties
@@ -1,3 +1,5 @@
+# Rename this file to cloudant.properties
+# and then add your information.
 ### Required
 cloudant.account=
 cloudant.username=


### PR DESCRIPTION
Following the advice in README.md, we don't want to accidentally
check in the test properties file with account credentials!

Renamed the files to "sample" names and updated the docs.