### PR TITLE
46770 character encoding bug

### DIFF
--- a/src/main/java/com/cloudant/client/api/Database.java
+++ b/src/main/java/com/cloudant/client/api/Database.java
@@ -14,6 +14,7 @@ import static org.lightcouch.internal.URIBuilder.buildUri;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
+import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Type;
 import java.net.URI;
 import java.util.ArrayList;
@@ -235,7 +236,7 @@ public class Database {
 		 InputStream stream = null; 
 		 try {
 			 stream = getStream(client.executeRequest(createPost(uri, body, "application/json")));
-			 Reader reader = new InputStreamReader(stream);
+			 Reader reader = new InputStreamReader(stream, "UTF-8");
 			 JsonArray jsonArray = new JsonParser().parse(reader)
 						.getAsJsonObject().getAsJsonArray("docs");
 			List<T> list = new ArrayList<T>();
@@ -245,6 +246,9 @@ public class Database {
 				list.add(t);
 			}
 			return list;
+		 } catch (UnsupportedEncodingException e) {
+			// This should never happen as every implementation of the java platform is required to support UTF-8.
+			throw new RuntimeException(e);
 		 }
 		 finally {
 			 close(stream);

--- a/src/main/java/com/cloudant/client/api/Search.java
+++ b/src/main/java/com/cloudant/client/api/Search.java
@@ -10,6 +10,7 @@ import static org.lightcouch.internal.CouchDbUtil.getStream;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
+import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -121,7 +122,7 @@ public class Search {
 		InputStream instream = null;
 		List<T> result = new ArrayList<T>();
 		try {  
-			Reader reader = new InputStreamReader(instream = queryForStream(query));
+			Reader reader = new InputStreamReader(instream = queryForStream(query), "UTF-8");
 			JsonObject json = new JsonParser().parse(reader).getAsJsonObject(); 
 			if ( json.has("rows") ) {
 				if (!includeDocs) {
@@ -136,6 +137,9 @@ public class Search {
 				log.warn("No ungrouped result available. Use queryGroups() if grouping set");
 			}
 			return result;
+		} catch (UnsupportedEncodingException e1) {
+			// This should never happen as every implementation of the java platform is required to support UTF-8.
+			throw new RuntimeException(e1);
 		}
 		finally {
 			close(instream);
@@ -154,7 +158,7 @@ public class Search {
 	public <T> Map<String,List<T>> queryGroups(String query, Class<T> classOfT) {
 		InputStream instream = null;
 		try {  
-			Reader reader = new InputStreamReader(instream = queryForStream(query));
+			Reader reader = new InputStreamReader(instream = queryForStream(query), "UTF-8");
 			JsonObject json = new JsonParser().parse(reader).getAsJsonObject(); 
 			Map<String,List<T>> result = new LinkedHashMap<String, List<T>>();
 			if ( json.has("groups") ) 	{
@@ -175,6 +179,9 @@ public class Search {
 				log.warn("No grouped results available. Use query() if non grouped query");
 			}
 			return result;
+		} catch (UnsupportedEncodingException e1) {
+			// This should never happen as every implementation of the java platform is required to support UTF-8.
+			throw new RuntimeException(e1);
 		}
 		finally {
 			close(instream);
@@ -194,7 +201,7 @@ public class Search {
 	public <T> SearchResult<T> querySearchResult(String query, Class<T> classOfT) {
 		InputStream instream = null;
 		try {  
-			Reader reader = new InputStreamReader(instream = queryForStream(query));
+			Reader reader = new InputStreamReader(instream = queryForStream(query), "UTF-8");
 			JsonObject json = new JsonParser().parse(reader).getAsJsonObject(); 
 			SearchResult<T> sr = new SearchResult<T>();
 			sr.setTotalRows(getAsLong(json, "total_rows")); 
@@ -215,6 +222,9 @@ public class Search {
 				sr.setRanges(getFieldsCounts(json.getAsJsonObject("ranges").entrySet()));
 			}
 			return sr;
+		} catch (UnsupportedEncodingException e) {
+			// This should never happen as every implementation of the java platform is required to support UTF-8.
+			throw new RuntimeException(e);
 		}
 		finally {
 			close(instream);

--- a/src/main/java/org/lightcouch/Changes.java
+++ b/src/main/java/org/lightcouch/Changes.java
@@ -19,6 +19,7 @@ package org.lightcouch;
 import java.io.BufferedReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.UnsupportedEncodingException;
 import java.net.URI;
 
 import org.apache.http.client.methods.HttpGet;
@@ -87,8 +88,13 @@ public class Changes {
 		final URI uri = uriBuilder.query("feed", "continuous").build();
 		httpGet = new HttpGet(uri);
 		final InputStream in = dbc.get(httpGet);
-		final InputStreamReader is = new InputStreamReader(in);
-		setReader(new BufferedReader(is));
+		try {
+			final InputStreamReader is = new InputStreamReader(in, "UTF-8");
+			setReader(new BufferedReader(is));
+		} catch (UnsupportedEncodingException e) {
+			// This should never happen as every implementation of the java platform is required to support UTF-8.
+			throw new RuntimeException(e);
+		}
 		return this;
 	}
 

--- a/src/main/java/org/lightcouch/CouchDbClientBase.java
+++ b/src/main/java/org/lightcouch/CouchDbClientBase.java
@@ -13,6 +13,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
+import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Type;
 import java.net.URI;
 import java.util.List;
@@ -212,8 +213,11 @@ public abstract class CouchDbClientBase {
 			try {
 				Type typeOfList = new TypeToken<List<String>>() {}.getType();
 				instream = get(buildUri(getBaseUri()).path("_all_dbs").build());
-				Reader reader = new InputStreamReader(instream);
+				Reader reader = new InputStreamReader(instream, "UTF-8");
 				return getGson().fromJson(reader, typeOfList);
+			} catch (UnsupportedEncodingException e) {
+				// This should never happen as every implementation of the java platform is required to support UTF-8.
+				throw new RuntimeException(e);
 			} finally {
 				close(instream);
 			}
@@ -226,8 +230,11 @@ public abstract class CouchDbClientBase {
 			InputStream instream = null;
 			try {
 				instream = get(buildUri(getBaseUri()).build());
-				Reader reader = new InputStreamReader(instream);
+				Reader reader = new InputStreamReader(instream, "UTF-8");
 				return getAsString(new JsonParser().parse(reader).getAsJsonObject(), "version");
+			} catch (UnsupportedEncodingException e) {
+				// This should never happen as every implementation of the java platform is required to support UTF-8.
+				throw new RuntimeException(e);
 			} finally {
 				close(instream);
 			}
@@ -323,7 +330,10 @@ public abstract class CouchDbClientBase {
 			InputStream in = null;
 			try {
 				in = get(uri);
-				return getGson().fromJson(new InputStreamReader(in), classType);
+				return getGson().fromJson(new InputStreamReader(in, "UTF-8"), classType);
+			} catch (UnsupportedEncodingException e) {
+				// This should never happen as every implementation of the java platform is required to support UTF-8.
+				throw new RuntimeException(e);
 			} finally {
 				close(in);
 			}

--- a/src/main/java/org/lightcouch/Replication.java
+++ b/src/main/java/org/lightcouch/Replication.java
@@ -22,6 +22,7 @@ import static org.lightcouch.internal.CouchDbUtil.getStream;
 import static org.lightcouch.internal.URIBuilder.buildUri;
 
 import java.io.InputStreamReader;
+import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.util.Map;
 
@@ -100,8 +101,11 @@ public class Replication {
 			}
 			final URI uri = buildUri(client.getBaseUri()).path("_replicate").build();
 			response = client.post(uri, json.toString());
-			final InputStreamReader reader = new InputStreamReader(getStream(response));
+			final InputStreamReader reader = new InputStreamReader(getStream(response), "UTF-8");
 			return client.getGson().fromJson(reader, ReplicationResult.class);
+		} catch (UnsupportedEncodingException e) {
+			// This should never happen as every implementation of the java platform is required to support UTF-8.
+			throw new RuntimeException(e);
 		} finally {
 			close(response);
 		}

--- a/src/main/java/org/lightcouch/Replicator.java
+++ b/src/main/java/org/lightcouch/Replicator.java
@@ -24,6 +24,7 @@ import static org.lightcouch.internal.URIBuilder.buildUri;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
+import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
@@ -125,7 +126,7 @@ public class Replicator {
 		InputStream instream = null;
 		try {  
 			final URI uri = buildUri(dbURI).path("_all_docs").query("include_docs", "true").build();
-			final Reader reader = new InputStreamReader(instream = client.get(uri));
+			final Reader reader = new InputStreamReader(instream = client.get(uri), "UTF-8");
 			final JsonArray jsonArray = new JsonParser().parse(reader)
 					.getAsJsonObject().getAsJsonArray("rows");
 			final List<ReplicatorDocument> list = new ArrayList<ReplicatorDocument>();
@@ -137,6 +138,9 @@ public class Replicator {
 				}
 			}
 			return list;
+		} catch (UnsupportedEncodingException e) {
+			// This should never happen as every implementation of the java platform is required to support UTF-8.
+			throw new RuntimeException(e);
 		} finally {
 			close(instream);
 		}

--- a/src/main/java/org/lightcouch/View.java
+++ b/src/main/java/org/lightcouch/View.java
@@ -187,7 +187,7 @@ public class View {
 	public <K, V, T> ViewResult<K, V, T> queryView(Class<K> classOfK, Class<V> classOfV, Class<T> classOfT) {
 		InputStream instream = null;
 		try {  
-			Reader reader = new InputStreamReader(instream = queryForStream());
+			Reader reader = new InputStreamReader(instream = queryForStream(), "UTF-8");
 			JsonObject json = new JsonParser().parse(reader).getAsJsonObject(); 
 			ViewResult<K, V, T> vr = new ViewResult<K, V, T>();
 			vr.setTotalRows(getAsLong(json, "total_rows")); 
@@ -208,6 +208,9 @@ public class View {
 				vr.getRows().add(row);
 			}
 			return vr;
+		} catch (UnsupportedEncodingException e1) {
+			// This should never happen as every implementation of the java platform is required to support UTF-8.
+			throw new RuntimeException(e1);
 		} finally {
 			close(instream);
 		}
@@ -247,13 +250,16 @@ public class View {
 	private <V> V queryValue(Class<V> classOfV) {
 		InputStream instream = null;
 		try {  
-			Reader reader = new InputStreamReader(instream = queryForStream());
+			Reader reader = new InputStreamReader(instream = queryForStream(), "UTF-8");
 			JsonArray array = new JsonParser().parse(reader).
 							getAsJsonObject().get("rows").getAsJsonArray();
 			if(array.size() != 1) { // expect exactly 1 row
 				throw new NoDocumentException("Expecting exactly a single result of this view query, but was: " + array.size());
 			}
 			return JsonToObject(gson, array.get(0), "value", classOfV);
+		} catch (UnsupportedEncodingException e) {
+			// This should never happen as every implementation of the java platform is required to support UTF-8.
+			throw new RuntimeException(e);
 		} finally {
 			close(instream);
 		}

--- a/src/main/java/org/lightcouch/View.java
+++ b/src/main/java/org/lightcouch/View.java
@@ -29,6 +29,7 @@ import static org.lightcouch.internal.CouchDbUtil.readFile;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
+import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -157,7 +158,7 @@ public class View {
 	public <T> List<T> query(Class<T> classOfT) {
 		InputStream instream = null;
 		try {  
-			Reader reader = new InputStreamReader(instream = queryForStream());
+			Reader reader = new InputStreamReader(instream = queryForStream(), "UTF-8");
 			JsonArray jsonArray = new JsonParser().parse(reader)
 					.getAsJsonObject().getAsJsonArray("rows");
 			List<T> list = new ArrayList<T>();
@@ -170,6 +171,9 @@ public class View {
 				list.add(t);
 			}
 			return list;
+		} catch (UnsupportedEncodingException e) {
+			// This should never happen as every implementation of the java platform is required to support UTF-8.
+			throw new RuntimeException(e);
 		} finally {
 			close(instream);
 		}

--- a/src/main/java/org/lightcouch/internal/CouchDbUtil.java
+++ b/src/main/java/org/lightcouch/internal/CouchDbUtil.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
+import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Type;
 import java.net.URI;
 import java.net.URL;
@@ -227,8 +228,11 @@ final public class CouchDbUtil {
 		
 		try {
 			instream = getStream(response);
-			Reader reader = new InputStreamReader(instream);
+			Reader reader = new InputStreamReader(instream, "UTF-8");
 			return getAsString(new JsonParser().parse(reader).getAsJsonObject(), e);
+		} catch (UnsupportedEncodingException e1) {
+			// This should never happen as every implementation of the java platform is required to support UTF-8.
+			throw new RuntimeException(e1);
 		}
 		finally {
 			close(instream);
@@ -264,8 +268,13 @@ final public class CouchDbUtil {
 	 */
 	public static  <T> List<T> getResponseList(HttpResponse response, Gson gson, Class<T> klazz, Type typeofT) throws CouchDbException {
 		InputStream instream = getStream(response);
-		Reader reader = new InputStreamReader(instream);
-		return gson.fromJson(reader,typeofT);
+		try {
+			Reader reader = new InputStreamReader(instream, "UTF-8");
+			return gson.fromJson(reader,typeofT);
+		} catch (UnsupportedEncodingException e) {
+			// This should never happen as every implementation of the java platform is required to support UTF-8.
+			throw new RuntimeException(e);
+		}
 	}
 	
 	/**
@@ -273,8 +282,13 @@ final public class CouchDbUtil {
 	 * @return {@link Response}
 	 */
 	public static <T> T getResponse(HttpResponse response, Class<T> classType, Gson gson) throws CouchDbException {
-		InputStreamReader reader = new InputStreamReader(getStream(response));
-		return gson.fromJson(reader, classType);
+		try {
+			InputStreamReader reader = new InputStreamReader(getStream(response), "UTF-8");
+			return gson.fromJson(reader, classType);
+		} catch (UnsupportedEncodingException e) {
+			// This should never happen as every implementation of the java platform is required to support UTF-8.
+			throw new RuntimeException(e);
+		}
 	}
 	 
 	/**
@@ -283,7 +297,12 @@ final public class CouchDbUtil {
 	 */
 	public static  Map<String,EnumSet<Permissions>> getResponseMap(HttpResponse response, Gson gson, Type typeofT) throws CouchDbException {
 		InputStream instream = getStream(response);
-		Reader reader = new InputStreamReader(instream);
-		return gson.fromJson(reader,typeofT);
+		try {
+			Reader reader = new InputStreamReader(instream, "UTF-8");
+			return gson.fromJson(reader,typeofT);
+		} catch (UnsupportedEncodingException e) {
+			// This should never happen as every implementation of the java platform is required to support UTF-8.
+			throw new RuntimeException(e);
+		}
 	}
 }

--- a/src/test/java/com/cloudant/test/main/CloudantTestSuite.java
+++ b/src/test/java/com/cloudant/test/main/CloudantTestSuite.java
@@ -16,6 +16,7 @@ import com.cloudant.tests.IndexTests;
 import com.cloudant.tests.ReplicationTest;
 import com.cloudant.tests.ReplicatorTest;
 import com.cloudant.tests.SearchTests;
+import com.cloudant.tests.UnicodeTest;
 import com.cloudant.tests.UpdateHandlerTest;
 import com.cloudant.tests.ViewsTest;
 
@@ -35,6 +36,7 @@ import com.cloudant.tests.ViewsTest;
 	   ReplicatorTest.class,
 	   SearchTests.class,
 	   UpdateHandlerTest.class,
+	   UnicodeTest.class,
 	   ViewsTest.class
 	})
 public class CloudantTestSuite {

--- a/src/test/java/com/cloudant/tests/UnicodeTest.java
+++ b/src/test/java/com/cloudant/tests/UnicodeTest.java
@@ -1,0 +1,346 @@
+package com.cloudant.tests;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.net.SocketException;
+import java.net.URI;
+import java.nio.CharBuffer;
+import java.nio.charset.Charset;
+import java.nio.charset.UnsupportedCharsetException;
+import java.util.List;
+import java.util.Properties;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.http.Consts;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPut;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.protocol.HTTP;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.cloudant.client.api.CloudantClient;
+import com.cloudant.client.api.Database;
+import com.cloudant.client.api.model.Index;
+import com.cloudant.client.api.model.IndexField;
+import com.cloudant.client.api.model.IndexField.SortOrder;
+import com.cloudant.tests.util.Utils;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+public class UnicodeTest {
+
+	private static final Log log = LogFactory.getLog(UnicodeTest.class);
+	private static final String DB_NAME = "unicodetestdb";
+
+	// According to JSON (ECMA-404, section 9 "Strings"):
+	// - All Unicode characters except those that must be escaped
+	//   (U+0000..U+001F, U+0022, U+005C) may be placed in a string.
+	// - All Unicode characters may be included as Unicode escapes
+	//   (after conversion to UTF-16).
+	private static final String TESTSTRING = "Gr\u00fc\u00dfe \u65e5\u672c\u8a9e \uD834\uDD1E.";
+	private static final String TESTSTRING_ESCAPED = "Gr\\u00fc\\u00dfe \\u65e5\\u672c\\u8a9e \\uD834\\uDD1E.";
+
+	private static CloudantClient dbClient;
+	private static Database db;
+	private static Properties props ;
+
+	@BeforeClass
+	public static void setUpClass() {
+		props = Utils.getProperties("cloudant.properties",log);
+		dbClient = new CloudantClient(props.getProperty("cloudant.account"),
+				  props.getProperty("cloudant.username"),
+				  props.getProperty("cloudant.password"));
+	}
+
+	@AfterClass
+	public static void tearDownClass() {
+		dbClient.shutdown();
+	}
+
+	@Before
+	public void setup() {
+		db = dbClient.database(DB_NAME, true);
+	}
+	
+	@After
+	public void tearDown() {
+		dbClient.deleteDB(DB_NAME, "delete database");
+	}
+
+	// ========================================================================
+	// REST request utilities.
+
+	/**
+	 * Returns the charset of a plain-text entity.
+	 */
+	private static Charset getPlainTextEntityCharset(HttpEntity entity, URI uri) {
+		// For plain text, use the charset that is mentioned in the response
+		// header field 'Content-Type'.
+		// See http://stackoverflow.com/questions/3216730/with-httpclient-is-there-a-way-to-get-the-character-set-of-the-page-with-a-head
+		ContentType contentType;
+		try {
+			contentType = ContentType.getOrDefault(entity);
+		} catch (UnsupportedCharsetException e) {
+			throw new RuntimeException("The output of "+uri+" is in charset "+e.getCharsetName()+", which is unsupported.",
+									   e);
+		}
+		Charset charset = contentType.getCharset();
+		if (charset == null) {
+			// In the HTTP protocol, the default charset is ISO-8859-1.
+			// But not for the Cloudant server:
+			// - When we retrieve a document without specifying an 'Accept' header,
+			//   it replies with a UTF-8 encoded JSON string and a header
+			//   "Content-Type: text/plain;charset=utf-8".
+			// - When we do the same thing with a "Accept: application/json" header,
+			//   it replies with the same UTF-8 encoded JSON string and a header
+			//   "Content-Type: application/json". So here the UTF-8 encoding must
+			//   be implicitly understood.
+			if ("application/json".equals(contentType.getMimeType())) {
+				charset = Consts.UTF_8;
+			} else {
+				charset = HTTP.DEF_CONTENT_CHARSET;
+			}
+		}
+		return charset;
+	}
+
+	/**
+	 * Copies the content of an entity to an Appendable, as a sequence of chars.
+	 * @param destination An Appendable (such as a StringBuilder, a Writer, or a PrintStream).
+	 * @param reader A Reader that wraps the InputStream of the entity returned by the given URI.
+	 *               Should be buffered.
+	 * @throws RuntimeException if there is an exception reading the entity
+	 * @throws IOException if there is an exception writing to the destination
+	 */
+	private static void pipeEntityContentAsChars(Appendable destination, Reader reader, URI uri) throws IOException {
+		char[] buffer = new char[1024];
+		for (;;) {
+			int n;
+			try {
+				n = reader.read(buffer);
+			} catch (SocketException e) {
+				// At EOF, we may get this exception:
+				// java.net.SocketException: Socket is closed
+				//   at com.sun.net.ssl.internal.ssl.SSLSocketImpl.checkEOF(SSLSocketImpl.java:1284)
+				//   at com.sun.net.ssl.internal.ssl.AppInputStream.read(AppInputStream.java:65)
+				//   at org.apache.http.impl.io.AbstractSessionInputBuffer.fillBuffer(AbstractSessionInputBuffer.java:149)
+				//   at org.apache.http.impl.io.SocketInputBuffer.fillBuffer(SocketInputBuffer.java:110)
+				//   at org.apache.http.impl.io.AbstractSessionInputBuffer.readLine(AbstractSessionInputBuffer.java:264)
+				//   at org.apache.http.impl.io.ChunkedInputStream.getChunkSize(ChunkedInputStream.java:246)
+				//   at org.apache.http.impl.io.ChunkedInputStream.nextChunk(ChunkedInputStream.java:204)
+				//   at org.apache.http.impl.io.ChunkedInputStream.read(ChunkedInputStream.java:167)
+				//   at org.apache.http.conn.EofSensorInputStream.read(EofSensorInputStream.java:138)
+				//   at java.io.BufferedInputStream.read1(BufferedInputStream.java:256)
+				//   at java.io.BufferedInputStream.read(BufferedInputStream.java:317)
+				//   at sun.nio.cs.StreamDecoder.readBytes(StreamDecoder.java:264)
+				//   at sun.nio.cs.StreamDecoder.implRead(StreamDecoder.java:306)
+				//   at sun.nio.cs.StreamDecoder.read(StreamDecoder.java:158)
+				//   at java.io.InputStreamReader.read(InputStreamReader.java:167)
+				//   at java.io.Reader.read(Reader.java:123)
+				// See also http://stackoverflow.com/questions/17040698/httpcomponentss-ssl-connection-results-in-socket-is-closed
+				break;
+			} catch (IOException e) {
+				throw new RuntimeException("Error reading from "+uri, e);
+			}
+			if (n < 0)
+				break;
+			destination.append(CharBuffer.wrap(buffer, 0, n));
+		}
+	}
+
+	/**
+	 * Outputs a plain-text entity to a character accumulator.
+	 * @param destination An Appendable (such as a StringBuilder, a Writer, or a PrintStream).
+	 * @throws RuntimeException if there is an exception reading the entity
+	 * @throws IOException if there is an exception writing to the destination
+	 */
+	private static void pipePlainTextEntity(Appendable destination, HttpEntity entity, URI uri) throws IOException {
+		Charset charset = getPlainTextEntityCharset(entity, uri);
+		InputStream stream;
+		try {
+			stream = entity.getContent();
+		} catch (IOException e) {
+			throw new RuntimeException("Error starting to read from "+uri, e);
+		}
+		Reader reader = new InputStreamReader(new BufferedInputStream(stream), charset);
+		try {
+			pipeEntityContentAsChars(destination, reader, uri);
+		} finally {
+			try {
+				reader.close();
+			} catch (IOException e) {
+				// Ignore errors. We were only reading from a socket.
+			}
+		}
+	}
+
+	/**
+	 * Returns a plain-text entity as a string.
+	 * @throws RuntimeException if there is an exception reading the entity
+	 */
+	private static String getPlainTextEntityAsString(HttpEntity entity, URI uri) {
+		StringBuilder buf = new StringBuilder();
+		try {
+			pipePlainTextEntity(buf, entity, uri);
+		} catch (IOException e) {
+			// Shouldn't happen.
+			throw new RuntimeException(e);
+		}
+		return buf.toString();
+	}
+
+	/**
+	 * The JsonParser instance to reuse each time parseAsJson method is invoked
+	 */
+	static private final JsonParser JSON_PARSER = new JsonParser();
+
+	/**
+	 * Returns a JSON entity as a JSON object.
+	 */
+	private static JsonObject getJSONEntityAsJsonObject(HttpEntity entity, URI uri) {
+		// Optimized: Avoids the use of a temporary string.
+		Charset charset = getPlainTextEntityCharset(entity, uri);
+		InputStream stream;
+		try {
+			stream = entity.getContent();
+		} catch (IOException e) {
+			throw new RuntimeException("Error starting to read from "+uri, e);
+		}
+		Reader reader = new InputStreamReader(new BufferedInputStream(stream), charset);
+		return JSON_PARSER.parse(reader).getAsJsonObject();
+	}
+
+	/**
+	 * Closes a REST response.
+	 */
+	private static void closeResponse(HttpResponse response) {
+		if (response instanceof CloseableHttpResponse) {
+			try {
+				((CloseableHttpResponse)response).close();
+			} catch (IOException e) {
+				// We were only reading from a socket.
+			}
+		}
+	}
+
+	// ========================================================================
+
+	/**
+	 * Test whether literal Unicode characters in a string work.
+	 */
+	@Test
+	public void testLiteralUnicode() {
+		URI uri = URI.create(db.getDBUri()+"literal");
+		{
+			HttpPut request = new HttpPut(uri);
+			request.addHeader("Accept", "application/json");
+			HttpEntity entity = new StringEntity("{\"foo\":\""+TESTSTRING+"\"}", ContentType.APPLICATION_JSON); //$NON-NLS-1$ //$NON-NLS-2$
+			request.setEntity(entity);
+			HttpResponse response = dbClient.executeRequest(request);
+			assertEquals(201, response.getStatusLine().getStatusCode());
+			closeResponse(response);
+		}
+		{
+			HttpGet request = new HttpGet(uri);
+			request.addHeader("Accept", "application/json");
+			HttpResponse response = dbClient.executeRequest(request);
+			assertEquals(200, response.getStatusLine().getStatusCode());
+			String result = getPlainTextEntityAsString(response.getEntity(), uri);
+			System.out.println("testLiteralUnicode: Result as returned in entity: "+result);
+			closeResponse(response);
+		}
+		{
+			HttpGet request = new HttpGet(uri);
+			request.addHeader("Accept", "application/json");
+			HttpResponse response = dbClient.executeRequest(request);
+			assertEquals(200, response.getStatusLine().getStatusCode());
+			JsonObject result = getJSONEntityAsJsonObject(response.getEntity(), uri);
+			String value = result.get("foo").getAsString();
+			assertEquals(TESTSTRING, value);
+			closeResponse(response);
+		}
+	}
+
+	/**
+	 * Test whether escaped Unicode characters in a string work.
+	 */
+	@Test
+	public void testEscapedUnicode() {
+		URI uri = URI.create(db.getDBUri()+"escaped");
+		{
+			HttpPut request = new HttpPut(uri);
+			request.addHeader("Accept", "application/json");
+			HttpEntity entity = new StringEntity("{\"foo\":\""+TESTSTRING_ESCAPED+"\"}", ContentType.APPLICATION_JSON); //$NON-NLS-1$ //$NON-NLS-2$
+			request.setEntity(entity);
+			HttpResponse response = dbClient.executeRequest(request);
+			assertEquals(201, response.getStatusLine().getStatusCode());
+			closeResponse(response);
+		}
+		{
+			HttpGet request = new HttpGet(uri);
+			request.addHeader("Accept", "application/json");
+			HttpResponse response = dbClient.executeRequest(request);
+			assertEquals(200, response.getStatusLine().getStatusCode());
+			String result = getPlainTextEntityAsString(response.getEntity(), uri);
+			System.out.println("testEscapedUnicode: Result as returned in entity: "+result);
+			closeResponse(response);
+		}
+		{
+			HttpGet request = new HttpGet(uri);
+			request.addHeader("Accept", "application/json");
+			HttpResponse response = dbClient.executeRequest(request);
+			assertEquals(200, response.getStatusLine().getStatusCode());
+			JsonObject result = getJSONEntityAsJsonObject(response.getEntity(), uri);
+			String value = result.get("foo").getAsString();
+			assertEquals(TESTSTRING, value);
+			closeResponse(response);
+		}
+	}
+
+	public static class MyObject {
+		public String foo;
+	}
+
+	/**
+	 * Test whether Unicode characters in a Java object work.
+	 */
+	// This test used to fail if the default encoding of the current JVM is not UTF-8.
+	// To reproduce: In Eclipse, use "Run > Run Configurations...", tab "Common",
+	// panel "Encoding", set the encoding to ISO-8859-1.
+	@Test
+	public void testUnicodeInObject() {
+		db.createIndex(
+			"myview", "mydesigndoc", "json",
+			new IndexField[] {
+				new IndexField("foo", SortOrder.asc)
+			});
+		// Show the indices.
+		for (Index index : db.listIndices()) {
+			System.out.println(index);
+		}
+		// Create an object.
+		MyObject object = new MyObject();
+		object.foo = TESTSTRING;
+		db.save(object);
+		// We can now retrieve the matching documents through
+		// GET /wladmin/_design/mydesigndoc/_view/myview?reduce=false&include_docs=true
+		List<MyObject> result = db.view("mydesigndoc/myview").reduce(false).includeDocs(true).query(MyObject.class);
+		assertEquals(1, result.size());
+		String value = result.get(0).foo;
+		assertEquals(TESTSTRING, value);
+	}
+}


### PR DESCRIPTION
Fixes FB#46770.

This fixes the specific bug identified by the test case included in the bug report: Instantiating an InputStreamReader using the platform's default charset can lead to corruption of non ASCII characters. The fix forces the InputStreamReader to use UTF-8. 

Additionally, all other usages of InputStreamReader have been changed to use UTF-8 instead of the platform default charset.

Note that UTF-8 is required to be supported by every implementation of the Java platform - see under "Standard charsets" here:
http://docs.oracle.com/javase/7/docs/api/java/nio/charset/Charset.html

*TESTING*
The test case from the bug report has been modified to fit the style used by the existing tests and incorporated into the test suite.  It was confirmed using the modified test that prior to the code fixes the test failed when the platform's default charset was set to use ISO08859-1 and that once fixed the test passes.

reviewer @mikerhodes
reviewer @rhyshort 