### PR TITLE
46986 queries do not encode +

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ target
 *.log.*
 src/test/resources/cloudant.properties
 src/test/resources/cloudant-2.properties
+.idea/
+*.iml
+build/
+.gradle/

--- a/src/main/java/com/cloudant/client/api/Database.java
+++ b/src/main/java/com/cloudant/client/api/Database.java
@@ -69,849 +69,849 @@ import com.google.gson.reflect.TypeToken;
  */
 public class Database {
 
-	static final Log log = LogFactory.getLog(Database.class);
-	private CouchDatabase db;
-	private CloudantClient client;
-	
-	/**
-	 * 
-	 * @param client
-	 * @param db
-	 */
-	Database(CloudantClient client, CouchDatabase db ) {
-		super();
-		this.client = client;
-		this.db = db;		
-	}
-	
-	/**
-	 * Set permissions for a user/apiKey on the database
-	 * @param userNameorApikey
-	 * @param permissions permissions to grant
-	 */
-	public void setPermissions(String userNameorApikey,  EnumSet<Permissions> permissions) {
-		assertNotEmpty(userNameorApikey,"userNameorApikey");
-		assertNotEmpty(permissions,"permissions");
-		final JsonArray jsonPermissions = new JsonArray();
-		for (Permissions s : permissions) {
-			final JsonPrimitive permission = new JsonPrimitive(s.toString());
-			jsonPermissions.add(permission);
-		}
-	    		
-	    // get existing permissions
-		URI uri = buildUri(getDBUri()).path("_security").build();
-		JsonObject perms =  client.get(uri, JsonObject.class);
-	 		
-	    // now set back
-		JsonElement elem = perms.getAsJsonObject().get("cloudant");
-		if ( elem == null) {
-			perms.addProperty("_id", "_security");
-			elem = new JsonObject();
-			perms.add("cloudant", elem);
-		}
-		elem.getAsJsonObject().add(userNameorApikey, jsonPermissions);
-		
-	    HttpResponse response = null;
-	    HttpPut put = new HttpPut(buildUri(uri).build());
-		setEntity(put, client.getGson().toJson(perms),"application/json");
-		try {
-			response = executeRequest(put);
-			String ok = getAsString(response,"ok");
-			if ( !ok.equalsIgnoreCase("true")) {
-				//raise exception
-			}
-		}
-		finally {
-			close(response);
-		}
-	}
-	
-	/**
-	 * Returns the Permissions on the database from the /db/_security document
-	 * @return Map<String,EnumSet<Permissions>> the map of userNames to their Permissions
-	 */
-	public Map<String,EnumSet<Permissions>> getPermissions() {
-		HttpResponse resp = null;
-		HttpGet get = new HttpGet(buildUri(getDBUri()).path("_security").build());
-		try {
-			resp = client.executeRequest(get);
-			return getResponseMap(resp, client.getGson(), 
-					new TypeToken<Map<String,EnumSet<Permissions>>>(){}.getType());
-		}
-		finally {
-			close(resp);
-		}
-	}
-		
-	
-	/**
-	 * Get info about the shards in the database
-	 * @return List of shards
-	 */
-	 public List<Shard> getShards() {
-		HttpResponse response = null;
-		HttpGet get = new HttpGet(buildUri(db.getDBUri()).path("/_shards").build());
-		try {
-			response = client.executeRequest(get);
-			return getResponseList(response, client.getGson(), Shard.class,
-							new TypeToken<List<Shard>>(){}.getType());
-		}
-		finally {
-			close(response);
-		}
-	}
-	
-	 /**
-	 * Get info about the shard a document belongs to 
-	 * @param String documentId
-	 * @return Shard info
-	 */
-	 public Shard getShard(String docId) {
-		assertNotEmpty(docId,"docId");
-		return client.get(buildUri(getDBUri()).path("_shards/").path(docId).build(), Shard.class);
-	}
-
-
-	/**
-	 * Create a new index
-	 * @param indexName optional name of the index (if not provided one will be generated) 
-	 * @param designDocName optional name of the design doc in which the index will be created
-	 * @param indexType optional, type of index (only "json" as of now)
-	 * @param fields array of fields in the index
-	 */
-	 public void createIndex(String indexName, String designDocName, String indexType, IndexField[] fields) {
-		String indexDefn = getIndexDefinition(indexName,designDocName,indexType,fields);
-		createIndex(indexDefn);
-	 }
-	 
-	 /**
-	  * create a new Index
-	  * @param @see <a href="http://docs.cloudant.com/api/cloudant-query.html#creating-a-new-index">indexDefinition</a> 
-	  */
-	 public void createIndex(String indexDefinition) {
-		 assertNotEmpty(indexDefinition, "indexDefinition");
-		 HttpResponse putresp = null;
-		 URI uri = buildUri(getDBUri()).path("_index").build();
-		 try {
-			 putresp = client.executeRequest(createPost(uri,indexDefinition,"application/json"));
-			 String result = getAsString(putresp,"result");
-			 if  (result.equalsIgnoreCase("created")) {
-				 log.info(String.format("Created Index: '%s'", indexDefinition));
-			 }
-			 else {
-				 log.warn(String.format("Index already exists : '%s'", indexDefinition));
-			 }
-		 }
-		 finally {
-			 close(putresp);
-		 }
-	 }
-	 
-	  
-	 /**
-	  * Find documents using an index 
-	  * @param selectorJson JSON object describing criteria used to select documents.
-	  *        Is of the form "selector": { <your data here> } @see <a href="http://docs.cloudant.com/api/cloudant-query.html#cloudant-query-selectors">selector syntax</a>
-	  * @param classOfT The class of Java objects to be returned
-	  * @return List of classOfT objects
-	  */
-	 public <T> List<T> findByIndex(String selectorJson, Class<T> classOfT) {
-		 return findByIndex(selectorJson, classOfT, new FindByIndexOptions());
-	 }
-	 
-	 /**
-	  * Find documents using an index 
-	  * @param selectorJson JSON object describing criteria used to select documents.
-	  *        Is of the form "selector": { <your data here> }  @see <a href="http://docs.cloudant.com/api/cloudant-query.html#cloudant-query-selectors">selector syntax</a>
-	  * @param options   {@link FindByIndexOptions query Index options} 
-	  * @param classOfT The class of Java objects to be returned
-	  * @return List of classOfT objects
-	  */
-	 public <T> List<T> findByIndex(String selectorJson, Class<T> classOfT, FindByIndexOptions options) {
-		 assertNotEmpty(selectorJson, "selectorJson");
-		 assertNotEmpty(options, "options");
-		 
-		 URI uri = buildUri(getDBUri()).path("_find").build();
-		 String body = getFindByIndexBody(selectorJson, options);
-		 InputStream stream = null; 
-		 try {
-			 stream = getStream(client.executeRequest(createPost(uri, body, "application/json")));
-			 Reader reader = new InputStreamReader(stream, "UTF-8");
-			 JsonArray jsonArray = new JsonParser().parse(reader)
-						.getAsJsonObject().getAsJsonArray("docs");
-			List<T> list = new ArrayList<T>();
-			for (JsonElement jsonElem : jsonArray) {
-				JsonElement elem = jsonElem.getAsJsonObject();
-				T t = client.getGson().fromJson(elem, classOfT);
-				list.add(t);
-			}
-			return list;
-		 } catch (UnsupportedEncodingException e) {
-			// This should never happen as every implementation of the java platform is required to support UTF-8.
-			throw new RuntimeException(e);
-		 }
-		 finally {
-			 close(stream);
-		 }
-	}
-	 
-	 /**
-	  * List all indices
-	  * @return List of Index
-	  */
-	 public List<Index> listIndices() {
-		 HttpResponse response = null;
-		 try {
-			 response = client.executeRequest(new HttpGet(buildUri(getDBUri()).path("_index/").build()));
-			 return getResponseList(response, client.getGson(), Index.class,
-							new TypeToken<List<Index>>(){}.getType());
-		 }
-		 finally {
-			 close(response);
-		 }
-	 }
-	 
-	 /**
-	  * Delete an index
-	  * @param indexName name of the index
-	  * @param designDocId ID of the design doc
-	  */
-	 public void deleteIndex(String indexName, String designDocId) {
-		 assertNotEmpty(indexName, "indexName");
-		 assertNotEmpty(designDocId, "designDocId");
-		 URI uri = buildUri(getDBUri()).path("_index/").path(designDocId).path("/json/").path(indexName).build();
-		 HttpResponse response = null;
-		try {
-			response = client.executeRequest(new HttpDelete(uri)); 
-			getResponse(response,Response.class, client.getGson());
-		} finally {
-			close(response);
-		}
-	 }
-	 
-	 /**
-	  * Provides access to Cloudant <tt>Search</tt> APIs.
-	  * @see Search
-	  */
-	 public Search search(String searchIndexId) {
-		 return new Search(this, searchIndexId);
-	 }
-	 
-	 /**
-	  * Provides access to CouchDB Design Documents.
-	  * @see CouchDbDesign
-	  */
-	public DbDesign design() {
-		return new DbDesign(db,client);
-	}
-
-
-
-	/**
-	 * Provides access to CouchDB <tt>View</tt> APIs.
-	 * @see View
-	 */
-	public com.cloudant.client.api.View view(String viewId) {
-		 View couchDbview = db.view(viewId);
-		 com.cloudant.client.api.View view = new com.cloudant.client.api.View();
-		 view.setView(couchDbview);
-		 return view ;
-	}
-
-
-
-	/**
-	 * Provides access to <tt>Change Notifications</tt> API.
-	 * @see Changes
-	 */
-	public com.cloudant.client.api.Changes changes() {
-		Changes couchDbChanges = db.changes();
-		com.cloudant.client.api.Changes changes = new com.cloudant.client.api.Changes(couchDbChanges);
-		return changes ;
-	}
-
-
-
-	/**
-	 * Finds an Object of the specified type.
-	 * @param <T> Object type.
-	 * @param classType The class of type T.
-	 * @param id The document id.
-	 * @return An object of type T.
-	 * @throws NoDocumentException If the document is not found in the database.
-	 */
-	public <T> T find(Class<T> classType, String id) {
-		return db.find(classType, id);
-	}
-
-
-
-	/**
-	 * Finds an Object of the specified type.
-	 * @param <T> Object type.
-	 * @param classType The class of type T.
-	 * @param id The document id.
-	 * @param params Extra parameters to append.
-	 * @return An object of type T.
-	 * @throws NoDocumentException If the document is not found in the database.
-	 */
-	public <T> T find(Class<T> classType, String id, Params params) {
-		assertNotEmpty(params, "params");
-		return db.find(classType, id, params.getInternalParams());
-	}
-
-
-
-	/**
-	 * Finds an Object of the specified type.
-	 * @param <T> Object type.
-	 * @param classType The class of type T.
-	 * @param id The document _id field.
-	 * @param rev The document _rev field.
-	 * @return An object of type T.
-	 * @throws NoDocumentException If the document is not found in the database.
-	 */
-	public <T> T find(Class<T> classType, String id, String rev) {
-		return db.find(classType, id, rev);
-	}
-
-
-
-	/**
-	 * This method finds any document given a URI.
-	 * <p>The URI must be URI-encoded.
-	 * @param classType The class of type T.
-	 * @param uri The URI as string.
-	 * @return An object of type T.
-	 */
-	public <T> T findAny(Class<T> classType, String uri) {
-		return db.findAny(classType, uri);
-	}
-
-
-
-	/**
-	 * Finds a document and return the result as {@link InputStream}.
-	 * <p><b>Note</b>: The stream must be closed after use to release the connection.
-	 * @param id The document _id field.
-	 * @return The result as {@link InputStream}
-	 * @throws NoDocumentException If the document is not found in the database.
-	 * @see #find(String, String)
-	 */
-	public InputStream find(String id) {
-		return db.find(id);
-	}
-
-
-
-	/**
-	 * Finds a document given id and revision and returns the result as {@link InputStream}.
-	 * <p><b>Note</b>: The stream must be closed after use to release the connection.
-	 * @param id The document _id field.
-	 * @param rev The document _rev field.
-	 * @return The result as {@link InputStream}
-	 * @throws NoDocumentException If the document is not found in the database.
-	 */
-	public InputStream find(String id, String rev) {
-		return db.find(id, rev);
-	}
-
-
-
-	/**
-	 * Checks if a document exist in the database.
-	 * @param id The document _id field.
-	 * @return true If the document is found, false otherwise.
-	 */
-	public boolean contains(String id) {
-		return db.contains(id);
-	}
-
-
-	/**
-	 * Saves an object in the database, using HTTP <tt>PUT</tt> request.
-	 * <p>If the object doesn't have an <code>_id</code> value, the code will assign a <code>UUID</code> as the document id.
-	 * @param object The object to save
-	 * @throws DocumentConflictException If a conflict is detected during the save.
-	 * @return {@link Response}
-	 */
-	public com.cloudant.client.api.model.Response save(Object object) {
-		Response couchDbResponse = db.save(object);
-		com.cloudant.client.api.model.Response response = new com.cloudant.client.api.model.Response(couchDbResponse);
-		return response ; 
-	}
-
-	/**
-	 * Saves an object in the database, using HTTP <tt>PUT</tt> request.
-	 * <p>If the object doesn't have an <code>_id</code> value, the code will assign a <code>UUID</code> as the document id.
-	 * @param object The object to save
-	 * @param writeQuorum the write Quorum
-	 * @throws DocumentConflictException If a conflict is detected during the save.
-	 * @return {@link Response}
-	 */
-	public com.cloudant.client.api.model.Response save(Object object, int writeQuorum) {
-		Response couchDbResponse = client.put(getDBUri(), object, true, writeQuorum, client.getGson());
-		com.cloudant.client.api.model.Response response = new com.cloudant.client.api.model.Response(couchDbResponse);
-		return response ;
-	}
-	
-	
-	/**
-	 * Saves an object in the database using HTTP <tt>POST</tt> request.
-	 * <p>The database will be responsible for generating the document id.
-	 * @param object The object to save
-	 * @return {@link Response}
-	 */
-	public com.cloudant.client.api.model.Response post(Object object) {
-		Response couchDbResponse =db.post(object);
-		com.cloudant.client.api.model.Response response = new com.cloudant.client.api.model.Response(couchDbResponse);
-		return response ;
-	}
-	
-	/**
-	 * Saves an object in the database using HTTP <tt>POST</tt> request with specificied write quorum
-	 * <p>The database will be responsible for generating the document id.
-	 * @param object The object to save
-	 * @param writeQuorum the write Quorum
-	 * @return {@link Response}
-	 */
-	public com.cloudant.client.api.model.Response post(Object object, int writeQuorum) {
-		assertNotEmpty(object, "object");
-		HttpResponse response = null;
-		try { 
-			URI uri = buildUri(getDBUri()).query("w",writeQuorum).build();
-			response = client.executeRequest(createPost(uri, client.getGson().toJson(object),"application/json"));
-			Response couchDbResponse =getResponse(response,Response.class, client.getGson());
-			com.cloudant.client.api.model.Response cloudantResponse = new com.cloudant.client.api.model.Response(couchDbResponse);
-			return cloudantResponse ;
-		} finally {
-			close(response);
-		}
-	}
-
-
-
-	/**
-	 * Saves a document with <tt>batch=ok</tt> query param.
-	 * @param object The object to save.
-	 */
-	public void batch(Object object) {
-		db.batch(object);
-	}
-
-
-
-	/**
-	 * Updates an object in the database, the object must have the correct <code>_id</code> and <code>_rev</code> values.
-	 * @param object The object to update
-	 * @throws DocumentConflictException If a conflict is detected during the update.
-	 * @return {@link Response}
-	 */
-	public com.cloudant.client.api.model.Response update(Object object) {
-		Response couchDbResponse = db.update(object);
-		com.cloudant.client.api.model.Response response = new com.cloudant.client.api.model.Response(couchDbResponse);
-		return response ;
-	}
-
-	/**
-	 * Updates an object in the database, the object must have the correct <code>_id</code> and <code>_rev</code> values.
-	 * @param object The object to update
-	 * @param writeQuorum the write Quorum
-	 * @throws DocumentConflictException If a conflict is detected during the update.
-	 * @return {@link Response}
-	 */
-	public com.cloudant.client.api.model.Response update(Object object, int writeQuorum) {
-		Response couchDbResponse =client.put(getDBUri(), object, false, writeQuorum,client.getGson());
-		com.cloudant.client.api.model.Response response = new com.cloudant.client.api.model.Response(couchDbResponse);
-		return response ;
-	}
-
-
-	/**
-	 * Removes a document from the database. 
-	 * <p>The object must have the correct <code>_id</code> and <code>_rev</code> values.
-	 * @param object The document to remove as object.
-	 * @throws NoDocumentException If the document is not found in the database.
-	 * @return {@link Response}
-	 */
-	public com.cloudant.client.api.model.Response remove(Object object) {
-		Response couchDbResponse = db.remove(object);
-		com.cloudant.client.api.model.Response response = new com.cloudant.client.api.model.Response(couchDbResponse);
-		return response ; 
-	}
-
-
-
-	/**
-	 * Removes a document from the database given both a document <code>_id</code> and <code>_rev</code> values.
-	 * @param id The document _id field.
-	 * @param rev The document _rev field.
-	 * @throws NoDocumentException If the document is not found in the database.
-	 * @return {@link Response}
-	 */
-	public com.cloudant.client.api.model.Response remove(String id, String rev) {
-		Response couchDbResponse =  db.remove(id, rev);
-		com.cloudant.client.api.model.Response response = new com.cloudant.client.api.model.Response(couchDbResponse);
-		return response ;  
-	}
-
-
-
-	/**
-	 * Performs a Bulk Documents insert request.
-	 * @param objects The {@link List} of objects.
-	 * @return {@code List<Response>} Containing the resulted entries.
-	 */
-	public List<com.cloudant.client.api.model.Response> bulk(List<?> objects) {
-		List<Response> couchDbResponseList =  db.bulk(objects, false);
-		List<com.cloudant.client.api.model.Response> cloudantResponseList = new ArrayList<com.cloudant.client.api.model.Response>();
-		for(Response couchDbResponse : couchDbResponseList){
-			com.cloudant.client.api.model.Response response = new com.cloudant.client.api.model.Response(couchDbResponse);
-			cloudantResponseList.add(response);
-		}
-		return cloudantResponseList ;
-	}
-	
-	/**
-	 * Saves an attachment to a new document with a generated <tt>UUID</tt> as the document id.
-	 * <p>To retrieve an attachment, see {@link #find(String)}.
-	 * @param instream The {@link InputStream} holding the binary data.
-	 * @param name The attachment name.
-	 * @param contentType The attachment "Content-Type".
-	 * @return {@link Response}
-	 */
-	public com.cloudant.client.api.model.Response saveAttachment(InputStream in, String name,
-			String contentType) {
-		Response couchDbResponse =  db.saveAttachment(in, name, contentType);
-		com.cloudant.client.api.model.Response response = new com.cloudant.client.api.model.Response(couchDbResponse);
-		return response ;   
-	}
-
-
-
-	/**
-	 * Saves an attachment to an existing document given both a document id
-	 * and revision, or save to a new document given only the id, and rev as {@code null}.
-	 * <p>To retrieve an attachment, see {@link #find(String)}.
-	 * @param instream The {@link InputStream} holding the binary data.
-	 * @param name The attachment name.
-	 * @param contentType The attachment "Content-Type".
-	 * @param docId The document id to save the attachment under, or {@code null} to save under a new document.
-	 * @param docRev The document revision to save the attachment under, or {@code null} when saving to a new document.
-	 * @throws DocumentConflictException 
-	 * @return {@link Response}
-	 */
-	public com.cloudant.client.api.model.Response saveAttachment(InputStream in, String name,
-			String contentType, String docId, String docRev) {
-		Response couchDbResponse =  db.saveAttachment(in, name, contentType, docId, docRev);
-		com.cloudant.client.api.model.Response response = new com.cloudant.client.api.model.Response(couchDbResponse);
-		return response ;   
-	}
-
-
-
-	/**
-	 * Invokes an Update Handler.
-	 * <pre>
-	 * String query = "field=foo&value=bar";
-	 * String output = dbClient.invokeUpdateHandler("designDoc/update1", "docId", query);
-	 * </pre>
-	 * @param updateHandlerUri The Update Handler URI, in the format: <code>designDoc/update1</code>
-	 * @param docId The document id to update.
-	 * @param query The query string parameters, e.g, <code>field=field1&value=value1</code>
-	 * @return The output of the request.
-	 */
-	public String invokeUpdateHandler(String updateHandlerUri, String docId,
-			String query) {
-		return db.invokeUpdateHandler(updateHandlerUri, docId, query);
-	}
-
-
-
-	/**
-	 * Invokes an Update Handler.
-	 * <p>Use this method in particular when the docId contain special characters such as slashes (/).
-	 * <pre>
-	 * Params params = new Params()
-	 *	.addParam("field", "foo")
-	 *	.addParam("value", "bar"); 
-	 * String output = dbClient.invokeUpdateHandler("designDoc/update1", "docId", params);
-	 * </pre>
-	 * @param updateHandlerUri The Update Handler URI, in the format: <code>designDoc/update1</code>
-	 * @param docId The document id to update.
-	 * @param query The query parameters as {@link Params}.
-	 * @return The output of the request.
-	 */
-	public String invokeUpdateHandler(String updateHandlerUri, String docId,
-			Params params) {
-		assertNotEmpty(params, "params");
-		return db.invokeUpdateHandler(updateHandlerUri, docId, params.getInternalParams());
-	}
-
-
-
-	/**
-	 * Synchronize all design documents with the database.
-	 */
-	public void syncDesignDocsWithDb() {
-		db.syncDesignDocsWithDb();
-	}
-
-
-
-	/**
-	 * @return The database URI.
-	 */
-	public URI getDBUri() {
-		return db.getDBUri();
-	}
-
-
-
-	/**
-	 * @return {@link CouchDbInfo} Containing the DB info.
-	 */
-	public DbInfo info() {
-		return client.get(buildUri(getDBUri()).build(), DbInfo.class);
-	}
-
-
-
-	/**
-	 * Requests the database commits any recent changes to disk.
-	 */
-	public void ensureFullCommit() {
-		db.ensureFullCommit();
-	}
-
-
-	// private helper methods
-
-	/**
-	 * Form a create index json from parameters
-	 */
-	private String getIndexDefinition(String indexName, String designDocName,
-				String indexType, IndexField[] fields) {
-		assertNotEmpty(fields, "index fields");
-		boolean addComma = false;
-		String json = "{";
-		if ( !(indexName == null || indexName.isEmpty()) ) {
-			json += "\"name\": \"" + indexName + "\"";
-			addComma = true;
-		}
-		if ( !(designDocName == null || designDocName.isEmpty()) ) {
-			if (addComma) {
-				json += ",";
-			}
-			json += "\"ddoc\": \"" + designDocName + "\"";
-			addComma = true;
-		}
-		if ( !(indexType == null || indexType.isEmpty()) ) {
-			if (addComma) {
-				json += ",";
-			}
-			json += "\"type\": \"" + indexType + "\"";
-			addComma = true;
-		}
-		
-		if (addComma) {
-			json += ",";
-		}
-		json += "\"index\": { \"fields\": [";
-		for (int i = 0 ; i < fields.length; i++) {
-			json += "{\"" + fields[i].getName() + "\": " +  "\"" + fields[i].getOrder() + "\"}";
-			if ( i+1 < fields.length) {
-				json += ",";
-			}
-		}
-		
-		return json + "] }}";
-	}
-	 
-	/**
-	 * 
-	 * @param selectorJson
-	 * @param sortOrder
-	 * @param limit
-	 * @param skip
-	 * @param returnFields
-	 * @param readQuorum
-	 * @return
-	 */
-	private String getFindByIndexBody(String selectorJson,
-						FindByIndexOptions options) {
-		
-		StringBuilder rf = null;
-		if ( options.getFields().size() > 0) {
-			rf = new StringBuilder("\"fields\": [");
-			int i = 0;
-			for ( String s : options.getFields() ) {
-				if (i > 0 ) {
-					rf.append(",");
-				}
-				rf.append("\"").append(s).append("\"");
-				i++;
-			}
-			rf.append("]");
-		}
-				
-		StringBuilder so = null;
-		if ( options.getSort().size() > 0) {
-			so = new StringBuilder("\"sort\": [");
-			int i = 0;
-			for ( IndexField idxfld : options.getSort() ) {
-				if (i > 0 ) {
-					so.append(",");
-				}
-				so.append("{\"")
-					   .append(idxfld.getName())
-					   .append("\": \"")
-					   .append(idxfld.getOrder())
-					   .append("\"}");
-				i++;
-			}
-			so.append("]");
-		}
-		
-		//parse and find if valid json issue #28
-		boolean isObject = true;
-		try {
-			client.getGson().fromJson(selectorJson, JsonObject.class );
-		}
-		catch(JsonParseException e) {
-			isObject = false;
-		}
-		
-		if (!isObject) {
-			// needs to start with selector
-			if ( !(selectorJson.trim().startsWith("\"selector\"")) ) {
-				throw new JsonParseException("selectorJson should be valid json or like \"selector\": {...} ");
-			}
-		}
-		
-		StringBuilder finalbody = new StringBuilder();
-		if ( isObject ) {
-			finalbody.append("{\"selector\": ")
-				.append(selectorJson);
-		}
-		else {
-			//old support
-			finalbody.append("{" + selectorJson);
-		}
-		
-		if ( rf != null ) {
-			finalbody.append(",")
-					 .append(rf.toString());
-		}
-		if ( so != null ) {
-			finalbody.append(",")
-					 .append(so.toString());
-		}
-		if ( options.getLimit() != null ) {
-			finalbody.append(",")
-					 .append("\"limit\": ")
-					 .append(options.getLimit());
-		}
-		if ( options.getSkip() != null ) {
-			finalbody.append(",")
-					 .append("\"skip\": ")
-					 .append(options.getSkip());
-		}
-		if ( options.getReadQuorum() != null ) {
-			finalbody.append(",")
-					 .append("\"r\": ")
-					 .append(options.getReadQuorum());
-		}
-		finalbody.append("}");
-		
-		return finalbody.toString();
-	}
-	
-	HttpResponse executeRequest(HttpRequestBase request) {
-		return client.executeRequest(request);
-	}
-	
-	Gson getGson() {
-		return client.getGson();
-	}
-	
+    static final Log log = LogFactory.getLog(Database.class);
+    private CouchDatabase db;
+    private CloudantClient client;
+
+    /**
+     *
+     * @param client
+     * @param db
+     */
+    Database(CloudantClient client, CouchDatabase db ) {
+        super();
+        this.client = client;
+        this.db = db;
+    }
+
+    /**
+     * Set permissions for a user/apiKey on the database
+     * @param userNameorApikey
+     * @param permissions permissions to grant
+     */
+    public void setPermissions(String userNameorApikey,  EnumSet<Permissions> permissions) {
+        assertNotEmpty(userNameorApikey,"userNameorApikey");
+        assertNotEmpty(permissions,"permissions");
+        final JsonArray jsonPermissions = new JsonArray();
+        for (Permissions s : permissions) {
+            final JsonPrimitive permission = new JsonPrimitive(s.toString());
+            jsonPermissions.add(permission);
+        }
+
+        // get existing permissions
+        URI uri = buildUri(getDBUri()).path("_security").build();
+        JsonObject perms =  client.get(uri, JsonObject.class);
+
+        // now set back
+        JsonElement elem = perms.getAsJsonObject().get("cloudant");
+        if ( elem == null) {
+            perms.addProperty("_id", "_security");
+            elem = new JsonObject();
+            perms.add("cloudant", elem);
+        }
+        elem.getAsJsonObject().add(userNameorApikey, jsonPermissions);
+
+        HttpResponse response = null;
+        HttpPut put = new HttpPut(buildUri(uri).build());
+        setEntity(put, client.getGson().toJson(perms),"application/json");
+        try {
+            response = executeRequest(put);
+            String ok = getAsString(response,"ok");
+            if ( !ok.equalsIgnoreCase("true")) {
+                //raise exception
+            }
+        }
+        finally {
+            close(response);
+        }
+    }
+
+    /**
+     * Returns the Permissions on the database from the /db/_security document
+     * @return Map<String,EnumSet<Permissions>> the map of userNames to their Permissions
+     */
+    public Map<String,EnumSet<Permissions>> getPermissions() {
+        HttpResponse resp = null;
+        HttpGet get = new HttpGet(buildUri(getDBUri()).path("_security").build());
+        try {
+            resp = client.executeRequest(get);
+            return getResponseMap(resp, client.getGson(),
+                    new TypeToken<Map<String,EnumSet<Permissions>>>(){}.getType());
+        }
+        finally {
+            close(resp);
+        }
+    }
+
+
+    /**
+     * Get info about the shards in the database
+     * @return List of shards
+     */
+     public List<Shard> getShards() {
+        HttpResponse response = null;
+        HttpGet get = new HttpGet(buildUri(db.getDBUri()).path("/_shards").build());
+        try {
+            response = client.executeRequest(get);
+            return getResponseList(response, client.getGson(), Shard.class,
+                            new TypeToken<List<Shard>>(){}.getType());
+        }
+        finally {
+            close(response);
+        }
+    }
+
+     /**
+     * Get info about the shard a document belongs to
+     * @param String documentId
+     * @return Shard info
+     */
+     public Shard getShard(String docId) {
+        assertNotEmpty(docId,"docId");
+        return client.get(buildUri(getDBUri()).path("_shards/").path(docId).build(), Shard.class);
+    }
+
+
+    /**
+     * Create a new index
+     * @param indexName optional name of the index (if not provided one will be generated)
+     * @param designDocName optional name of the design doc in which the index will be created
+     * @param indexType optional, type of index (only "json" as of now)
+     * @param fields array of fields in the index
+     */
+     public void createIndex(String indexName, String designDocName, String indexType, IndexField[] fields) {
+        String indexDefn = getIndexDefinition(indexName,designDocName,indexType,fields);
+        createIndex(indexDefn);
+     }
+
+     /**
+      * create a new Index
+      * @param @see <a href="http://docs.cloudant.com/api/cloudant-query.html#creating-a-new-index">indexDefinition</a>
+      */
+     public void createIndex(String indexDefinition) {
+         assertNotEmpty(indexDefinition, "indexDefinition");
+         HttpResponse putresp = null;
+         URI uri = buildUri(getDBUri()).path("_index").build();
+         try {
+             putresp = client.executeRequest(createPost(uri,indexDefinition,"application/json"));
+             String result = getAsString(putresp,"result");
+             if  (result.equalsIgnoreCase("created")) {
+                 log.info(String.format("Created Index: '%s'", indexDefinition));
+             }
+             else {
+                 log.warn(String.format("Index already exists : '%s'", indexDefinition));
+             }
+         }
+         finally {
+             close(putresp);
+         }
+     }
+
+
+     /**
+      * Find documents using an index
+      * @param selectorJson JSON object describing criteria used to select documents.
+      *        Is of the form "selector": { <your data here> } @see <a href="http://docs.cloudant.com/api/cloudant-query.html#cloudant-query-selectors">selector syntax</a>
+      * @param classOfT The class of Java objects to be returned
+      * @return List of classOfT objects
+      */
+     public <T> List<T> findByIndex(String selectorJson, Class<T> classOfT) {
+         return findByIndex(selectorJson, classOfT, new FindByIndexOptions());
+     }
+
+     /**
+      * Find documents using an index
+      * @param selectorJson JSON object describing criteria used to select documents.
+      *        Is of the form "selector": { <your data here> }  @see <a href="http://docs.cloudant.com/api/cloudant-query.html#cloudant-query-selectors">selector syntax</a>
+      * @param options   {@link FindByIndexOptions query Index options}
+      * @param classOfT The class of Java objects to be returned
+      * @return List of classOfT objects
+      */
+     public <T> List<T> findByIndex(String selectorJson, Class<T> classOfT, FindByIndexOptions options) {
+         assertNotEmpty(selectorJson, "selectorJson");
+         assertNotEmpty(options, "options");
+
+         URI uri = buildUri(getDBUri()).path("_find").build();
+         String body = getFindByIndexBody(selectorJson, options);
+         InputStream stream = null;
+         try {
+             stream = getStream(client.executeRequest(createPost(uri, body, "application/json")));
+             Reader reader = new InputStreamReader(stream, "UTF-8");
+             JsonArray jsonArray = new JsonParser().parse(reader)
+                        .getAsJsonObject().getAsJsonArray("docs");
+            List<T> list = new ArrayList<T>();
+            for (JsonElement jsonElem : jsonArray) {
+                JsonElement elem = jsonElem.getAsJsonObject();
+                T t = client.getGson().fromJson(elem, classOfT);
+                list.add(t);
+            }
+            return list;
+         } catch (UnsupportedEncodingException e) {
+            // This should never happen as every implementation of the java platform is required to support UTF-8.
+            throw new RuntimeException(e);
+         }
+         finally {
+             close(stream);
+         }
+    }
+
+     /**
+      * List all indices
+      * @return List of Index
+      */
+     public List<Index> listIndices() {
+         HttpResponse response = null;
+         try {
+             response = client.executeRequest(new HttpGet(buildUri(getDBUri()).path("_index/").build()));
+             return getResponseList(response, client.getGson(), Index.class,
+                            new TypeToken<List<Index>>(){}.getType());
+         }
+         finally {
+             close(response);
+         }
+     }
+
+     /**
+      * Delete an index
+      * @param indexName name of the index
+      * @param designDocId ID of the design doc
+      */
+     public void deleteIndex(String indexName, String designDocId) {
+         assertNotEmpty(indexName, "indexName");
+         assertNotEmpty(designDocId, "designDocId");
+         URI uri = buildUri(getDBUri()).path("_index/").path(designDocId).path("/json/").path(indexName).build();
+         HttpResponse response = null;
+        try {
+            response = client.executeRequest(new HttpDelete(uri));
+            getResponse(response,Response.class, client.getGson());
+        } finally {
+            close(response);
+        }
+     }
+
+     /**
+      * Provides access to Cloudant <tt>Search</tt> APIs.
+      * @see Search
+      */
+     public Search search(String searchIndexId) {
+         return new Search(this, searchIndexId);
+     }
+
+     /**
+      * Provides access to CouchDB Design Documents.
+      * @see CouchDbDesign
+      */
+    public DbDesign design() {
+        return new DbDesign(db,client);
+    }
+
+
+
+    /**
+     * Provides access to CouchDB <tt>View</tt> APIs.
+     * @see View
+     */
+    public com.cloudant.client.api.View view(String viewId) {
+         View couchDbview = db.view(viewId);
+         com.cloudant.client.api.View view = new com.cloudant.client.api.View();
+         view.setView(couchDbview);
+         return view ;
+    }
+
+
+
+    /**
+     * Provides access to <tt>Change Notifications</tt> API.
+     * @see Changes
+     */
+    public com.cloudant.client.api.Changes changes() {
+        Changes couchDbChanges = db.changes();
+        com.cloudant.client.api.Changes changes = new com.cloudant.client.api.Changes(couchDbChanges);
+        return changes ;
+    }
+
+
+
+    /**
+     * Finds an Object of the specified type.
+     * @param <T> Object type.
+     * @param classType The class of type T.
+     * @param id The document id.
+     * @return An object of type T.
+     * @throws NoDocumentException If the document is not found in the database.
+     */
+    public <T> T find(Class<T> classType, String id) {
+        return db.find(classType, id);
+    }
+
+
+
+    /**
+     * Finds an Object of the specified type.
+     * @param <T> Object type.
+     * @param classType The class of type T.
+     * @param id The document id.
+     * @param params Extra parameters to append.
+     * @return An object of type T.
+     * @throws NoDocumentException If the document is not found in the database.
+     */
+    public <T> T find(Class<T> classType, String id, Params params) {
+        assertNotEmpty(params, "params");
+        return db.find(classType, id, params.getInternalParams());
+    }
+
+
+
+    /**
+     * Finds an Object of the specified type.
+     * @param <T> Object type.
+     * @param classType The class of type T.
+     * @param id The document _id field.
+     * @param rev The document _rev field.
+     * @return An object of type T.
+     * @throws NoDocumentException If the document is not found in the database.
+     */
+    public <T> T find(Class<T> classType, String id, String rev) {
+        return db.find(classType, id, rev);
+    }
+
+
+
+    /**
+     * This method finds any document given a URI.
+     * <p>The URI must be URI-encoded.
+     * @param classType The class of type T.
+     * @param uri The URI as string.
+     * @return An object of type T.
+     */
+    public <T> T findAny(Class<T> classType, String uri) {
+        return db.findAny(classType, uri);
+    }
+
+
+
+    /**
+     * Finds a document and return the result as {@link InputStream}.
+     * <p><b>Note</b>: The stream must be closed after use to release the connection.
+     * @param id The document _id field.
+     * @return The result as {@link InputStream}
+     * @throws NoDocumentException If the document is not found in the database.
+     * @see #find(String, String)
+     */
+    public InputStream find(String id) {
+        return db.find(id);
+    }
+
+
+
+    /**
+     * Finds a document given id and revision and returns the result as {@link InputStream}.
+     * <p><b>Note</b>: The stream must be closed after use to release the connection.
+     * @param id The document _id field.
+     * @param rev The document _rev field.
+     * @return The result as {@link InputStream}
+     * @throws NoDocumentException If the document is not found in the database.
+     */
+    public InputStream find(String id, String rev) {
+        return db.find(id, rev);
+    }
+
+
+
+    /**
+     * Checks if a document exist in the database.
+     * @param id The document _id field.
+     * @return true If the document is found, false otherwise.
+     */
+    public boolean contains(String id) {
+        return db.contains(id);
+    }
+
+
+    /**
+     * Saves an object in the database, using HTTP <tt>PUT</tt> request.
+     * <p>If the object doesn't have an <code>_id</code> value, the code will assign a <code>UUID</code> as the document id.
+     * @param object The object to save
+     * @throws DocumentConflictException If a conflict is detected during the save.
+     * @return {@link Response}
+     */
+    public com.cloudant.client.api.model.Response save(Object object) {
+        Response couchDbResponse = db.save(object);
+        com.cloudant.client.api.model.Response response = new com.cloudant.client.api.model.Response(couchDbResponse);
+        return response ;
+    }
+
+    /**
+     * Saves an object in the database, using HTTP <tt>PUT</tt> request.
+     * <p>If the object doesn't have an <code>_id</code> value, the code will assign a <code>UUID</code> as the document id.
+     * @param object The object to save
+     * @param writeQuorum the write Quorum
+     * @throws DocumentConflictException If a conflict is detected during the save.
+     * @return {@link Response}
+     */
+    public com.cloudant.client.api.model.Response save(Object object, int writeQuorum) {
+        Response couchDbResponse = client.put(getDBUri(), object, true, writeQuorum, client.getGson());
+        com.cloudant.client.api.model.Response response = new com.cloudant.client.api.model.Response(couchDbResponse);
+        return response ;
+    }
+
+
+    /**
+     * Saves an object in the database using HTTP <tt>POST</tt> request.
+     * <p>The database will be responsible for generating the document id.
+     * @param object The object to save
+     * @return {@link Response}
+     */
+    public com.cloudant.client.api.model.Response post(Object object) {
+        Response couchDbResponse =db.post(object);
+        com.cloudant.client.api.model.Response response = new com.cloudant.client.api.model.Response(couchDbResponse);
+        return response ;
+    }
+
+    /**
+     * Saves an object in the database using HTTP <tt>POST</tt> request with specificied write quorum
+     * <p>The database will be responsible for generating the document id.
+     * @param object The object to save
+     * @param writeQuorum the write Quorum
+     * @return {@link Response}
+     */
+    public com.cloudant.client.api.model.Response post(Object object, int writeQuorum) {
+        assertNotEmpty(object, "object");
+        HttpResponse response = null;
+        try {
+            URI uri = buildUri(getDBUri()).query("w",writeQuorum).build();
+            response = client.executeRequest(createPost(uri, client.getGson().toJson(object),"application/json"));
+            Response couchDbResponse =getResponse(response,Response.class, client.getGson());
+            com.cloudant.client.api.model.Response cloudantResponse = new com.cloudant.client.api.model.Response(couchDbResponse);
+            return cloudantResponse ;
+        } finally {
+            close(response);
+        }
+    }
+
+
+
+    /**
+     * Saves a document with <tt>batch=ok</tt> query param.
+     * @param object The object to save.
+     */
+    public void batch(Object object) {
+        db.batch(object);
+    }
+
+
+
+    /**
+     * Updates an object in the database, the object must have the correct <code>_id</code> and <code>_rev</code> values.
+     * @param object The object to update
+     * @throws DocumentConflictException If a conflict is detected during the update.
+     * @return {@link Response}
+     */
+    public com.cloudant.client.api.model.Response update(Object object) {
+        Response couchDbResponse = db.update(object);
+        com.cloudant.client.api.model.Response response = new com.cloudant.client.api.model.Response(couchDbResponse);
+        return response ;
+    }
+
+    /**
+     * Updates an object in the database, the object must have the correct <code>_id</code> and <code>_rev</code> values.
+     * @param object The object to update
+     * @param writeQuorum the write Quorum
+     * @throws DocumentConflictException If a conflict is detected during the update.
+     * @return {@link Response}
+     */
+    public com.cloudant.client.api.model.Response update(Object object, int writeQuorum) {
+        Response couchDbResponse =client.put(getDBUri(), object, false, writeQuorum,client.getGson());
+        com.cloudant.client.api.model.Response response = new com.cloudant.client.api.model.Response(couchDbResponse);
+        return response ;
+    }
+
+
+    /**
+     * Removes a document from the database.
+     * <p>The object must have the correct <code>_id</code> and <code>_rev</code> values.
+     * @param object The document to remove as object.
+     * @throws NoDocumentException If the document is not found in the database.
+     * @return {@link Response}
+     */
+    public com.cloudant.client.api.model.Response remove(Object object) {
+        Response couchDbResponse = db.remove(object);
+        com.cloudant.client.api.model.Response response = new com.cloudant.client.api.model.Response(couchDbResponse);
+        return response ;
+    }
+
+
+
+    /**
+     * Removes a document from the database given both a document <code>_id</code> and <code>_rev</code> values.
+     * @param id The document _id field.
+     * @param rev The document _rev field.
+     * @throws NoDocumentException If the document is not found in the database.
+     * @return {@link Response}
+     */
+    public com.cloudant.client.api.model.Response remove(String id, String rev) {
+        Response couchDbResponse =  db.remove(id, rev);
+        com.cloudant.client.api.model.Response response = new com.cloudant.client.api.model.Response(couchDbResponse);
+        return response ;
+    }
+
+
+
+    /**
+     * Performs a Bulk Documents insert request.
+     * @param objects The {@link List} of objects.
+     * @return {@code List<Response>} Containing the resulted entries.
+     */
+    public List<com.cloudant.client.api.model.Response> bulk(List<?> objects) {
+        List<Response> couchDbResponseList =  db.bulk(objects, false);
+        List<com.cloudant.client.api.model.Response> cloudantResponseList = new ArrayList<com.cloudant.client.api.model.Response>();
+        for(Response couchDbResponse : couchDbResponseList){
+            com.cloudant.client.api.model.Response response = new com.cloudant.client.api.model.Response(couchDbResponse);
+            cloudantResponseList.add(response);
+        }
+        return cloudantResponseList ;
+    }
+
+    /**
+     * Saves an attachment to a new document with a generated <tt>UUID</tt> as the document id.
+     * <p>To retrieve an attachment, see {@link #find(String)}.
+     * @param instream The {@link InputStream} holding the binary data.
+     * @param name The attachment name.
+     * @param contentType The attachment "Content-Type".
+     * @return {@link Response}
+     */
+    public com.cloudant.client.api.model.Response saveAttachment(InputStream in, String name,
+            String contentType) {
+        Response couchDbResponse =  db.saveAttachment(in, name, contentType);
+        com.cloudant.client.api.model.Response response = new com.cloudant.client.api.model.Response(couchDbResponse);
+        return response ;
+    }
+
+
+
+    /**
+     * Saves an attachment to an existing document given both a document id
+     * and revision, or save to a new document given only the id, and rev as {@code null}.
+     * <p>To retrieve an attachment, see {@link #find(String)}.
+     * @param instream The {@link InputStream} holding the binary data.
+     * @param name The attachment name.
+     * @param contentType The attachment "Content-Type".
+     * @param docId The document id to save the attachment under, or {@code null} to save under a new document.
+     * @param docRev The document revision to save the attachment under, or {@code null} when saving to a new document.
+     * @throws DocumentConflictException
+     * @return {@link Response}
+     */
+    public com.cloudant.client.api.model.Response saveAttachment(InputStream in, String name,
+            String contentType, String docId, String docRev) {
+        Response couchDbResponse =  db.saveAttachment(in, name, contentType, docId, docRev);
+        com.cloudant.client.api.model.Response response = new com.cloudant.client.api.model.Response(couchDbResponse);
+        return response ;
+    }
+
+
+
+    /**
+     * Invokes an Update Handler.
+     * <pre>
+     * String query = "field=foo&value=bar";
+     * String output = dbClient.invokeUpdateHandler("designDoc/update1", "docId", query);
+     * </pre>
+     * @param updateHandlerUri The Update Handler URI, in the format: <code>designDoc/update1</code>
+     * @param docId The document id to update.
+     * @param query The query string parameters, e.g, <code>field=field1&value=value1</code>
+     * @return The output of the request.
+     */
+    public String invokeUpdateHandler(String updateHandlerUri, String docId,
+            String query) {
+        return db.invokeUpdateHandler(updateHandlerUri, docId, query);
+    }
+
+
+
+    /**
+     * Invokes an Update Handler.
+     * <p>Use this method in particular when the docId contain special characters such as slashes (/).
+     * <pre>
+     * Params params = new Params()
+     *	.addParam("field", "foo")
+     *	.addParam("value", "bar");
+     * String output = dbClient.invokeUpdateHandler("designDoc/update1", "docId", params);
+     * </pre>
+     * @param updateHandlerUri The Update Handler URI, in the format: <code>designDoc/update1</code>
+     * @param docId The document id to update.
+     * @param query The query parameters as {@link Params}.
+     * @return The output of the request.
+     */
+    public String invokeUpdateHandler(String updateHandlerUri, String docId,
+            Params params) {
+        assertNotEmpty(params, "params");
+        return db.invokeUpdateHandler(updateHandlerUri, docId, params.getInternalParams());
+    }
+
+
+
+    /**
+     * Synchronize all design documents with the database.
+     */
+    public void syncDesignDocsWithDb() {
+        db.syncDesignDocsWithDb();
+    }
+
+
+
+    /**
+     * @return The database URI.
+     */
+    public URI getDBUri() {
+        return db.getDBUri();
+    }
+
+
+
+    /**
+     * @return {@link CouchDbInfo} Containing the DB info.
+     */
+    public DbInfo info() {
+        return client.get(buildUri(getDBUri()).build(), DbInfo.class);
+    }
+
+
+
+    /**
+     * Requests the database commits any recent changes to disk.
+     */
+    public void ensureFullCommit() {
+        db.ensureFullCommit();
+    }
+
+
+    // private helper methods
+
+    /**
+     * Form a create index json from parameters
+     */
+    private String getIndexDefinition(String indexName, String designDocName,
+                String indexType, IndexField[] fields) {
+        assertNotEmpty(fields, "index fields");
+        boolean addComma = false;
+        String json = "{";
+        if ( !(indexName == null || indexName.isEmpty()) ) {
+            json += "\"name\": \"" + indexName + "\"";
+            addComma = true;
+        }
+        if ( !(designDocName == null || designDocName.isEmpty()) ) {
+            if (addComma) {
+                json += ",";
+            }
+            json += "\"ddoc\": \"" + designDocName + "\"";
+            addComma = true;
+        }
+        if ( !(indexType == null || indexType.isEmpty()) ) {
+            if (addComma) {
+                json += ",";
+            }
+            json += "\"type\": \"" + indexType + "\"";
+            addComma = true;
+        }
+
+        if (addComma) {
+            json += ",";
+        }
+        json += "\"index\": { \"fields\": [";
+        for (int i = 0 ; i < fields.length; i++) {
+            json += "{\"" + fields[i].getName() + "\": " +  "\"" + fields[i].getOrder() + "\"}";
+            if ( i+1 < fields.length) {
+                json += ",";
+            }
+        }
+
+        return json + "] }}";
+    }
+
+    /**
+     *
+     * @param selectorJson
+     * @param sortOrder
+     * @param limit
+     * @param skip
+     * @param returnFields
+     * @param readQuorum
+     * @return
+     */
+    private String getFindByIndexBody(String selectorJson,
+                        FindByIndexOptions options) {
+
+        StringBuilder rf = null;
+        if ( options.getFields().size() > 0) {
+            rf = new StringBuilder("\"fields\": [");
+            int i = 0;
+            for ( String s : options.getFields() ) {
+                if (i > 0 ) {
+                    rf.append(",");
+                }
+                rf.append("\"").append(s).append("\"");
+                i++;
+            }
+            rf.append("]");
+        }
+
+        StringBuilder so = null;
+        if ( options.getSort().size() > 0) {
+            so = new StringBuilder("\"sort\": [");
+            int i = 0;
+            for ( IndexField idxfld : options.getSort() ) {
+                if (i > 0 ) {
+                    so.append(",");
+                }
+                so.append("{\"")
+                       .append(idxfld.getName())
+                       .append("\": \"")
+                       .append(idxfld.getOrder())
+                       .append("\"}");
+                i++;
+            }
+            so.append("]");
+        }
+
+        //parse and find if valid json issue #28
+        boolean isObject = true;
+        try {
+            client.getGson().fromJson(selectorJson, JsonObject.class );
+        }
+        catch(JsonParseException e) {
+            isObject = false;
+        }
+
+        if (!isObject) {
+            // needs to start with selector
+            if ( !(selectorJson.trim().startsWith("\"selector\"")) ) {
+                throw new JsonParseException("selectorJson should be valid json or like \"selector\": {...} ");
+            }
+        }
+
+        StringBuilder finalbody = new StringBuilder();
+        if ( isObject ) {
+            finalbody.append("{\"selector\": ")
+                .append(selectorJson);
+        }
+        else {
+            //old support
+            finalbody.append("{" + selectorJson);
+        }
+
+        if ( rf != null ) {
+            finalbody.append(",")
+                     .append(rf.toString());
+        }
+        if ( so != null ) {
+            finalbody.append(",")
+                     .append(so.toString());
+        }
+        if ( options.getLimit() != null ) {
+            finalbody.append(",")
+                     .append("\"limit\": ")
+                     .append(options.getLimit());
+        }
+        if ( options.getSkip() != null ) {
+            finalbody.append(",")
+                     .append("\"skip\": ")
+                     .append(options.getSkip());
+        }
+        if ( options.getReadQuorum() != null ) {
+            finalbody.append(",")
+                     .append("\"r\": ")
+                     .append(options.getReadQuorum());
+        }
+        finalbody.append("}");
+
+        return finalbody.toString();
+    }
+
+    HttpResponse executeRequest(HttpRequestBase request) {
+        return client.executeRequest(request);
+    }
+
+    Gson getGson() {
+        return client.getGson();
+    }
+
 }
 
 class ShardDeserializer implements JsonDeserializer<List<Shard>> {
 
-	
-	public List<Shard> deserialize(JsonElement json, Type typeOfT,
-			JsonDeserializationContext context) throws JsonParseException {
-		
-		final List<Shard> shards = new ArrayList<Shard>();
-		
-		final JsonObject jsonObject = json.getAsJsonObject();
-		Set<Map.Entry<String,JsonElement>> shardsObj = jsonObject.get("shards").getAsJsonObject().entrySet();
-		
-		for ( Entry<String,JsonElement> entry : shardsObj ) {
-			String range = entry.getKey();
-			List<String> nodeNames = context.deserialize(entry.getValue(), new TypeToken<List<String>>(){}.getType());
-			shards.add( new Shard(range,nodeNames) );
-		}
-		
-		return shards;
-	}
+
+    public List<Shard> deserialize(JsonElement json, Type typeOfT,
+            JsonDeserializationContext context) throws JsonParseException {
+
+        final List<Shard> shards = new ArrayList<Shard>();
+
+        final JsonObject jsonObject = json.getAsJsonObject();
+        Set<Map.Entry<String,JsonElement>> shardsObj = jsonObject.get("shards").getAsJsonObject().entrySet();
+
+        for ( Entry<String,JsonElement> entry : shardsObj ) {
+            String range = entry.getKey();
+            List<String> nodeNames = context.deserialize(entry.getValue(), new TypeToken<List<String>>(){}.getType());
+            shards.add( new Shard(range,nodeNames) );
+        }
+
+        return shards;
+    }
   }
 
 
 class IndexDeserializer implements JsonDeserializer<List<Index>> {
 
-	
-	public List<Index> deserialize(JsonElement json, Type typeOfT,
-			JsonDeserializationContext context) throws JsonParseException {
-		
-		final List<Index> indices = new ArrayList<Index>();
-		
-		final JsonObject jsonObject = json.getAsJsonObject();
-		JsonArray indArray = jsonObject.get("indexes").getAsJsonArray();
-		for ( int i = 0; i < indArray.size(); i++ ) {
-			JsonObject ind = indArray.get(i).getAsJsonObject();
-			String ddoc = null;
-			if ( !ind.get("ddoc").isJsonNull() ) { // ddoc is optional
-				ddoc = ind.get("ddoc").getAsString();
-			}
-			Index idx = new Index(ddoc,ind.get("name").getAsString(),
-								ind.get("type").getAsString());
-			JsonArray fldArray = ind.get("def").getAsJsonObject().get("fields").getAsJsonArray();
-			for ( int j = 0; j < fldArray.size(); j++ ) {
-				Set<Map.Entry<String,JsonElement>>  fld = fldArray.get(j).getAsJsonObject().entrySet();
-				for ( Entry<String,JsonElement> entry : fld ) {
-					idx.addIndexField(entry.getKey(),
-								SortOrder.valueOf(entry.getValue().getAsString())
-								);
-				}
-			}//end fldArray
-			indices.add(idx);
-			
-		}// end indexes
-		
-		return indices;
-	}
+
+    public List<Index> deserialize(JsonElement json, Type typeOfT,
+            JsonDeserializationContext context) throws JsonParseException {
+
+        final List<Index> indices = new ArrayList<Index>();
+
+        final JsonObject jsonObject = json.getAsJsonObject();
+        JsonArray indArray = jsonObject.get("indexes").getAsJsonArray();
+        for ( int i = 0; i < indArray.size(); i++ ) {
+            JsonObject ind = indArray.get(i).getAsJsonObject();
+            String ddoc = null;
+            if ( !ind.get("ddoc").isJsonNull() ) { // ddoc is optional
+                ddoc = ind.get("ddoc").getAsString();
+            }
+            Index idx = new Index(ddoc,ind.get("name").getAsString(),
+                                ind.get("type").getAsString());
+            JsonArray fldArray = ind.get("def").getAsJsonObject().get("fields").getAsJsonArray();
+            for ( int j = 0; j < fldArray.size(); j++ ) {
+                Set<Map.Entry<String,JsonElement>>  fld = fldArray.get(j).getAsJsonObject().entrySet();
+                for ( Entry<String,JsonElement> entry : fld ) {
+                    idx.addIndexField(entry.getKey(),
+                                SortOrder.valueOf(entry.getValue().getAsString())
+                                );
+                }
+            }//end fldArray
+            indices.add(idx);
+
+        }// end indexes
+
+        return indices;
+    }
   }
 
 class SecurityDeserializer implements JsonDeserializer<Map<String,EnumSet<Permissions>>> {
 
-	
-	public Map<String,EnumSet<Permissions>> deserialize(JsonElement json, Type typeOfT,
-			JsonDeserializationContext context) throws JsonParseException {
-		
-		Map<String,EnumSet<Permissions>> perms = new HashMap<String,EnumSet<Permissions>>();
-		JsonElement elem = json.getAsJsonObject().get("cloudant");
-		if ( elem == null ) {
-			return perms;
-		}
-		Set<Map.Entry<String,JsonElement>> permList = elem.getAsJsonObject().entrySet();
-		for ( Entry<String,JsonElement> entry : permList ) {
-			String user = entry.getKey();
-			EnumSet<Permissions> p= context.deserialize(entry.getValue(), new TypeToken<EnumSet<Permissions>>(){}.getType());
-			perms.put(user,  p);
-		}
-		return perms;
-		
-	}
+
+    public Map<String,EnumSet<Permissions>> deserialize(JsonElement json, Type typeOfT,
+            JsonDeserializationContext context) throws JsonParseException {
+
+        Map<String,EnumSet<Permissions>> perms = new HashMap<String,EnumSet<Permissions>>();
+        JsonElement elem = json.getAsJsonObject().get("cloudant");
+        if ( elem == null ) {
+            return perms;
+        }
+        Set<Map.Entry<String,JsonElement>> permList = elem.getAsJsonObject().entrySet();
+        for ( Entry<String,JsonElement> entry : permList ) {
+            String user = entry.getKey();
+            EnumSet<Permissions> p= context.deserialize(entry.getValue(), new TypeToken<EnumSet<Permissions>>(){}.getType());
+            perms.put(user,  p);
+        }
+        return perms;
+
+    }
 }

