### PR TITLE
Database.getFindByIndexBody() generates invalid JSON when >1 sort fields are used

### DIFF
--- a/src/main/java/com/cloudant/client/api/Database.java
+++ b/src/main/java/com/cloudant/client/api/Database.java
@@ -764,6 +764,7 @@ public class Database {
 					   .append("\": \"")
 					   .append(idxfld.getOrder())
 					   .append("\"}");
+				i++;
 			}
 			so.append("]");
 		}


### PR DESCRIPTION
getFindByIndexBody() generates a JSON array of sort fields in a way that works for one sort field, but fails with more than one field because of missing commas.
Ex:
[{"myField": "asc"}] Valid
[{"myFieldOne": "asc"}{"myFieldTwo": "asc"}] Invalid because of missing comma.

The logic to build the array is inside a foreach loop, including:
   if (i > 0 ) {
      so.append(",");
   }
The loop is missing an incrementer for i so the value is never > 0 and the comma is never inserted.