### PR TITLE
Make sure tests clean up after themselves

### DIFF
--- a/src/test/java/com/cloudant/tests/AttachmentsTest.java
+++ b/src/test/java/com/cloudant/tests/AttachmentsTest.java
@@ -49,6 +49,7 @@ public class AttachmentsTest  {
 
 	@After
 	public void tearDown(){
+		account.deleteDB("lightcouch-db-test", "delete database");
 		account.shutdown();
 	}
 

--- a/src/test/java/com/cloudant/tests/BulkDocumentTest.java
+++ b/src/test/java/com/cloudant/tests/BulkDocumentTest.java
@@ -49,6 +49,7 @@ public class BulkDocumentTest{
 
 	@After
 	public void tearDown(){
+		account.deleteDB("lightcouch-db-test", "delete database");
 		account.shutdown();
 	}
 

--- a/src/test/java/com/cloudant/tests/ChangeNotificationsTest.java
+++ b/src/test/java/com/cloudant/tests/ChangeNotificationsTest.java
@@ -54,6 +54,7 @@ public class ChangeNotificationsTest {
 
 	@After
 	public void tearDown(){
+		account.deleteDB("lightcouch-db-test", "delete database");
 		account.shutdown();
 	}
 

--- a/src/test/java/com/cloudant/tests/DBServerTest.java
+++ b/src/test/java/com/cloudant/tests/DBServerTest.java
@@ -48,6 +48,7 @@ public class DBServerTest {
 
 	@After
 	public void tearDown(){
+		account.deleteDB("lightcouch-db-test", "delete database");
 		account.shutdown();
 	}
 

--- a/src/test/java/com/cloudant/tests/DesignDocumentsTest.java
+++ b/src/test/java/com/cloudant/tests/DesignDocumentsTest.java
@@ -44,6 +44,7 @@ public class DesignDocumentsTest {
 
 	@After
 	public void tearDown(){
+		account.deleteDB("lightcouch-db-test", "delete database");
 		account.shutdown();
 	}
 

--- a/src/test/java/com/cloudant/tests/DocumentsCRUDTest.java
+++ b/src/test/java/com/cloudant/tests/DocumentsCRUDTest.java
@@ -56,6 +56,7 @@ public class DocumentsCRUDTest {
 
 	@After
 	public void tearDown(){
+		account.deleteDB("lightcouch-db-test", "delete database");
 		account.shutdown();
 	}
 

--- a/src/test/java/com/cloudant/tests/IndexTests.java
+++ b/src/test/java/com/cloudant/tests/IndexTests.java
@@ -45,8 +45,8 @@ public class IndexTests {
 
 	@After
 	public  void tearDown() {
-		account.shutdown();
 		account.deleteDB("movies-demo", "delete database");
+		account.shutdown();
 	}
 	
 	

--- a/src/test/java/com/cloudant/tests/ReplicationTest.java
+++ b/src/test/java/com/cloudant/tests/ReplicationTest.java
@@ -42,7 +42,7 @@ import com.cloudant.client.api.model.ReplicatorDocument;
 import com.cloudant.client.api.model.Response;
 import com.cloudant.client.api.model.ViewResult;
 
-//@Ignore
+@Ignore
 public class ReplicationTest {
 	private static final Log log = LogFactory.getLog(ReplicationTest.class);
 	

--- a/src/test/java/com/cloudant/tests/ReplicationTest.java
+++ b/src/test/java/com/cloudant/tests/ReplicationTest.java
@@ -31,6 +31,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import com.cloudant.client.api.CloudantClient;

--- a/src/test/java/com/cloudant/tests/ReplicatorTest.java
+++ b/src/test/java/com/cloudant/tests/ReplicatorTest.java
@@ -50,6 +50,8 @@ public class ReplicatorTest {
 
 	@After
 	public void tearDown(){
+		account.deleteDB("lightcouch-db-test", "delete database");
+		account.deleteDB("lightcouch-db-test-2", "delete database");
 		account.shutdown();
 	}
 

--- a/src/test/java/com/cloudant/tests/ReplicatorTest.java
+++ b/src/test/java/com/cloudant/tests/ReplicatorTest.java
@@ -12,6 +12,7 @@ import java.util.UUID;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import com.cloudant.client.api.CloudantClient;
@@ -20,6 +21,8 @@ import com.cloudant.client.api.model.ReplicatorDocument;
 import com.cloudant.client.api.model.Response;
 import com.cloudant.client.api.model.ViewResult;
 
+
+@Ignore
 public class ReplicatorTest {
 
 	private static Properties props ;

--- a/src/test/java/com/cloudant/tests/SearchTests.java
+++ b/src/test/java/com/cloudant/tests/SearchTests.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -15,6 +16,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.lightcouch.internal.URIBuilder;
 
 import com.cloudant.client.api.CloudantClient;
 import com.cloudant.client.api.Database;
@@ -23,182 +25,181 @@ import com.cloudant.client.api.model.DesignDocument;
 import com.cloudant.client.api.model.SearchResult;
 import com.cloudant.client.api.model.SearchResult.SearchResultRows;
 import com.cloudant.test.main.RequiresCloudant;
-import org.lightcouch.internal.URIBuilder;
 
 @Category(RequiresCloudant.class)
 public class SearchTests {
 
-    private static final Log log = LogFactory.getLog(SearchTests.class);
-    private static Database db;
-    private CloudantClient account;
+	private static final Log log = LogFactory.getLog(SearchTests.class);
+	private static Database db;
+	private CloudantClient account;
+	
+	@Before
+	public  void setUp() {
+		account = CloudantClientHelper.getClient();
+		
+		// replciate the animals db for search tests
+		com.cloudant.client.api.Replication r = account.replication();
+		r.source("https://examples.cloudant.com/animaldb");
+		r.createTarget(true);
+		r.target(CloudantClientHelper.SERVER_URI.toString()+ "/animaldb");
+		r.trigger();
+		db = account.database("animaldb", false);
+		
+		// sync the design doc for faceted search
+		DesignDocument designDoc = db.design().getFromDesk("views101");
+		db.design().synchronizeWithDb(designDoc);
+	}
 
-    @Before
-    public  void setUp() {
-        account = CloudantClientHelper.getClient();
-
-        // replciate the animals db for search tests
-        com.cloudant.client.api.Replication r = account.replication();
-        r.source("https://examples.cloudant.com/animaldb");
-        r.createTarget(true);
-        r.target(CloudantClientHelper.SERVER_URI.toString()+ "/animaldb");
-        r.trigger();
-        db = account.database("animaldb", false);
-
-        // sync the design doc for faceted search
-        DesignDocument designDoc = db.design().getFromDesk("views101");
-        db.design().synchronizeWithDb(designDoc);
-    }
-
-    @After
-    public  void tearDown() {
-        account.deleteDB("animaldb", "delete database");
-        account.shutdown();
-    }
-
-
-
-    @Test
-    public void searchCountsTest() {
-
-        // do a faceted search for counts
-        Search srch = db.search("views101/animals");
-        SearchResult<Animal> rslt= srch.limit(10)
-                .includeDocs(true)
-                .counts(new String[] {"class","diet"})
-                .querySearchResult("l*", Animal.class);
-        assertNotNull(rslt);
-        assertNotNull(rslt.getCounts());
-        assert(rslt.getCounts().keySet().size() == 2);
-        assertEquals(rslt.getCounts().get("class").keySet().size(), 1);
-        assertEquals(rslt.getCounts().get("class").get("mammal"), new Long(2));
-        assertEquals(rslt.getCounts().get("diet").keySet().size() , 2);
-        assertEquals(rslt.getCounts().get("diet").get("herbivore") , new Long(1));
-        assertEquals(rslt.getCounts().get("diet").get("omnivore") , new Long(1));
-        assertNotNull(rslt.getBookmark());
-        assertEquals(rslt.getGroups().size() , 0);
-        assertEquals(rslt.getRows().size() , 2);
-        for ( @SuppressWarnings("rawtypes") SearchResultRows r : rslt.getRows() ) {
-            assertNotNull(r.getDoc());
-            assertNotNull(r.getFields());
-            assertNotNull(r.getId());
-            assertNotNull(r.getOrder());
-        }
-
-    }
-
-    @Test
-    public void rowsTest() {
-        Search srch = db.search("views101/animals");
-        List<Animal> animals= srch.limit(10)
-                .includeDocs(true)
-                .counts(new String[] {"class","diet"})
-                .query("l*",  Animal.class);
-        assertNotNull(animals);
-        assertEquals(animals.size(), 2);
-         for ( Animal a : animals ) {
-             assertNotNull(a);
-         }
-    }
-
-    @Test
-    public void groupsTest() {
-        Search srch = db.search("views101/animals");
-        Map<String,List<Animal>> groups = srch.limit(10)
-                .includeDocs(true)
-                .counts(new String[] {"class","diet"})
-                .groupField("class", false)
-                .queryGroups("l*", Animal.class);
-        assertNotNull(groups);
-        assertEquals(groups.size(), 1);
-        for ( Entry<String, List<Animal>> g : groups.entrySet()) {
-            assertNotNull(g.getKey());
-            assertEquals(g.getValue().size(),2);
-            for ( Animal a : g.getValue() ) {
-                assertNotNull(a);
-             }
-        }
-    }
-
-    @Test
-    public void rangesTest() {
-        // do a faceted search for ranges
-        Search srch = db.search("views101/animals");
-        SearchResult<Animal> rslt= srch.includeDocs(true)
-                .counts(new String[] {"class","diet"})
-                .ranges("{ \"min_length\": {\"small\": \"[0 TO 1.0]\","
-                  + "\"medium\": \"[1.1 TO 3.0]\", \"large\": \"[3.1 TO 9999999]\"} }")
-                .querySearchResult("class:mammal", Animal.class);
-        assertNotNull(rslt);
-        assertNotNull(rslt.getRanges());
-        assertEquals(rslt.getRanges().entrySet().size(),1);
-        assertEquals(rslt.getRanges().get("min_length").entrySet().size(),3);
-        assertEquals(rslt.getRanges().get("min_length").get("small"), new Long(3));
-        assertEquals(rslt.getRanges().get("min_length").get("medium"), new Long(3));
-        assertEquals(rslt.getRanges().get("min_length").get("large"), new Long(2));
-
-    }
-
-
-    @Test
-    public void sortTest() {
-        // do a faceted search for counts
-        Search srch = db.search("views101/animals");
-        SearchResult<Animal> rslt= srch.includeDocs(true)
-                    .sort("[\"diet<string>\"]")
-                    .querySearchResult("class:mammal", Animal.class);
-        assertNotNull(rslt);
-        assertEquals(rslt.getRows().get(0).getOrder()[0].toString(), ("carnivore"));
-        assertEquals(rslt.getRows().get(1).getOrder()[0].toString(), ("herbivore"));
-        assertEquals(rslt.getRows().get(5).getOrder()[0].toString(), ("omnivore"));
-    }
-
-    @Test
-    public void groupSortTest() {
-        Search srch = db.search("views101/animals");
-        Map<String,List<Animal>> groups = srch.includeDocs(true)
-                .groupField("diet", false)
-                .groupSort("[\"-diet<string>\"]")
-                .queryGroups("l*", Animal.class);
-        assertNotNull(groups);
-        assertEquals(groups.size(), 2);
-        Iterator<String> it = groups.keySet().iterator();
-        assertEquals("omnivore", it.next()); // diet in reverse order
-        assertEquals("herbivore",it.next());
-    }
-
-
-
-    @Test
-    public void drillDownTest() {
-        // do a faceted search for drilldown
-        Search srch = db.search("views101/animals");
-        SearchResult<Animal> rslt= srch.includeDocs(true)
-                .counts(new String[] {"class","diet"})
-                .ranges("{ \"min_length\": {\"small\": \"[0 TO 1.0]\","
-                  + "\"medium\": \"[1.1 TO 3.0]\", \"large\": \"[3.1 TO 9999999]\"} }")
-                 .drillDown("class", "mammals")
-                .querySearchResult("class:mammal", Animal.class);
-        assertNotNull(rslt);
-        assertNotNull(rslt.getRanges());
-        assertEquals(rslt.getRanges().entrySet().size(),1);
-        assertEquals(rslt.getRanges().get("min_length").entrySet().size(),3);
-        assertEquals(rslt.getRanges().get("min_length").get("small"), new Long(0));
-        assertEquals(rslt.getRanges().get("min_length").get("medium"), new Long(0));
-        assertEquals(rslt.getRanges().get("min_length").get("large"), new Long(0));
-    }
-
-
-    @Test
-    public void bookmarkTest() {
-        Search srch = db.search("views101/animals");
-        SearchResult<Animal> rslt= srch.limit(4)
-                .querySearchResult("class:mammal", Animal.class);
-
-        Search srch1 = db.search("views101/animals");
-        srch1.bookmark(rslt.getBookmark())
-            .querySearchResult("class:mammal", Animal.class);
-
-    }
+	@After
+	public  void tearDown() {
+		account.deleteDB("animaldb", "delete database");
+		account.shutdown();
+	}
+	
+		
+	
+	@Test
+	public void searchCountsTest() {
+				
+		// do a faceted search for counts
+		Search srch = db.search("views101/animals");
+		SearchResult<Animal> rslt= srch.limit(10)
+				.includeDocs(true)
+				.counts(new String[] {"class","diet"})
+				.querySearchResult("l*", Animal.class);
+		assertNotNull(rslt);
+		assertNotNull(rslt.getCounts());
+		assert(rslt.getCounts().keySet().size() == 2);
+		assertEquals(rslt.getCounts().get("class").keySet().size(), 1);
+		assertEquals(rslt.getCounts().get("class").get("mammal"), new Long(2));
+		assertEquals(rslt.getCounts().get("diet").keySet().size() , 2);
+		assertEquals(rslt.getCounts().get("diet").get("herbivore") , new Long(1));
+		assertEquals(rslt.getCounts().get("diet").get("omnivore") , new Long(1));
+		assertNotNull(rslt.getBookmark());
+		assertEquals(rslt.getGroups().size() , 0);
+		assertEquals(rslt.getRows().size() , 2);
+		for ( @SuppressWarnings("rawtypes") SearchResultRows r : rslt.getRows() ) {
+			assertNotNull(r.getDoc());
+			assertNotNull(r.getFields());
+			assertNotNull(r.getId());
+			assertNotNull(r.getOrder());
+		}
+	 
+	}
+	
+	@Test
+	public void rowsTest() {
+		Search srch = db.search("views101/animals");
+		List<Animal> animals= srch.limit(10)
+				.includeDocs(true)
+				.counts(new String[] {"class","diet"})
+				.query("l*",  Animal.class);
+		assertNotNull(animals);
+		assertEquals(animals.size(), 2);
+		 for ( Animal a : animals ) {
+			 assertNotNull(a);
+		 }
+	}
+	
+	@Test
+	public void groupsTest() {
+		Search srch = db.search("views101/animals");
+		Map<String,List<Animal>> groups = srch.limit(10)
+				.includeDocs(true)
+				.counts(new String[] {"class","diet"})
+				.groupField("class", false)
+				.queryGroups("l*", Animal.class);
+		assertNotNull(groups);
+		assertEquals(groups.size(), 1);
+		for ( Entry<String, List<Animal>> g : groups.entrySet()) {
+			assertNotNull(g.getKey());
+			assertEquals(g.getValue().size(),2);
+			for ( Animal a : g.getValue() ) {
+				assertNotNull(a);
+			 }
+		}
+	}
+	
+	@Test
+	public void rangesTest() {
+		// do a faceted search for ranges
+		Search srch = db.search("views101/animals");
+		SearchResult<Animal> rslt= srch.includeDocs(true)
+				.counts(new String[] {"class","diet"})
+				.ranges("{ \"min_length\": {\"small\": \"[0 TO 1.0]\","
+				  + "\"medium\": \"[1.1 TO 3.0]\", \"large\": \"[3.1 TO 9999999]\"} }")
+				.querySearchResult("class:mammal", Animal.class);
+		assertNotNull(rslt);
+		assertNotNull(rslt.getRanges());
+		assertEquals(rslt.getRanges().entrySet().size(),1);
+		assertEquals(rslt.getRanges().get("min_length").entrySet().size(),3);
+		assertEquals(rslt.getRanges().get("min_length").get("small"), new Long(3));
+		assertEquals(rslt.getRanges().get("min_length").get("medium"), new Long(3));
+		assertEquals(rslt.getRanges().get("min_length").get("large"), new Long(2));
+		
+	}
+	
+	
+	@Test
+	public void sortTest() {
+		// do a faceted search for counts
+		Search srch = db.search("views101/animals");
+		SearchResult<Animal> rslt= srch.includeDocs(true)
+					.sort("[\"diet<string>\"]")
+					.querySearchResult("class:mammal", Animal.class);
+		assertNotNull(rslt);
+		assertEquals(rslt.getRows().get(0).getOrder()[0].toString(), ("carnivore"));
+		assertEquals(rslt.getRows().get(1).getOrder()[0].toString(), ("herbivore"));
+		assertEquals(rslt.getRows().get(5).getOrder()[0].toString(), ("omnivore"));
+	}
+	
+	@Test
+	public void groupSortTest() {
+		Search srch = db.search("views101/animals");
+		Map<String,List<Animal>> groups = srch.includeDocs(true)
+				.groupField("diet", false)
+				.groupSort("[\"-diet<string>\"]")
+				.queryGroups("l*", Animal.class);
+		assertNotNull(groups);
+		assertEquals(groups.size(), 2);
+		Iterator<String> it = groups.keySet().iterator();
+		assertEquals("omnivore", it.next()); // diet in reverse order
+		assertEquals("herbivore",it.next());
+	}
+	
+	
+	
+	@Test
+	public void drillDownTest() {
+		// do a faceted search for drilldown
+				Search srch = db.search("views101/animals");
+				SearchResult<Animal> rslt= srch.includeDocs(true)
+						.counts(new String[] {"class","diet"})
+						.ranges("{ \"min_length\": {\"small\": \"[0 TO 1.0]\","
+						  + "\"medium\": \"[1.1 TO 3.0]\", \"large\": \"[3.1 TO 9999999]\"} }")
+						 .drillDown("class", "mammals")
+						.querySearchResult("class:mammal", Animal.class);
+				assertNotNull(rslt);
+				assertNotNull(rslt.getRanges());
+				assertEquals(rslt.getRanges().entrySet().size(),1);
+				assertEquals(rslt.getRanges().get("min_length").entrySet().size(),3);
+				assertEquals(rslt.getRanges().get("min_length").get("small"), new Long(0));
+				assertEquals(rslt.getRanges().get("min_length").get("medium"), new Long(0));
+				assertEquals(rslt.getRanges().get("min_length").get("large"), new Long(0));
+	}
+	
+	
+	@Test
+	public void bookmarkTest() {
+		Search srch = db.search("views101/animals");
+		SearchResult<Animal> rslt= srch.limit(4)
+				.querySearchResult("class:mammal", Animal.class);
+		
+		Search srch1 = db.search("views101/animals");
+		srch1.bookmark(rslt.getBookmark())
+			.querySearchResult("class:mammal", Animal.class);
+		
+	}
 
     private void escapingTest(String expectedResult, String query) {
         URIBuilder uriBuilder = new URIBuilder();
@@ -234,3 +235,4 @@ public class SearchTests {
     }
 
 }
+

--- a/src/test/java/com/cloudant/tests/UpdateHandlerTest.java
+++ b/src/test/java/com/cloudant/tests/UpdateHandlerTest.java
@@ -31,59 +31,59 @@ import com.cloudant.client.api.model.Response;
 
 public class UpdateHandlerTest {
 
+	private static Database db;
+	private CloudantClient account;
+	
 
-    private static Database db;
-    private CloudantClient account;
+	@Before
+	public  void setUp() {
+		account = CloudantClientHelper.getClient();
+		db = account.database("lightcouch-db-test", true);
+		db.syncDesignDocsWithDb();
+	}
 
+	@After
+	public void tearDown(){
+		account.deleteDB("lightcouch-db-test", "delete database");
+		account.shutdown();
+	}
 
-    @Before
-    public  void setUp() {
-        account = CloudantClientHelper.getClient();
-        db = account.database("lightcouch-db-test", true);
-        db.syncDesignDocsWithDb();
-    }
+	@Test
+	public void updateHandler_queryString() {
+		final String oldValue = "foo";
+		final String newValue = "foo bar+plus=equals&ampersand";
+		
+		Response response = db.save(new Foo(null, oldValue));
 
-    @After
-    public void tearDown(){
-        account.shutdown();
-    }
-
-    @Test
-    public void updateHandler_queryString() {
-        final String oldValue = "foo";
-        final String newValue = "foo bar+plus=equals&ampersand";
-
-        Response response = db.save(new Foo(null, oldValue));
-
-        Params params = new Params()
-                    .addParam("field", "title")
-                    .addParam("value", newValue);
-
+		Params params = new Params()
+				.addParam("field", "title")
+				.addParam("value", newValue);
+		
         String output = db.invokeUpdateHandler("example/example_update", response.getId(), params);
-
-        // retrieve from db to verify
-        Foo foo = db.find(Foo.class, response.getId());
-
-        assertNotNull(output);
-        assertEquals(foo.getTitle(), newValue);
-    }
-
-    @Test
-    public void updateHandler_queryParams() {
-        final String oldValue = "foo";
+		
+		// retrieve from db to verify
+		Foo foo = db.find(Foo.class, response.getId());
+		
+		assertNotNull(output);
+		assertEquals(foo.getTitle(), newValue);
+	}
+	
+	@Test
+	public void updateHandler_queryParams() {
+		final String oldValue = "foo";
         final String newValue = "foo bar+plus=equals&ampersand";
+		
+		Response response = db.save(new Foo(null, oldValue));
 
-        Response response = db.save(new Foo(null, oldValue));
-
-        Params params = new Params()
-                    .addParam("field", "title")
-                    .addParam("value", newValue);
-        String output = db.invokeUpdateHandler("example/example_update", response.getId(), params);
-
-        // retrieve from db to verify
-        Foo foo = db.find(Foo.class, response.getId());
-
-        assertNotNull(output);
-        assertEquals(foo.getTitle(), newValue);
-    }
+		Params params = new Params()
+					.addParam("field", "title")
+					.addParam("value", newValue);
+		String output = db.invokeUpdateHandler("example/example_update", response.getId(), params);
+		
+		// retrieve from db to verify
+		Foo foo = db.find(Foo.class, response.getId());
+		
+		assertNotNull(output);
+		assertEquals(foo.getTitle(), newValue);
+	}
 }

--- a/src/test/java/com/cloudant/tests/ViewsTest.java
+++ b/src/test/java/com/cloudant/tests/ViewsTest.java
@@ -59,6 +59,7 @@ public class ViewsTest {
 
 	@After
 	public void tearDown(){
+		account.deleteDB("lightcouch-db-test", "delete database");
 		account.shutdown();
 	}
 


### PR DESCRIPTION
## What

Ensure all tests delete the databases they created during their tear down.

## Why
Deleting databases and cleaning up other resources mean that previous test state does not effect the current test run.

## How
Call `deleteDb` method on `CloudantClient` in the `tearDown` method.


## Notes

Replicator and Replication tests have been disabled because they cause intermittent failures on travis, I've opened a ticket (47545) to investigate and fix this issue.

SearchTests and Updatehandler tests were merged with changes on master, as a result their diff is miss leading.

reviewer : @brynh 
reviewer: @tomblench 