--- a/src/main/java/com/cloudant/client/api/Database.java
+++ b/src/main/java/com/cloudant/client/api/Database.java
@@ -620,7 +620,9 @@ public class Database {
      * @param docId The document id to update.
      * @param query The query string parameters, e.g, <code>field=field1&value=value1</code>
      * @return The output of the request.
+     * @deprecated use {@link #invokeUpdateHandler(String, String, Params)} instead.
      */
+    @Deprecated
     public String invokeUpdateHandler(String updateHandlerUri, String docId,
             String query) {
         return db.invokeUpdateHandler(updateHandlerUri, docId, query);
@@ -630,7 +632,6 @@ public class Database {
 
     /**
      * Invokes an Update Handler.
-     * <p>Use this method in particular when the docId contain special characters such as slashes (/).
      * <pre>
      * Params params = new Params()
      *	.addParam("field", "foo")

--- a/src/main/java/org/lightcouch/CouchDatabaseBase.java
+++ b/src/main/java/org/lightcouch/CouchDatabaseBase.java
@@ -47,450 +47,450 @@ import com.google.gson.reflect.TypeToken;
  */
 public abstract class CouchDatabaseBase {
 
-	static final Log log = LogFactory.getLog(CouchDatabase.class);
-	
-	CouchDbClientBase client;
-	private URI dbURI;
-	
-	private CouchDbDesign design;
-	private String dbName;
-	
-	
-	CouchDatabaseBase(CouchDbClientBase client, String name, boolean create) {
-		assertNotEmpty(name, "name");
-		this.dbName = name;
-		this.client = client;
-		this.dbURI   = buildUri(client.getBaseUri()).path(name).path("/").build();
-		connect(create);
-		this.design = new CouchDbDesign(this);
-	}
+    static final Log log = LogFactory.getLog(CouchDatabase.class);
+
+    CouchDbClientBase client;
+    private URI dbURI;
+
+    private CouchDbDesign design;
+    private String dbName;
 
 
-	/**
-	 * Provides access to CouchDB Design Documents.
-	 * @see CouchDbDesign
-	 */
-	public CouchDbDesign design() {
-		return design;
-	}
-	
-	/**
-	 * Provides access to CouchDB <tt>View</tt> APIs.
-	 * @see View
-	 */
-	public View view(String viewId) {
-		return new View(this, viewId);
-	}
+    CouchDatabaseBase(CouchDbClientBase client, String name, boolean create) {
+        assertNotEmpty(name, "name");
+        this.dbName = name;
+        this.client = client;
+        this.dbURI   = buildUri(client.getBaseUri()).path(name).path("/").build();
+        connect(create);
+        this.design = new CouchDbDesign(this);
+    }
 
-		
-	/**
-	 * Provides access to <tt>Change Notifications</tt> API.
-	 * @see Changes
-	 */
-	public Changes changes() {
-		return new Changes(this);
-	}
-	
-	/**
-	 * Finds an Object of the specified type.
-	 * @param <T> Object type.
-	 * @param classType The class of type T.
-	 * @param id The document id.
-	 * @return An object of type T.
-	 * @throws NoDocumentException If the document is not found in the database.
-	 */
-	public <T> T find(Class<T> classType, String id) {
-		assertNotEmpty(classType, "Class");
-		assertNotEmpty(id, "id");
-		final URI uri = buildUri(getDBUri()).pathToEncode(id).buildEncoded();
-		return client.get(uri, classType);
-	}
-	
-	/**
-	 * Finds an Object of the specified type.
-	 * @param <T> Object type.
-	 * @param classType The class of type T.
-	 * @param id The document id.
-	 * @param params Extra parameters to append.
-	 * @return An object of type T.
-	 * @throws NoDocumentException If the document is not found in the database.
-	 */
-	public <T> T find(Class<T> classType, String id, Params params) {
-		assertNotEmpty(classType, "Class");
-		assertNotEmpty(id, "id");
-		final URI uri = buildUri(getDBUri()).pathToEncode(id).query(params).buildEncoded();
-		return client.get(uri, classType);
-	}
-	
-	/**
-	 * Finds an Object of the specified type.
-	 * @param <T> Object type.
-	 * @param classType The class of type T.
-	 * @param id The document _id field.
-	 * @param rev The document _rev field.
-	 * @return An object of type T.
-	 * @throws NoDocumentException If the document is not found in the database.
-	 */
-	public <T> T find(Class<T> classType, String id, String rev) {
-		assertNotEmpty(classType, "Class");
-		assertNotEmpty(id, "id");
-		assertNotEmpty(id, "rev");
-		final URI uri = buildUri(getDBUri()).pathToEncode(id).query("rev", rev).buildEncoded();
-		return client.get(uri, classType);
-	}
-	
-	/**
-	 * This method finds any document given a URI.
-	 * <p>The URI must be URI-encoded.
-	 * @param classType The class of type T.
-	 * @param uri The URI as string.
-	 * @return An object of type T.
-	 */
-	public <T> T findAny(Class<T> classType, String uri) {
-		assertNotEmpty(classType, "Class");
-		assertNotEmpty(uri, "uri");
-		return client.get(URI.create(uri), classType);
-	}
-	
-	/**
-	 * Finds a document and return the result as {@link InputStream}.
-	 * <p><b>Note</b>: The stream must be closed after use to release the connection.
-	 * @param id The document _id field.
-	 * @return The result as {@link InputStream}
-	 * @throws NoDocumentException If the document is not found in the database.
-	 * @see #find(String, String)
-	 */
-	public InputStream find(String id) {
-		assertNotEmpty(id, "id");
-		return client.get(buildUri(getDBUri()).path(id).build());
-	}
-	
-	/**
-	 * Finds a document given id and revision and returns the result as {@link InputStream}.
-	 * <p><b>Note</b>: The stream must be closed after use to release the connection.
-	 * @param id The document _id field.
-	 * @param rev The document _rev field.
-	 * @return The result as {@link InputStream}
-	 * @throws NoDocumentException If the document is not found in the database.
-	 */
-	public InputStream find(String id, String rev) {
-		assertNotEmpty(id, "id");
-		assertNotEmpty(rev, "rev");
-		final URI uri = buildUri(getDBUri()).path(id).query("rev", rev).build();
-		return client.get(uri);
-	}
-	
-	/**
-	 * Checks if a document exist in the database.
-	 * @param id The document _id field.
-	 * @return true If the document is found, false otherwise.
-	 */
-	public boolean contains(String id) { 
-		assertNotEmpty(id, "id");
-		HttpResponse response = null;
-		try {
-			response = client.head(buildUri(getDBUri()).path(id).build());
-		} catch (NoDocumentException e) {
-			return false;
-		} finally {
-			close(response);
-		}
-		return true;
-	}
-	
-	/**
-	 * Saves an object in the database, using HTTP <tt>PUT</tt> request.
-	 * <p>If the object doesn't have an <code>_id</code> value, the code will assign a <code>UUID</code> as the document id.
-	 * @param object The object to save
-	 * @throws DocumentConflictException If a conflict is detected during the save.
-	 * @return {@link Response}
-	 */
-	public Response save(Object object) {
-		return client.put(getDBUri(), object, true);
-	}
-	
-	/**
-	 * Saves an object in the database using HTTP <tt>POST</tt> request.
-	 * <p>The database will be responsible for generating the document id.
-	 * @param object The object to save
-	 * @return {@link Response}
-	 */
-	public Response post(Object object) {
-		assertNotEmpty(object, "object");
-		HttpResponse response = null;
-		try { 
-			URI uri = buildUri(getDBUri()).build();
-			response = client.post(uri, getGson().toJson(object));
-			return getResponse(response,Response.class, client.getGson());
-		} finally {
-			close(response);
-		}
-	}
-	
-	/**
-	 * Saves a document with <tt>batch=ok</tt> query param.
-	 * @param object The object to save.
-	 */
-	public void batch(Object object) {
-		assertNotEmpty(object, "object");
-		HttpResponse response = null;
-		try { 
-			URI uri = buildUri(getDBUri()).query("batch", "ok").build();
-			response = client.post(uri, getGson().toJson(object));
-		} finally {
-			close(response);
-		}
-	}
-	
-	/**
-	 * Updates an object in the database, the object must have the correct <code>_id</code> and <code>_rev</code> values.
-	 * @param object The object to update
-	 * @throws DocumentConflictException If a conflict is detected during the update.
-	 * @return {@link Response}
-	 */
-	public Response update(Object object) {
-		return client.put(getDBUri(), object, false);
-	}
-	
-	/**
-	 * Removes a document from the database. 
-	 * <p>The object must have the correct <code>_id</code> and <code>_rev</code> values.
-	 * @param object The document to remove as object.
-	 * @throws NoDocumentException If the document is not found in the database.
-	 * @return {@link Response}
-	 */
-	public Response remove(Object object) {
-		assertNotEmpty(object, "object");
-		JsonObject jsonObject = getGson().toJsonTree(object).getAsJsonObject();
-		final String id = getAsString(jsonObject, "_id");
-		final String rev = getAsString(jsonObject, "_rev");
-		return remove(id, rev);
-	}
-	
-	/**
-	 * Removes a document from the database given both a document <code>_id</code> and <code>_rev</code> values.
-	 * @param id The document _id field.
-	 * @param rev The document _rev field.
-	 * @throws NoDocumentException If the document is not found in the database.
-	 * @return {@link Response}
-	 */
-	public Response remove(String id, String rev) {
-		assertNotEmpty(id, "id");
-		assertNotEmpty(rev, "rev");
-		final URI uri = buildUri(getDBUri()).pathToEncode(id).query("rev", rev).buildEncoded();
-		return client.delete(uri);
-	}
-	
-	/**
-	 * Performs a Bulk Documents insert request.
-	 * @param objects The {@link List} of objects.
-	 * @param allOrNothing Indicates whether the request has <tt>all-or-nothing</tt> semantics.
-	 * @return {@code List<Response>} Containing the resulted entries.
-	 */
-	public List<Response> bulk(List<?> objects, boolean allOrNothing) {
-		assertNotEmpty(objects, "objects");
-		HttpResponse response = null;
-		try { 
-			final String allOrNothingVal = allOrNothing ? "\"all_or_nothing\": true, " : "";
-			final URI uri = buildUri(getDBUri()).path("_bulk_docs").build();
-			final String json = String.format("{%s%s%s}", allOrNothingVal, "\"docs\": ", getGson().toJson(objects));
-			response = client.post(uri, json);
-			return getResponseList(response, client.getGson(), Response.class,
-						new TypeToken<List<Response>>(){}.getType());
-		} finally {
-			close(response);
-		}
-	}
-	
-	/**
-	 * Saves an attachment to a new document with a generated <tt>UUID</tt> as the document id.
-	 * <p>To retrieve an attachment, see {@link #find(String)}.
-	 * @param instream The {@link InputStream} holding the binary data.
-	 * @param name The attachment name.
-	 * @param contentType The attachment "Content-Type".
-	 * @return {@link Response}
-	 */
-	public Response saveAttachment(InputStream in, String name, String contentType) {
-		assertNotEmpty(in, "in");
-		assertNotEmpty(name, "name");
-		assertNotEmpty(contentType, "ContentType");
-		final URI uri = buildUri(getDBUri()).path(generateUUID()).path("/").path(name).build();
-		return client.put(uri, in, contentType);
-	}
-	
-	/**
-	 * Saves an attachment to an existing document given both a document id
-	 * and revision, or save to a new document given only the id, and rev as {@code null}.
-	 * <p>To retrieve an attachment, see {@link #find(String)}.
-	 * @param instream The {@link InputStream} holding the binary data.
-	 * @param name The attachment name.
-	 * @param contentType The attachment "Content-Type".
-	 * @param docId The document id to save the attachment under, or {@code null} to save under a new document.
-	 * @param docRev The document revision to save the attachment under, or {@code null} when saving to a new document.
-	 * @throws DocumentConflictException 
-	 * @return {@link Response}
-	 */
-	public Response saveAttachment(InputStream in, String name, String contentType, String docId, String docRev) {
-		assertNotEmpty(in, "in");
-		assertNotEmpty(name, "name");
-		assertNotEmpty(contentType, "ContentType");
-		assertNotEmpty(docId, "docId");
-		final URI uri = buildUri(getDBUri()).path(docId).path("/").path(name).query("rev", docRev).build();
-		return client.put(uri, in, contentType);
-	}
-	
-	/**
-	 * Invokes an Update Handler.
-	 * <pre>
-	 * String query = "field=foo&value=bar";
-	 * String output = dbClient.invokeUpdateHandler("designDoc/update1", "docId", query);
-	 * </pre>
-	 * @param updateHandlerUri The Update Handler URI, in the format: <code>designDoc/update1</code>
-	 * @param docId The document id to update.
-	 * @param query The query string parameters, e.g, <code>field=field1&value=value1</code>
-	 * @return The output of the request.
-	 */
-	public String invokeUpdateHandler(String updateHandlerUri, String docId, String query) {
-		assertNotEmpty(updateHandlerUri, "uri");
-		assertNotEmpty(docId, "docId");
-		final String[] v = updateHandlerUri.split("/");
-		final String path = String.format("_design/%s/_update/%s/", v[0], v[1]);
-		final URI uri = buildUri(getDBUri()).path(path).path(docId).query(query).build();
-		final HttpResponse response = client.executeRequest(new HttpPut(uri));
-		return streamToString(getStream(response));
-	}
-	
-	/**
-	 * Invokes an Update Handler.
-	 * <p>Use this method in particular when the docId contain special characters such as slashes (/).
-	 * <pre>
-	 * Params params = new Params()
-	 *	.addParam("field", "foo")
-	 *	.addParam("value", "bar"); 
-	 * String output = dbClient.invokeUpdateHandler("designDoc/update1", "docId", params);
-	 * </pre>
-	 * @param updateHandlerUri The Update Handler URI, in the format: <code>designDoc/update1</code>
-	 * @param docId The document id to update.
-	 * @param query The query parameters as {@link Params}.
-	 * @return The output of the request.
-	 */
-	public String invokeUpdateHandler(String updateHandlerUri, String docId, Params params) {
-		assertNotEmpty(updateHandlerUri, "uri");
-		assertNotEmpty(docId, "docId");
-		final String[] v = updateHandlerUri.split("/");
-		final String path = String.format("_design/%s/_update/%s/", v[0], v[1]);
-		final URI uri = buildUri(getDBUri()).path(path).pathToEncode(docId).query(params).buildEncoded();
-		final HttpResponse response = client.executeRequest(new HttpPut(uri));
-		return streamToString(getStream(response));
-	}
-	
-	
-	
-	/**
-	 * Synchronize all design documents with the database.
-	 */
-	public void syncDesignDocsWithDb() {
-		design().synchronizeAllWithDb();
-	}
-	
-	
-	
-	
-	/**
-	 * @return The database URI.
-	 */
-	public URI getDBUri() {
-		return dbURI;
-	}
+
+    /**
+     * Provides access to CouchDB Design Documents.
+     * @see CouchDbDesign
+     */
+    public CouchDbDesign design() {
+        return design;
+    }
+
+    /**
+     * Provides access to CouchDB <tt>View</tt> APIs.
+     * @see View
+     */
+    public View view(String viewId) {
+        return new View(this, viewId);
+    }
+
+
+    /**
+     * Provides access to <tt>Change Notifications</tt> API.
+     * @see Changes
+     */
+    public Changes changes() {
+        return new Changes(this);
+    }
+
+    /**
+     * Finds an Object of the specified type.
+     * @param <T> Object type.
+     * @param classType The class of type T.
+     * @param id The document id.
+     * @return An object of type T.
+     * @throws NoDocumentException If the document is not found in the database.
+     */
+    public <T> T find(Class<T> classType, String id) {
+        assertNotEmpty(classType, "Class");
+        assertNotEmpty(id, "id");
+        final URI uri = buildUri(getDBUri()).pathToEncode(id).buildEncoded();
+        return client.get(uri, classType);
+    }
+
+    /**
+     * Finds an Object of the specified type.
+     * @param <T> Object type.
+     * @param classType The class of type T.
+     * @param id The document id.
+     * @param params Extra parameters to append.
+     * @return An object of type T.
+     * @throws NoDocumentException If the document is not found in the database.
+     */
+    public <T> T find(Class<T> classType, String id, Params params) {
+        assertNotEmpty(classType, "Class");
+        assertNotEmpty(id, "id");
+        final URI uri = buildUri(getDBUri()).pathToEncode(id).query(params).buildEncoded();
+        return client.get(uri, classType);
+    }
+
+    /**
+     * Finds an Object of the specified type.
+     * @param <T> Object type.
+     * @param classType The class of type T.
+     * @param id The document _id field.
+     * @param rev The document _rev field.
+     * @return An object of type T.
+     * @throws NoDocumentException If the document is not found in the database.
+     */
+    public <T> T find(Class<T> classType, String id, String rev) {
+        assertNotEmpty(classType, "Class");
+        assertNotEmpty(id, "id");
+        assertNotEmpty(id, "rev");
+        final URI uri = buildUri(getDBUri()).pathToEncode(id).query("rev", rev).buildEncoded();
+        return client.get(uri, classType);
+    }
+
+    /**
+     * This method finds any document given a URI.
+     * <p>The URI must be URI-encoded.
+     * @param classType The class of type T.
+     * @param uri The URI as string.
+     * @return An object of type T.
+     */
+    public <T> T findAny(Class<T> classType, String uri) {
+        assertNotEmpty(classType, "Class");
+        assertNotEmpty(uri, "uri");
+        return client.get(URI.create(uri), classType);
+    }
+
+    /**
+     * Finds a document and return the result as {@link InputStream}.
+     * <p><b>Note</b>: The stream must be closed after use to release the connection.
+     * @param id The document _id field.
+     * @return The result as {@link InputStream}
+     * @throws NoDocumentException If the document is not found in the database.
+     * @see #find(String, String)
+     */
+    public InputStream find(String id) {
+        assertNotEmpty(id, "id");
+        return client.get(buildUri(getDBUri()).path(id).build());
+    }
+
+    /**
+     * Finds a document given id and revision and returns the result as {@link InputStream}.
+     * <p><b>Note</b>: The stream must be closed after use to release the connection.
+     * @param id The document _id field.
+     * @param rev The document _rev field.
+     * @return The result as {@link InputStream}
+     * @throws NoDocumentException If the document is not found in the database.
+     */
+    public InputStream find(String id, String rev) {
+        assertNotEmpty(id, "id");
+        assertNotEmpty(rev, "rev");
+        final URI uri = buildUri(getDBUri()).path(id).query("rev", rev).build();
+        return client.get(uri);
+    }
+
+    /**
+     * Checks if a document exist in the database.
+     * @param id The document _id field.
+     * @return true If the document is found, false otherwise.
+     */
+    public boolean contains(String id) {
+        assertNotEmpty(id, "id");
+        HttpResponse response = null;
+        try {
+            response = client.head(buildUri(getDBUri()).path(id).build());
+        } catch (NoDocumentException e) {
+            return false;
+        } finally {
+            close(response);
+        }
+        return true;
+    }
+
+    /**
+     * Saves an object in the database, using HTTP <tt>PUT</tt> request.
+     * <p>If the object doesn't have an <code>_id</code> value, the code will assign a <code>UUID</code> as the document id.
+     * @param object The object to save
+     * @throws DocumentConflictException If a conflict is detected during the save.
+     * @return {@link Response}
+     */
+    public Response save(Object object) {
+        return client.put(getDBUri(), object, true);
+    }
+
+    /**
+     * Saves an object in the database using HTTP <tt>POST</tt> request.
+     * <p>The database will be responsible for generating the document id.
+     * @param object The object to save
+     * @return {@link Response}
+     */
+    public Response post(Object object) {
+        assertNotEmpty(object, "object");
+        HttpResponse response = null;
+        try {
+            URI uri = buildUri(getDBUri()).build();
+            response = client.post(uri, getGson().toJson(object));
+            return getResponse(response,Response.class, client.getGson());
+        } finally {
+            close(response);
+        }
+    }
+
+    /**
+     * Saves a document with <tt>batch=ok</tt> query param.
+     * @param object The object to save.
+     */
+    public void batch(Object object) {
+        assertNotEmpty(object, "object");
+        HttpResponse response = null;
+        try {
+            URI uri = buildUri(getDBUri()).query("batch", "ok").build();
+            response = client.post(uri, getGson().toJson(object));
+        } finally {
+            close(response);
+        }
+    }
+
+    /**
+     * Updates an object in the database, the object must have the correct <code>_id</code> and <code>_rev</code> values.
+     * @param object The object to update
+     * @throws DocumentConflictException If a conflict is detected during the update.
+     * @return {@link Response}
+     */
+    public Response update(Object object) {
+        return client.put(getDBUri(), object, false);
+    }
+
+    /**
+     * Removes a document from the database.
+     * <p>The object must have the correct <code>_id</code> and <code>_rev</code> values.
+     * @param object The document to remove as object.
+     * @throws NoDocumentException If the document is not found in the database.
+     * @return {@link Response}
+     */
+    public Response remove(Object object) {
+        assertNotEmpty(object, "object");
+        JsonObject jsonObject = getGson().toJsonTree(object).getAsJsonObject();
+        final String id = getAsString(jsonObject, "_id");
+        final String rev = getAsString(jsonObject, "_rev");
+        return remove(id, rev);
+    }
+
+    /**
+     * Removes a document from the database given both a document <code>_id</code> and <code>_rev</code> values.
+     * @param id The document _id field.
+     * @param rev The document _rev field.
+     * @throws NoDocumentException If the document is not found in the database.
+     * @return {@link Response}
+     */
+    public Response remove(String id, String rev) {
+        assertNotEmpty(id, "id");
+        assertNotEmpty(rev, "rev");
+        final URI uri = buildUri(getDBUri()).pathToEncode(id).query("rev", rev).buildEncoded();
+        return client.delete(uri);
+    }
+
+    /**
+     * Performs a Bulk Documents insert request.
+     * @param objects The {@link List} of objects.
+     * @param allOrNothing Indicates whether the request has <tt>all-or-nothing</tt> semantics.
+     * @return {@code List<Response>} Containing the resulted entries.
+     */
+    public List<Response> bulk(List<?> objects, boolean allOrNothing) {
+        assertNotEmpty(objects, "objects");
+        HttpResponse response = null;
+        try {
+            final String allOrNothingVal = allOrNothing ? "\"all_or_nothing\": true, " : "";
+            final URI uri = buildUri(getDBUri()).path("_bulk_docs").build();
+            final String json = String.format("{%s%s%s}", allOrNothingVal, "\"docs\": ", getGson().toJson(objects));
+            response = client.post(uri, json);
+            return getResponseList(response, client.getGson(), Response.class,
+                        new TypeToken<List<Response>>(){}.getType());
+        } finally {
+            close(response);
+        }
+    }
+
+    /**
+     * Saves an attachment to a new document with a generated <tt>UUID</tt> as the document id.
+     * <p>To retrieve an attachment, see {@link #find(String)}.
+     * @param instream The {@link InputStream} holding the binary data.
+     * @param name The attachment name.
+     * @param contentType The attachment "Content-Type".
+     * @return {@link Response}
+     */
+    public Response saveAttachment(InputStream in, String name, String contentType) {
+        assertNotEmpty(in, "in");
+        assertNotEmpty(name, "name");
+        assertNotEmpty(contentType, "ContentType");
+        final URI uri = buildUri(getDBUri()).path(generateUUID()).path("/").path(name).build();
+        return client.put(uri, in, contentType);
+    }
+
+    /**
+     * Saves an attachment to an existing document given both a document id
+     * and revision, or save to a new document given only the id, and rev as {@code null}.
+     * <p>To retrieve an attachment, see {@link #find(String)}.
+     * @param instream The {@link InputStream} holding the binary data.
+     * @param name The attachment name.
+     * @param contentType The attachment "Content-Type".
+     * @param docId The document id to save the attachment under, or {@code null} to save under a new document.
+     * @param docRev The document revision to save the attachment under, or {@code null} when saving to a new document.
+     * @throws DocumentConflictException
+     * @return {@link Response}
+     */
+    public Response saveAttachment(InputStream in, String name, String contentType, String docId, String docRev) {
+        assertNotEmpty(in, "in");
+        assertNotEmpty(name, "name");
+        assertNotEmpty(contentType, "ContentType");
+        assertNotEmpty(docId, "docId");
+        final URI uri = buildUri(getDBUri()).path(docId).path("/").path(name).query("rev", docRev).build();
+        return client.put(uri, in, contentType);
+    }
+
+    /**
+     * Invokes an Update Handler.
+     * <pre>
+     * String query = "field=foo&value=bar";
+     * String output = dbClient.invokeUpdateHandler("designDoc/update1", "docId", query);
+     * </pre>
+     * @param updateHandlerUri The Update Handler URI, in the format: <code>designDoc/update1</code>
+     * @param docId The document id to update.
+     * @param query The query string parameters, e.g, <code>field=field1&value=value1</code>
+     * @return The output of the request.
+     */
+    public String invokeUpdateHandler(String updateHandlerUri, String docId, String query) {
+        assertNotEmpty(updateHandlerUri, "uri");
+        assertNotEmpty(docId, "docId");
+        final String[] v = updateHandlerUri.split("/");
+        final String path = String.format("_design/%s/_update/%s/", v[0], v[1]);
+        final URI uri = buildUri(getDBUri()).path(path).path(docId).query(query).build();
+        final HttpResponse response = client.executeRequest(new HttpPut(uri));
+        return streamToString(getStream(response));
+    }
+
+    /**
+     * Invokes an Update Handler.
+     * <p>Use this method in particular when the docId contain special characters such as slashes (/).
+     * <pre>
+     * Params params = new Params()
+     *	.addParam("field", "foo")
+     *	.addParam("value", "bar");
+     * String output = dbClient.invokeUpdateHandler("designDoc/update1", "docId", params);
+     * </pre>
+     * @param updateHandlerUri The Update Handler URI, in the format: <code>designDoc/update1</code>
+     * @param docId The document id to update.
+     * @param query The query parameters as {@link Params}.
+     * @return The output of the request.
+     */
+    public String invokeUpdateHandler(String updateHandlerUri, String docId, Params params) {
+        assertNotEmpty(updateHandlerUri, "uri");
+        assertNotEmpty(docId, "docId");
+        final String[] v = updateHandlerUri.split("/");
+        final String path = String.format("_design/%s/_update/%s/", v[0], v[1]);
+        final URI uri = buildUri(getDBUri()).path(path).pathToEncode(docId).query(params).buildEncoded();
+        final HttpResponse response = client.executeRequest(new HttpPut(uri));
+        return streamToString(getStream(response));
+    }
+
+
+
+    /**
+     * Synchronize all design documents with the database.
+     */
+    public void syncDesignDocsWithDb() {
+        design().synchronizeAllWithDb();
+    }
+
+
+
+
+    /**
+     * @return The database URI.
+     */
+    public URI getDBUri() {
+        return dbURI;
+    }
     
-	
-	
-	// End - Public API
-	
-	
-	
-	
-	/**
-	 * @return {@link CouchDbInfo} Containing the DB info.
-	 */
-	public CouchDbInfo info() {
-		return client.get(buildUri(getDBUri()).build(), CouchDbInfo.class);
-	}
-	
-	/**
-	 * Triggers a database <i>compact</i> request.
-	 */
-	public void compact() {
-		HttpResponse response = null;
-		try {
-			response = client.post(buildUri(getDBUri()).path("_compact").build(), "");
-		} finally {
-			close(response);
-		}
-	}
-
-	/**
-	 * Requests the database commits any recent changes to disk.
-	 */
-	public void ensureFullCommit() {
-		HttpResponse response = null;
-		try {
-			response = client.post(buildUri(getDBUri()).path("_ensure_full_commit").build(), "");
-		} finally {
-			close(response);
-		}
-	}
-
-	
-	/**
-	 * @return the dbName
-	 */
-	public String getDbName() {
-		return dbName;
-	}
 
 
-	private void connect(boolean create) {
-		
-		InputStream getresp = null;
-		HttpResponse putresp = null;
-		
-		try {
-			getresp = get(dbURI);
-		} catch (NoDocumentException e) { // db doesn't exist
-			if (!create) {
-				throw e;
-			}
-			final HttpPut put = new HttpPut(dbURI);
-			putresp = client.executeRequest(put);
-			log.info(String.format("Created Database: '%s'", dbName));
-		} finally {
-			close(getresp);
-			close(putresp);
-		}
-	}
-
-	// Helpers
-	Gson getGson() {
-		return client.getGson();
-	}
+    // End - Public API
 
 
-	InputStream get(HttpGet httpGet) {
-		return client.get(httpGet);
-	}
 
 
-	<T> T get(URI uri, Class<T> classType) {
-		return client.get(uri, classType);
-	}
-	
-	
-	InputStream get(URI uri) {
-		return client.get(uri);
-	}
-	
-	HttpResponse post(URI uri, String json) {
-		return client.post(uri, json);
-	}
+    /**
+     * @return {@link CouchDbInfo} Containing the DB info.
+     */
+    public CouchDbInfo info() {
+        return client.get(buildUri(getDBUri()).build(), CouchDbInfo.class);
+    }
+
+    /**
+     * Triggers a database <i>compact</i> request.
+     */
+    public void compact() {
+        HttpResponse response = null;
+        try {
+            response = client.post(buildUri(getDBUri()).path("_compact").build(), "");
+        } finally {
+            close(response);
+        }
+    }
+
+    /**
+     * Requests the database commits any recent changes to disk.
+     */
+    public void ensureFullCommit() {
+        HttpResponse response = null;
+        try {
+            response = client.post(buildUri(getDBUri()).path("_ensure_full_commit").build(), "");
+        } finally {
+            close(response);
+        }
+    }
+
+
+    /**
+     * @return the dbName
+     */
+    public String getDbName() {
+        return dbName;
+    }
+
+
+    private void connect(boolean create) {
+
+        InputStream getresp = null;
+        HttpResponse putresp = null;
+
+        try {
+            getresp = get(dbURI);
+        } catch (NoDocumentException e) { // db doesn't exist
+            if (!create) {
+                throw e;
+            }
+            final HttpPut put = new HttpPut(dbURI);
+            putresp = client.executeRequest(put);
+            log.info(String.format("Created Database: '%s'", dbName));
+        } finally {
+            close(getresp);
+            close(putresp);
+        }
+    }
+
+    // Helpers
+    Gson getGson() {
+        return client.getGson();
+    }
+
+
+    InputStream get(HttpGet httpGet) {
+        return client.get(httpGet);
+    }
+
+
+    <T> T get(URI uri, Class<T> classType) {
+        return client.get(uri, classType);
+    }
+
+
+    InputStream get(URI uri) {
+        return client.get(uri);
+    }
+
+    HttpResponse post(URI uri, String json) {
+        return client.post(uri, json);
+    }
 }

--- a/src/main/java/org/lightcouch/CouchDatabaseBase.java
+++ b/src/main/java/org/lightcouch/CouchDatabaseBase.java
@@ -305,7 +305,7 @@ public abstract class CouchDatabaseBase {
     /**
      * Saves an attachment to a new document with a generated <tt>UUID</tt> as the document id.
      * <p>To retrieve an attachment, see {@link #find(String)}.
-     * @param instream The {@link InputStream} holding the binary data.
+     * @param in The {@link InputStream} holding the binary data.
      * @param name The attachment name.
      * @param contentType The attachment "Content-Type".
      * @return {@link Response}
@@ -322,7 +322,7 @@ public abstract class CouchDatabaseBase {
      * Saves an attachment to an existing document given both a document id
      * and revision, or save to a new document given only the id, and rev as {@code null}.
      * <p>To retrieve an attachment, see {@link #find(String)}.
-     * @param instream The {@link InputStream} holding the binary data.
+     * @param in The {@link InputStream} holding the binary data.
      * @param name The attachment name.
      * @param contentType The attachment "Content-Type".
      * @param docId The document id to save the attachment under, or {@code null} to save under a new document.
@@ -349,7 +349,9 @@ public abstract class CouchDatabaseBase {
      * @param docId The document id to update.
      * @param query The query string parameters, e.g, <code>field=field1&value=value1</code>
      * @return The output of the request.
+     * @deprecated Use {@link #invokeUpdateHandler(String, String, Params)} instead.
      */
+    @Deprecated
     public String invokeUpdateHandler(String updateHandlerUri, String docId, String query) {
         assertNotEmpty(updateHandlerUri, "uri");
         assertNotEmpty(docId, "docId");
@@ -362,7 +364,6 @@ public abstract class CouchDatabaseBase {
 
     /**
      * Invokes an Update Handler.
-     * <p>Use this method in particular when the docId contain special characters such as slashes (/).
      * <pre>
      * Params params = new Params()
      *	.addParam("field", "foo")
@@ -371,7 +372,7 @@ public abstract class CouchDatabaseBase {
      * </pre>
      * @param updateHandlerUri The Update Handler URI, in the format: <code>designDoc/update1</code>
      * @param docId The document id to update.
-     * @param query The query parameters as {@link Params}.
+     * @param params The query parameters as {@link Params}.
      * @return The output of the request.
      */
     public String invokeUpdateHandler(String updateHandlerUri, String docId, Params params) {

--- a/src/main/java/org/lightcouch/Param.java
+++ b/src/main/java/org/lightcouch/Param.java
@@ -1,0 +1,59 @@
+package org.lightcouch;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.AbstractMap;
+
+public class Param {
+
+    private String key;
+    private Object value;
+
+    public Param(String key, Object value) {
+        this.key = key;
+        this.value = value;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    public Object getValue() {
+        return value;
+    }
+
+    public void setValue(Object value) {
+        this.value = value;
+    }
+
+    public String toURLEncodedString() {
+        return String.format("%s=%s", encodeQueryParameter(getKey()), encodeQueryParameter(getValue().toString()));
+    }
+
+    private static String encodeQueryParameter(String in) {
+        // As this is to escape individual parameters, we need to
+        // escape &, = and +.
+        try {
+            URI uri = new URI(
+                    null, // scheme
+                    null, // authority
+                    null, // path
+                    in,   // query
+                    null  // fragment
+            );
+            return uri.toASCIIString()
+                    .substring(1) // remove leading ?
+                    .replace("&", "%26") // encode qs separators
+                    .replace("=", "%3D")
+                    .replace("+", "%2B");
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(
+                    "Couldn't encode query parameter " + in,
+                    e);
+        }
+    }
+}

--- a/src/main/java/org/lightcouch/Params.java
+++ b/src/main/java/org/lightcouch/Params.java
@@ -16,8 +16,6 @@
 
 package org.lightcouch;
 
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -34,50 +32,64 @@ import java.util.List;
  */
 public class Params {
 
-    private List<String> params = new ArrayList<String>();
+    private List<Param> params = new ArrayList<Param>();
 
     public Params revsInfo() {
-        params.add("revs_info=true");
+        params.add(new Param("revs_info", true));
         return this;
     }
 
     public Params attachments() {
-        params.add("attachments=true");
+        params.add(new Param("attachments", true));
         return this;
     }
 
     public Params revisions() {
-        params.add("revs=true");
+        params.add(new Param("revs", true));
         return this;
     }
 
     public Params rev(String rev) {
-        params.add(String.format("rev=%s", rev));
+        params.add(new Param("rev", rev));
         return this;
     }
 
     public Params conflicts() {
-        params.add("conflicts=true");
+        params.add(new Param("conflicts", true));
         return this;
     }
 
     public Params localSeq() {
-        params.add("local_seq=true");
+        params.add(new Param("local_seq", true));
         return this;
     }
 
     public Params addParam(String name, String value) {
-        try {
-            name = URLEncoder.encode(name, "UTF-8");
-            value = URLEncoder.encode(value, "UTF-8");
-            params.add(String.format("%s=%s", name, value));
-        } catch (UnsupportedEncodingException e) {
-            throw new IllegalArgumentException(e);
-        }
+        params.add(new Param(name, value));
         return this;
     }
 
     public List<String> getParams() {
-        return params.isEmpty() ? null : params;
+        if (params.isEmpty()) {
+            return null;
+        }
+
+        List<String> result = new ArrayList<String>();
+        for (Param param : params) {
+            result.add(param.toURLEncodedString());
+        }
+        return result;
+    }
+
+    public int size() {
+        return params.size();
+    }
+
+    public Param get(int index) {
+        return params.get(index);
+    }
+
+    public void addAll(Params params) {
+        this.params.addAll(params.params);
     }
 }

--- a/src/main/java/org/lightcouch/Params.java
+++ b/src/main/java/org/lightcouch/Params.java
@@ -34,50 +34,50 @@ import java.util.List;
  */
 public class Params {
 
-	private List<String> params = new ArrayList<String>();
+    private List<String> params = new ArrayList<String>();
 
-	public Params revsInfo() {
-		params.add("revs_info=true");
-		return this;
-	}
+    public Params revsInfo() {
+        params.add("revs_info=true");
+        return this;
+    }
 
-	public Params attachments() {
-		params.add("attachments=true");
-		return this;
-	}
+    public Params attachments() {
+        params.add("attachments=true");
+        return this;
+    }
 
-	public Params revisions() {
-		params.add("revs=true");
-		return this;
-	}
+    public Params revisions() {
+        params.add("revs=true");
+        return this;
+    }
 
-	public Params rev(String rev) {
-		params.add(String.format("rev=%s", rev));
-		return this;
-	}
+    public Params rev(String rev) {
+        params.add(String.format("rev=%s", rev));
+        return this;
+    }
 
-	public Params conflicts() {
-		params.add("conflicts=true");
-		return this;
-	}
+    public Params conflicts() {
+        params.add("conflicts=true");
+        return this;
+    }
 
-	public Params localSeq() {
-		params.add("local_seq=true");
-		return this;
-	}
+    public Params localSeq() {
+        params.add("local_seq=true");
+        return this;
+    }
 
-	public Params addParam(String name, String value) {
-		try {
-			name = URLEncoder.encode(name, "UTF-8");
-			value = URLEncoder.encode(value, "UTF-8");
-			params.add(String.format("%s=%s", name, value));
-		} catch (UnsupportedEncodingException e) {
-			throw new IllegalArgumentException(e);
-		}
-		return this;
-	}
+    public Params addParam(String name, String value) {
+        try {
+            name = URLEncoder.encode(name, "UTF-8");
+            value = URLEncoder.encode(value, "UTF-8");
+            params.add(String.format("%s=%s", name, value));
+        } catch (UnsupportedEncodingException e) {
+            throw new IllegalArgumentException(e);
+        }
+        return this;
+    }
 
-	public List<String> getParams() {
-		return params.isEmpty() ? null : params;
-	}
+    public List<String> getParams() {
+        return params.isEmpty() ? null : params;
+    }
 }

--- a/src/main/java/org/lightcouch/internal/URIBuilder.java
+++ b/src/main/java/org/lightcouch/internal/URIBuilder.java
@@ -32,98 +32,98 @@ import org.lightcouch.Params;
  * 
  */
 public class URIBuilder {
-	private String scheme;
-	private String host;
-	private int port;
-	private String path = "";
-	private String pathToEncode = "";
-	/* The final query */
-	private final StringBuilder query = new StringBuilder();
-	/* key=value params */
-	private final List<String> qParams = new ArrayList<String>();
+    private String scheme;
+    private String host;
+    private int port;
+    private String path = "";
+    private String pathToEncode = "";
+    /* The final query */
+    private final StringBuilder query = new StringBuilder();
+    /* key=value params */
+    private final List<String> qParams = new ArrayList<String>();
 
-	public static URIBuilder buildUri() {
-		return new URIBuilder();
-	}
+    public static URIBuilder buildUri() {
+        return new URIBuilder();
+    }
 
-	public static URIBuilder buildUri(URI uri) {
-		URIBuilder builder = URIBuilder.buildUri().scheme(uri.getScheme())
-				.host(uri.getHost()).port(uri.getPort()).path(uri.getPath());
-		return builder;
-	}
+    public static URIBuilder buildUri(URI uri) {
+        URIBuilder builder = URIBuilder.buildUri().scheme(uri.getScheme())
+                .host(uri.getHost()).port(uri.getPort()).path(uri.getPath());
+        return builder;
+    }
 
-	public URI build() {
-		try {
-			for (int i = 0; i < qParams.size(); i++) {
-				String amp = (i != qParams.size() - 1) ? "&" : "";
-				query.append(qParams.get(i) + amp);
-			}
-			String q = (query.length() == 0) ? null : query.toString();
-			return new URI(scheme, null, host, port, path, q, null);
-		} catch (URISyntaxException e) {
-			throw new IllegalArgumentException(e);
-		}
-	}
-	
-	public URI buildEncoded() {
-		for (int i = 0; i < qParams.size(); i++) {
-			String amp = (i != qParams.size() - 1) ? "&" : "";
-			query.append(qParams.get(i) + amp);
-		}
-		try {
-			String q = (query.length() == 0) ? "" : "?" + query;
-			String uri = String.format("%s://%s:%s%s%s%s", new Object[]{scheme, host, port, path, pathToEncode, q});
-			return new URI(uri);
-		} catch (URISyntaxException e) {
-			throw new IllegalArgumentException(e);
-		} 
-	}
+    public URI build() {
+        try {
+            for (int i = 0; i < qParams.size(); i++) {
+                String amp = (i != qParams.size() - 1) ? "&" : "";
+                query.append(qParams.get(i) + amp);
+            }
+            String q = (query.length() == 0) ? null : query.toString();
+            return new URI(scheme, null, host, port, path, q, null);
+        } catch (URISyntaxException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
 
-	public URIBuilder scheme(String scheme) {
-		this.scheme = scheme;
-		return this;
-	}
+    public URI buildEncoded() {
+        for (int i = 0; i < qParams.size(); i++) {
+            String amp = (i != qParams.size() - 1) ? "&" : "";
+            query.append(qParams.get(i) + amp);
+        }
+        try {
+            String q = (query.length() == 0) ? "" : "?" + query;
+            String uri = String.format("%s://%s:%s%s%s%s", new Object[]{scheme, host, port, path, pathToEncode, q});
+            return new URI(uri);
+        } catch (URISyntaxException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
 
-	public URIBuilder host(String host) {
-		this.host = host;
-		return this;
-	}
+    public URIBuilder scheme(String scheme) {
+        this.scheme = scheme;
+        return this;
+    }
 
-	public URIBuilder port(int port) {
-		this.port = port;
-		return this;
-	}
+    public URIBuilder host(String host) {
+        this.host = host;
+        return this;
+    }
 
-	public URIBuilder path(String path) {
-		this.path += path;
-		return this;
-	}
-	
-	public URIBuilder pathToEncode(String path) {
-		try {
-			pathToEncode = URLEncoder.encode(path, "UTF-8");
-		} catch (UnsupportedEncodingException e) {
-			throw new IllegalArgumentException(e);
-		}
-		return this;
-	}
+    public URIBuilder port(int port) {
+        this.port = port;
+        return this;
+    }
 
-	public URIBuilder query(String name, Object value) {
-		if (name != null && value != null)
-			this.qParams.add(String.format("%s=%s", name, value));
-		return this;
-	}
+    public URIBuilder path(String path) {
+        this.path += path;
+        return this;
+    }
 
-	public URIBuilder query(String query) {
-		if (query != null)
-			this.query.append(query);
-		return this;
-	}
+    public URIBuilder pathToEncode(String path) {
+        try {
+            pathToEncode = URLEncoder.encode(path, "UTF-8");
+        } catch (UnsupportedEncodingException e) {
+            throw new IllegalArgumentException(e);
+        }
+        return this;
+    }
 
-	public URIBuilder query(Params params) {
-		if (params.getParams() != null)
-			this.qParams.addAll(params.getParams());
-		return this;
-	}
-	
+    public URIBuilder query(String name, Object value) {
+        if (name != null && value != null)
+            this.qParams.add(String.format("%s=%s", name, value));
+        return this;
+    }
+
+    public URIBuilder query(String query) {
+        if (query != null)
+            this.query.append(query);
+        return this;
+    }
+
+    public URIBuilder query(Params params) {
+        if (params.getParams() != null)
+            this.qParams.addAll(params.getParams());
+        return this;
+    }
+
 }

--- a/src/main/java/org/lightcouch/internal/URIBuilder.java
+++ b/src/main/java/org/lightcouch/internal/URIBuilder.java
@@ -20,8 +20,6 @@ import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URLEncoder;
-import java.util.ArrayList;
-import java.util.List;
 
 import org.lightcouch.Params;
 
@@ -36,11 +34,11 @@ public class URIBuilder {
     private String host;
     private int port;
     private String path = "";
-    private String pathToEncode = "";
+    private String encodedPath = "";
     /* The final query */
     private final StringBuilder query = new StringBuilder();
     /* key=value params */
-    private final List<String> qParams = new ArrayList<String>();
+    private final Params qParams = new Params();
 
     public static URIBuilder buildUri() {
         return new URIBuilder();
@@ -54,12 +52,21 @@ public class URIBuilder {
 
     public URI build() {
         try {
+            StringBuilder queryBuilder;
+            if (query.length() > 0) {
+                // This will only happen if the deprecated query(String) method was used.
+                queryBuilder = new StringBuilder(encodeQuery(query.toString()));
+            } else {
+                queryBuilder = new StringBuilder();
+            }
+
             for (int i = 0; i < qParams.size(); i++) {
                 String amp = (i != qParams.size() - 1) ? "&" : "";
-                query.append(qParams.get(i) + amp);
+                queryBuilder.append(qParams.get(i).toURLEncodedString() + amp);
             }
-            String q = (query.length() == 0) ? null : query.toString();
-            return new URI(scheme, null, host, port, path, q, null);
+            String q = (queryBuilder.length() == 0) ? "" : "?" + queryBuilder.toString();
+            String uriString = String.format("%s://%s:%s%s%s", scheme, host, port, path, q);
+            return new URI(uriString);
         } catch (URISyntaxException e) {
             throw new IllegalArgumentException(e);
         }
@@ -68,11 +75,11 @@ public class URIBuilder {
     public URI buildEncoded() {
         for (int i = 0; i < qParams.size(); i++) {
             String amp = (i != qParams.size() - 1) ? "&" : "";
-            query.append(qParams.get(i) + amp);
+            query.append(qParams.get(i).toURLEncodedString() + amp);
         }
         try {
             String q = (query.length() == 0) ? "" : "?" + query;
-            String uri = String.format("%s://%s:%s%s%s%s", new Object[]{scheme, host, port, path, pathToEncode, q});
+            String uri = String.format("%s://%s:%s%s%s%s", scheme, host, port, path, encodedPath, q);
             return new URI(uri);
         } catch (URISyntaxException e) {
             throw new IllegalArgumentException(e);
@@ -101,7 +108,7 @@ public class URIBuilder {
 
     public URIBuilder pathToEncode(String path) {
         try {
-            pathToEncode = URLEncoder.encode(path, "UTF-8");
+            encodedPath = URLEncoder.encode(path, "UTF-8");
         } catch (UnsupportedEncodingException e) {
             throw new IllegalArgumentException(e);
         }
@@ -110,10 +117,12 @@ public class URIBuilder {
 
     public URIBuilder query(String name, Object value) {
         if (name != null && value != null)
-            this.qParams.add(String.format("%s=%s", name, value));
+            this.qParams.addParam(name, value.toString());
         return this;
     }
 
+    /** @deprecated Use {@link #query(String, Object)} instead. */
+    @Deprecated
     public URIBuilder query(String query) {
         if (query != null)
             this.query.append(query);
@@ -122,8 +131,25 @@ public class URIBuilder {
 
     public URIBuilder query(Params params) {
         if (params.getParams() != null)
-            this.qParams.addAll(params.getParams());
+            this.qParams.addAll(params);
         return this;
     }
 
+    private String encodeQuery(String in) {
+        try {
+            URI uri = new URI(
+                    null, // scheme
+                    null, // authority
+                    null, // path
+                    in,   // query
+                    null  // fragment
+            );
+            return uri.toASCIIString()
+                    .substring(1); // remove leading ?;
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(
+                    "Couldn't encode query parameter " + in,
+                    e);
+        }
+    }
 }

--- a/src/test/java/com/cloudant/tests/SearchTests.java
+++ b/src/test/java/com/cloudant/tests/SearchTests.java
@@ -27,178 +27,178 @@ import com.cloudant.test.main.RequiresCloudant;
 @Category(RequiresCloudant.class)
 public class SearchTests {
 
-	private static final Log log = LogFactory.getLog(SearchTests.class);
-	private static Database db;
-	private CloudantClient account;
-	
-	@Before
-	public  void setUp() {
-		account = CloudantClientHelper.getClient();
-		
-		// replciate the animals db for search tests
-		com.cloudant.client.api.Replication r = account.replication();
-		r.source("https://examples.cloudant.com/animaldb");
-		r.createTarget(true);
-		r.target(CloudantClientHelper.SERVER_URI.toString()+ "/animaldb");
-		r.trigger();
-		db = account.database("animaldb", false);
-		
-		// sync the design doc for faceted search
-		DesignDocument designDoc = db.design().getFromDesk("views101");
-		db.design().synchronizeWithDb(designDoc);
-	}
+    private static final Log log = LogFactory.getLog(SearchTests.class);
+    private static Database db;
+    private CloudantClient account;
 
-	@After
-	public  void tearDown() {
-		account.shutdown();
-		account.deleteDB("animaldb", "delete database");
-	}
-	
-		
-	
-	@Test
-	public void searchCountsTest() {
-				
-		// do a faceted search for counts
-		Search srch = db.search("views101/animals");
-		SearchResult<Animal> rslt= srch.limit(10)
-				.includeDocs(true)
-				.counts(new String[] {"class","diet"})
-				.querySearchResult("l*", Animal.class);
-		assertNotNull(rslt);
-		assertNotNull(rslt.getCounts());
-		assert(rslt.getCounts().keySet().size() == 2);
-		assertEquals(rslt.getCounts().get("class").keySet().size(), 1);
-		assertEquals(rslt.getCounts().get("class").get("mammal"), new Long(2));
-		assertEquals(rslt.getCounts().get("diet").keySet().size() , 2);
-		assertEquals(rslt.getCounts().get("diet").get("herbivore") , new Long(1));
-		assertEquals(rslt.getCounts().get("diet").get("omnivore") , new Long(1));
-		assertNotNull(rslt.getBookmark());
-		assertEquals(rslt.getGroups().size() , 0);
-		assertEquals(rslt.getRows().size() , 2);
-		for ( @SuppressWarnings("rawtypes") SearchResultRows r : rslt.getRows() ) {
-			assertNotNull(r.getDoc());
-			assertNotNull(r.getFields());
-			assertNotNull(r.getId());
-			assertNotNull(r.getOrder());
-		}
-	 
-	}
-	
-	@Test
-	public void rowsTest() {
-		Search srch = db.search("views101/animals");
-		List<Animal> animals= srch.limit(10)
-				.includeDocs(true)
-				.counts(new String[] {"class","diet"})
-				.query("l*",  Animal.class);
-		assertNotNull(animals);
-		assertEquals(animals.size(), 2);
-		 for ( Animal a : animals ) {
-			 assertNotNull(a);
-		 }
-	}
-	
-	@Test
-	public void groupsTest() {
-		Search srch = db.search("views101/animals");
-		Map<String,List<Animal>> groups = srch.limit(10)
-				.includeDocs(true)
-				.counts(new String[] {"class","diet"})
-				.groupField("class", false)
-				.queryGroups("l*", Animal.class);
-		assertNotNull(groups);
-		assertEquals(groups.size(), 1);
-		for ( Entry<String, List<Animal>> g : groups.entrySet()) {
-			assertNotNull(g.getKey());
-			assertEquals(g.getValue().size(),2);
-			for ( Animal a : g.getValue() ) {
-				assertNotNull(a);
-			 }
-		}
-	}
-	
-	@Test
-	public void rangesTest() {
-		// do a faceted search for ranges
-		Search srch = db.search("views101/animals");
-		SearchResult<Animal> rslt= srch.includeDocs(true)
-				.counts(new String[] {"class","diet"})
-				.ranges("{ \"min_length\": {\"small\": \"[0 TO 1.0]\","
-				  + "\"medium\": \"[1.1 TO 3.0]\", \"large\": \"[3.1 TO 9999999]\"} }")
-				.querySearchResult("class:mammal", Animal.class);
-		assertNotNull(rslt);
-		assertNotNull(rslt.getRanges());
-		assertEquals(rslt.getRanges().entrySet().size(),1);
-		assertEquals(rslt.getRanges().get("min_length").entrySet().size(),3);
-		assertEquals(rslt.getRanges().get("min_length").get("small"), new Long(3));
-		assertEquals(rslt.getRanges().get("min_length").get("medium"), new Long(3));
-		assertEquals(rslt.getRanges().get("min_length").get("large"), new Long(2));
-		
-	}
-	
-	
-	@Test
-	public void sortTest() {
-		// do a faceted search for counts
-		Search srch = db.search("views101/animals");
-		SearchResult<Animal> rslt= srch.includeDocs(true)
-					.sort("[\"diet<string>\"]")
-					.querySearchResult("class:mammal", Animal.class);
-		assertNotNull(rslt);
-		assertEquals(rslt.getRows().get(0).getOrder()[0].toString(), ("carnivore"));
-		assertEquals(rslt.getRows().get(1).getOrder()[0].toString(), ("herbivore"));
-		assertEquals(rslt.getRows().get(5).getOrder()[0].toString(), ("omnivore"));
-	}
-	
-	@Test
-	public void groupSortTest() {
-		Search srch = db.search("views101/animals");
-		Map<String,List<Animal>> groups = srch.includeDocs(true)
-				.groupField("diet", false)
-				.groupSort("[\"-diet<string>\"]")
-				.queryGroups("l*", Animal.class);
-		assertNotNull(groups);
-		assertEquals(groups.size(), 2);
-		Iterator<String> it = groups.keySet().iterator();
-		assertEquals("omnivore", it.next()); // diet in reverse order
-		assertEquals("herbivore",it.next());
-	}
-	
-	
-	
-	@Test
-	public void drillDownTest() {
-		// do a faceted search for drilldown
-				Search srch = db.search("views101/animals");
-				SearchResult<Animal> rslt= srch.includeDocs(true)
-						.counts(new String[] {"class","diet"})
-						.ranges("{ \"min_length\": {\"small\": \"[0 TO 1.0]\","
-						  + "\"medium\": \"[1.1 TO 3.0]\", \"large\": \"[3.1 TO 9999999]\"} }")
-						 .drillDown("class", "mammals")
-						.querySearchResult("class:mammal", Animal.class);
-				assertNotNull(rslt);
-				assertNotNull(rslt.getRanges());
-				assertEquals(rslt.getRanges().entrySet().size(),1);
-				assertEquals(rslt.getRanges().get("min_length").entrySet().size(),3);
-				assertEquals(rslt.getRanges().get("min_length").get("small"), new Long(0));
-				assertEquals(rslt.getRanges().get("min_length").get("medium"), new Long(0));
-				assertEquals(rslt.getRanges().get("min_length").get("large"), new Long(0));
-	}
-	
-	
-	@Test
-	public void bookmarkTest() {
-		Search srch = db.search("views101/animals");
-		SearchResult<Animal> rslt= srch.limit(4)
-				.querySearchResult("class:mammal", Animal.class);
-		
-		Search srch1 = db.search("views101/animals");
-		srch1.bookmark(rslt.getBookmark())
-			.querySearchResult("class:mammal", Animal.class);
-		
-	}
+    @Before
+    public  void setUp() {
+        account = CloudantClientHelper.getClient();
 
-	
-	
+        // replciate the animals db for search tests
+        com.cloudant.client.api.Replication r = account.replication();
+        r.source("https://examples.cloudant.com/animaldb");
+        r.createTarget(true);
+        r.target(CloudantClientHelper.SERVER_URI.toString()+ "/animaldb");
+        r.trigger();
+        db = account.database("animaldb", false);
+
+        // sync the design doc for faceted search
+        DesignDocument designDoc = db.design().getFromDesk("views101");
+        db.design().synchronizeWithDb(designDoc);
+    }
+
+    @After
+    public  void tearDown() {
+        account.shutdown();
+        account.deleteDB("animaldb", "delete database");
+    }
+
+
+
+    @Test
+    public void searchCountsTest() {
+
+        // do a faceted search for counts
+        Search srch = db.search("views101/animals");
+        SearchResult<Animal> rslt= srch.limit(10)
+                .includeDocs(true)
+                .counts(new String[] {"class","diet"})
+                .querySearchResult("l*", Animal.class);
+        assertNotNull(rslt);
+        assertNotNull(rslt.getCounts());
+        assert(rslt.getCounts().keySet().size() == 2);
+        assertEquals(rslt.getCounts().get("class").keySet().size(), 1);
+        assertEquals(rslt.getCounts().get("class").get("mammal"), new Long(2));
+        assertEquals(rslt.getCounts().get("diet").keySet().size() , 2);
+        assertEquals(rslt.getCounts().get("diet").get("herbivore") , new Long(1));
+        assertEquals(rslt.getCounts().get("diet").get("omnivore") , new Long(1));
+        assertNotNull(rslt.getBookmark());
+        assertEquals(rslt.getGroups().size() , 0);
+        assertEquals(rslt.getRows().size() , 2);
+        for ( @SuppressWarnings("rawtypes") SearchResultRows r : rslt.getRows() ) {
+            assertNotNull(r.getDoc());
+            assertNotNull(r.getFields());
+            assertNotNull(r.getId());
+            assertNotNull(r.getOrder());
+        }
+
+    }
+
+    @Test
+    public void rowsTest() {
+        Search srch = db.search("views101/animals");
+        List<Animal> animals= srch.limit(10)
+                .includeDocs(true)
+                .counts(new String[] {"class","diet"})
+                .query("l*",  Animal.class);
+        assertNotNull(animals);
+        assertEquals(animals.size(), 2);
+         for ( Animal a : animals ) {
+             assertNotNull(a);
+         }
+    }
+
+    @Test
+    public void groupsTest() {
+        Search srch = db.search("views101/animals");
+        Map<String,List<Animal>> groups = srch.limit(10)
+                .includeDocs(true)
+                .counts(new String[] {"class","diet"})
+                .groupField("class", false)
+                .queryGroups("l*", Animal.class);
+        assertNotNull(groups);
+        assertEquals(groups.size(), 1);
+        for ( Entry<String, List<Animal>> g : groups.entrySet()) {
+            assertNotNull(g.getKey());
+            assertEquals(g.getValue().size(),2);
+            for ( Animal a : g.getValue() ) {
+                assertNotNull(a);
+             }
+        }
+    }
+
+    @Test
+    public void rangesTest() {
+        // do a faceted search for ranges
+        Search srch = db.search("views101/animals");
+        SearchResult<Animal> rslt= srch.includeDocs(true)
+                .counts(new String[] {"class","diet"})
+                .ranges("{ \"min_length\": {\"small\": \"[0 TO 1.0]\","
+                  + "\"medium\": \"[1.1 TO 3.0]\", \"large\": \"[3.1 TO 9999999]\"} }")
+                .querySearchResult("class:mammal", Animal.class);
+        assertNotNull(rslt);
+        assertNotNull(rslt.getRanges());
+        assertEquals(rslt.getRanges().entrySet().size(),1);
+        assertEquals(rslt.getRanges().get("min_length").entrySet().size(),3);
+        assertEquals(rslt.getRanges().get("min_length").get("small"), new Long(3));
+        assertEquals(rslt.getRanges().get("min_length").get("medium"), new Long(3));
+        assertEquals(rslt.getRanges().get("min_length").get("large"), new Long(2));
+
+    }
+
+
+    @Test
+    public void sortTest() {
+        // do a faceted search for counts
+        Search srch = db.search("views101/animals");
+        SearchResult<Animal> rslt= srch.includeDocs(true)
+                    .sort("[\"diet<string>\"]")
+                    .querySearchResult("class:mammal", Animal.class);
+        assertNotNull(rslt);
+        assertEquals(rslt.getRows().get(0).getOrder()[0].toString(), ("carnivore"));
+        assertEquals(rslt.getRows().get(1).getOrder()[0].toString(), ("herbivore"));
+        assertEquals(rslt.getRows().get(5).getOrder()[0].toString(), ("omnivore"));
+    }
+
+    @Test
+    public void groupSortTest() {
+        Search srch = db.search("views101/animals");
+        Map<String,List<Animal>> groups = srch.includeDocs(true)
+                .groupField("diet", false)
+                .groupSort("[\"-diet<string>\"]")
+                .queryGroups("l*", Animal.class);
+        assertNotNull(groups);
+        assertEquals(groups.size(), 2);
+        Iterator<String> it = groups.keySet().iterator();
+        assertEquals("omnivore", it.next()); // diet in reverse order
+        assertEquals("herbivore",it.next());
+    }
+
+
+
+    @Test
+    public void drillDownTest() {
+        // do a faceted search for drilldown
+                Search srch = db.search("views101/animals");
+                SearchResult<Animal> rslt= srch.includeDocs(true)
+                        .counts(new String[] {"class","diet"})
+                        .ranges("{ \"min_length\": {\"small\": \"[0 TO 1.0]\","
+                          + "\"medium\": \"[1.1 TO 3.0]\", \"large\": \"[3.1 TO 9999999]\"} }")
+                         .drillDown("class", "mammals")
+                        .querySearchResult("class:mammal", Animal.class);
+                assertNotNull(rslt);
+                assertNotNull(rslt.getRanges());
+                assertEquals(rslt.getRanges().entrySet().size(),1);
+                assertEquals(rslt.getRanges().get("min_length").entrySet().size(),3);
+                assertEquals(rslt.getRanges().get("min_length").get("small"), new Long(0));
+                assertEquals(rslt.getRanges().get("min_length").get("medium"), new Long(0));
+                assertEquals(rslt.getRanges().get("min_length").get("large"), new Long(0));
+    }
+
+
+    @Test
+    public void bookmarkTest() {
+        Search srch = db.search("views101/animals");
+        SearchResult<Animal> rslt= srch.limit(4)
+                .querySearchResult("class:mammal", Animal.class);
+
+        Search srch1 = db.search("views101/animals");
+        srch1.bookmark(rslt.getBookmark())
+            .querySearchResult("class:mammal", Animal.class);
+
+    }
+
+
+
 }

--- a/src/test/java/com/cloudant/tests/UpdateHandlerTest.java
+++ b/src/test/java/com/cloudant/tests/UpdateHandlerTest.java
@@ -30,58 +30,58 @@ import com.cloudant.client.api.model.Params;
 import com.cloudant.client.api.model.Response;
 
 public class UpdateHandlerTest {
-	
 
-	private static Database db;
-	private CloudantClient account;
-	
 
-	@Before
-	public  void setUp() {
-		account = CloudantClientHelper.getClient();
-		db = account.database("lightcouch-db-test", true);
-		db.syncDesignDocsWithDb();
-	}
+    private static Database db;
+    private CloudantClient account;
 
-	@After
-	public void tearDown(){
-		account.shutdown();
-	}
 
-	@Test
-	public void updateHandler_queryString() {
-		final String oldValue = "foo";
-		final String newValue = "foo bar";
-		
-		Response response = db.save(new Foo(null, oldValue));
-		
-		String query = "field=title&value=" + newValue;
-		
-		String output = db.invokeUpdateHandler("example/example_update", response.getId(), query);
-		
-		// retrieve from db to verify
-		Foo foo = db.find(Foo.class, response.getId());
-		
-		assertNotNull(output);
-		assertEquals(foo.getTitle(), newValue);
-	}
-	
-	@Test
-	public void updateHandler_queryParams() {
-		final String oldValue = "foo";
-		final String newValue = "foo bar";
-		
-		Response response = db.save(new Foo(null, oldValue));
+    @Before
+    public  void setUp() {
+        account = CloudantClientHelper.getClient();
+        db = account.database("lightcouch-db-test", true);
+        db.syncDesignDocsWithDb();
+    }
 
-		Params params = new Params()
-					.addParam("field", "title")
-					.addParam("value", newValue);
-		String output = db.invokeUpdateHandler("example/example_update", response.getId(), params);
-		
-		// retrieve from db to verify
-		Foo foo = db.find(Foo.class, response.getId());
-		
-		assertNotNull(output);
-		assertEquals(foo.getTitle(), newValue);
-	}
+    @After
+    public void tearDown(){
+        account.shutdown();
+    }
+
+    @Test
+    public void updateHandler_queryString() {
+        final String oldValue = "foo";
+        final String newValue = "foo bar";
+
+        Response response = db.save(new Foo(null, oldValue));
+
+        String query = "field=title&value=" + newValue;
+
+        String output = db.invokeUpdateHandler("example/example_update", response.getId(), query);
+
+        // retrieve from db to verify
+        Foo foo = db.find(Foo.class, response.getId());
+
+        assertNotNull(output);
+        assertEquals(foo.getTitle(), newValue);
+    }
+
+    @Test
+    public void updateHandler_queryParams() {
+        final String oldValue = "foo";
+        final String newValue = "foo bar";
+
+        Response response = db.save(new Foo(null, oldValue));
+
+        Params params = new Params()
+                    .addParam("field", "title")
+                    .addParam("value", newValue);
+        String output = db.invokeUpdateHandler("example/example_update", response.getId(), params);
+
+        // retrieve from db to verify
+        Foo foo = db.find(Foo.class, response.getId());
+
+        assertNotNull(output);
+        assertEquals(foo.getTitle(), newValue);
+    }
 }

--- a/src/test/java/com/cloudant/tests/UpdateHandlerTest.java
+++ b/src/test/java/com/cloudant/tests/UpdateHandlerTest.java
@@ -51,13 +51,15 @@ public class UpdateHandlerTest {
     @Test
     public void updateHandler_queryString() {
         final String oldValue = "foo";
-        final String newValue = "foo bar";
+        final String newValue = "foo bar+plus=equals&ampersand";
 
         Response response = db.save(new Foo(null, oldValue));
 
-        String query = "field=title&value=" + newValue;
+        Params params = new Params()
+                    .addParam("field", "title")
+                    .addParam("value", newValue);
 
-        String output = db.invokeUpdateHandler("example/example_update", response.getId(), query);
+        String output = db.invokeUpdateHandler("example/example_update", response.getId(), params);
 
         // retrieve from db to verify
         Foo foo = db.find(Foo.class, response.getId());
@@ -69,7 +71,7 @@ public class UpdateHandlerTest {
     @Test
     public void updateHandler_queryParams() {
         final String oldValue = "foo";
-        final String newValue = "foo bar";
+        final String newValue = "foo bar+plus=equals&ampersand";
 
         Response response = db.save(new Foo(null, oldValue));
 


### PR DESCRIPTION
Fixes FB#46986.

Ensures the characters `+`, `=` and `&` are correctly percent encoded when they appear in the query part of a URL.

Replacement of the characters is done in `URIBuilder.build`

*TESTING*
Tests added to ensure correct percent encoding of `+`, `=` and `&`.

reviewer @mikerhodes
reviewer @tomblench  