### PR TITLE
Create new delete database api

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+- [NEW] New API for deleting databases, `CloudantClient.deleteDB(String name)`
+- [Deprecated] Deprecated `CloudantClient.deleteDB(String name, String confirm)`
+  API.
 - [FIX] Fixed handling of non-ASCII characters when the platform's
   default charset is not UTF-8.
 - [FIX] Fixed encoding of `+`, `=` and `&` characters when they are used

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ String password = System.getProperty("cloudant_password");
 CloudantClient client = new CloudantClient("mdb","mdb",password);
 
 // Clean up the database we created previously.
-client.deleteDB("alice", "delete database");
+client.deleteDB("alice");
 
 // Create a new database.
 client.createDB("alice");
@@ -141,7 +141,7 @@ If you run this example, you will see:
 - [Server Functions](#server-functions)
 	- [CloudantClient.createDB(name)](#comcloudantclientapicloudantclientcreatedbname)
 	- [CloudantClient.database(name, create)](#comcloudantclientapicloudantclientdatabasenamecreate)
-	- [CloudantClient.deleteDB(name, confirmDelete)](#comcloudantclientapicloudantclientdeletedbnameconfirmdelete)
+	- [CloudantClient.deleteDB(name)](#comcloudantclientapicloudantclientdeletedbname)
 	- [CloudantClient.getAllDbs()](#comcloudantclientapicloudantclientgetalldbs)
 	- [CloudantClient.getMembership()](#comcloudantclientapicloudantclientgetmembership)
 	- [CloudantClient.getActiveTasks()](#comcloudantclientapicloudantclientgetactivetasks)
@@ -275,12 +275,12 @@ System.out.println("Database Name:" + db.info().getDbName() );
 
 ~~~
 
-### com.cloudant.client.api.CloudantClient.deleteDB(name,confirmDelete)
+### com.cloudant.client.api.CloudantClient.deleteDB(name)
 
 Destroy database named `name`.
 
 ~~~ java
-client.deleteDB("alice","delete database");
+client.deleteDB("alice");
 
 ~~~
 

--- a/src/main/java/com/cloudant/client/api/CloudantClient.java
+++ b/src/main/java/com/cloudant/client/api/CloudantClient.java
@@ -227,9 +227,19 @@ public class CloudantClient {
 	 * Request to  delete a database.
 	 * @param dbName The database name
 	 * @param confirm A confirmation string with the value: <tt>delete database</tt>
+	 * @deprecated use {@link CloudantClient#deleteDB(String)}
 	 */
+	@Deprecated
 	public void deleteDB(String dbName, String confirm) {
 		client.deleteDB(dbName, confirm);
+	}
+
+	/**
+	 * Request to  delete a database.
+	 * @param dbName The database name
+	 */
+	public void deleteDB(String dbName){
+		client.deleteDB(dbName);
 	}
 
 

--- a/src/main/java/org/lightcouch/CouchDbClientBase.java
+++ b/src/main/java/org/lightcouch/CouchDbClientBase.java
@@ -194,14 +194,22 @@ public abstract class CouchDbClientBase {
 		 * Requests CouchDB deletes a database.
 		 * @param dbName The database name
 		 * @param confirm A confirmation string with the value: <tt>delete database</tt>
+		 * @Deprecated Use {@link CouchDbClientBase#deleteDB(String)}
 		 */
+		@Deprecated
 		public void deleteDB(String dbName, String confirm) {
-			assertNotEmpty(dbName, "dbName");
 			if(!"delete database".equals(confirm))
 				throw new IllegalArgumentException("Invalid confirm!");
+			deleteDB(dbName);
+		}
+
+		/**
+		 * Requests CouchDB deletes a database.
+		 * @param dbName The database name
+		 */
+	    public void deleteDB(String dbName){
+			assertNotEmpty(dbName, "dbName");
 			delete(buildUri(getBaseUri()).path(dbName).build());
-			
-			
 		}
 
 		/**

--- a/src/test/java/com/cloudant/tests/AttachmentsTest.java
+++ b/src/test/java/com/cloudant/tests/AttachmentsTest.java
@@ -49,7 +49,7 @@ public class AttachmentsTest  {
 
 	@After
 	public void tearDown(){
-		account.deleteDB("lightcouch-db-test", "delete database");
+		account.deleteDB("lightcouch-db-test");
 		account.shutdown();
 	}
 

--- a/src/test/java/com/cloudant/tests/BulkDocumentTest.java
+++ b/src/test/java/com/cloudant/tests/BulkDocumentTest.java
@@ -49,7 +49,7 @@ public class BulkDocumentTest{
 
 	@After
 	public void tearDown(){
-		account.deleteDB("lightcouch-db-test", "delete database");
+		account.deleteDB("lightcouch-db-test");
 		account.shutdown();
 	}
 

--- a/src/test/java/com/cloudant/tests/ChangeNotificationsTest.java
+++ b/src/test/java/com/cloudant/tests/ChangeNotificationsTest.java
@@ -54,7 +54,7 @@ public class ChangeNotificationsTest {
 
 	@After
 	public void tearDown(){
-		account.deleteDB("lightcouch-db-test", "delete database");
+		account.deleteDB("lightcouch-db-test");
 		account.shutdown();
 	}
 

--- a/src/test/java/com/cloudant/tests/DBServerTest.java
+++ b/src/test/java/com/cloudant/tests/DBServerTest.java
@@ -48,7 +48,7 @@ public class DBServerTest {
 
 	@After
 	public void tearDown(){
-		account.deleteDB("lightcouch-db-test", "delete database");
+		account.deleteDB("lightcouch-db-test");
 		account.shutdown();
 	}
 

--- a/src/test/java/com/cloudant/tests/DatabaseTest.java
+++ b/src/test/java/com/cloudant/tests/DatabaseTest.java
@@ -43,7 +43,7 @@ public class DatabaseTest {
 
 	@After
 	public  void tearDown() {
-		account.deleteDB("animaldb", "delete database");
+		account.deleteDB("animaldb");
 		account.shutdown();
 	}
 	

--- a/src/test/java/com/cloudant/tests/DesignDocumentsTest.java
+++ b/src/test/java/com/cloudant/tests/DesignDocumentsTest.java
@@ -44,7 +44,7 @@ public class DesignDocumentsTest {
 
 	@After
 	public void tearDown(){
-		account.deleteDB("lightcouch-db-test", "delete database");
+		account.deleteDB("lightcouch-db-test");
 		account.shutdown();
 	}
 

--- a/src/test/java/com/cloudant/tests/DocumentsCRUDTest.java
+++ b/src/test/java/com/cloudant/tests/DocumentsCRUDTest.java
@@ -56,7 +56,7 @@ public class DocumentsCRUDTest {
 
 	@After
 	public void tearDown(){
-		account.deleteDB("lightcouch-db-test", "delete database");
+		account.deleteDB("lightcouch-db-test");
 		account.shutdown();
 	}
 

--- a/src/test/java/com/cloudant/tests/IndexTests.java
+++ b/src/test/java/com/cloudant/tests/IndexTests.java
@@ -45,7 +45,7 @@ public class IndexTests {
 
 	@After
 	public  void tearDown() {
-		account.deleteDB("movies-demo", "delete database");
+		account.deleteDB("movies-demo");
 		account.shutdown();
 	}
 	

--- a/src/test/java/com/cloudant/tests/ReplicationTest.java
+++ b/src/test/java/com/cloudant/tests/ReplicationTest.java
@@ -75,8 +75,8 @@ public class ReplicationTest {
 
 	@After
 	public void tearDown(){
-		account.deleteDB("lightcouch-db-test","delete database");
-		account.deleteDB("lightcouch-db-test-2","delete database");
+		account.deleteDB("lightcouch-db-test");
+		account.deleteDB("lightcouch-db-test-2");
 		account.shutdown();
 	}
 

--- a/src/test/java/com/cloudant/tests/ReplicatorTest.java
+++ b/src/test/java/com/cloudant/tests/ReplicatorTest.java
@@ -53,8 +53,8 @@ public class ReplicatorTest {
 
 	@After
 	public void tearDown(){
-		account.deleteDB("lightcouch-db-test", "delete database");
-		account.deleteDB("lightcouch-db-test-2", "delete database");
+		account.deleteDB("lightcouch-db-test");
+		account.deleteDB("lightcouch-db-test-2");
 		account.shutdown();
 	}
 

--- a/src/test/java/com/cloudant/tests/SearchTests.java
+++ b/src/test/java/com/cloudant/tests/SearchTests.java
@@ -52,7 +52,7 @@ public class SearchTests {
 
 	@After
 	public  void tearDown() {
-		account.deleteDB("animaldb", "delete database");
+		account.deleteDB("animaldb");
 		account.shutdown();
 	}
 	

--- a/src/test/java/com/cloudant/tests/UnicodeTest.java
+++ b/src/test/java/com/cloudant/tests/UnicodeTest.java
@@ -66,7 +66,7 @@ public class UnicodeTest {
 	
 	@After
 	public void tearDown() {
-		account.deleteDB(DB_NAME, "delete database");
+		account.deleteDB(DB_NAME);
 		account.shutdown();
 	}
 

--- a/src/test/java/com/cloudant/tests/UpdateHandlerTest.java
+++ b/src/test/java/com/cloudant/tests/UpdateHandlerTest.java
@@ -44,7 +44,7 @@ public class UpdateHandlerTest {
 
 	@After
 	public void tearDown(){
-		account.deleteDB("lightcouch-db-test", "delete database");
+		account.deleteDB("lightcouch-db-test");
 		account.shutdown();
 	}
 

--- a/src/test/java/com/cloudant/tests/ViewsTest.java
+++ b/src/test/java/com/cloudant/tests/ViewsTest.java
@@ -59,7 +59,7 @@ public class ViewsTest {
 
 	@After
 	public void tearDown(){
-		account.deleteDB("lightcouch-db-test", "delete database");
+		account.deleteDB("lightcouch-db-test");
 		account.shutdown();
 	}
 


### PR DESCRIPTION
## What
Create new Database api and deprecate the previous one.

## Why
A string confirming the operation to delete the database is needless, in the context that it is being used.

## How
Create `deleteDB(String dbName)`API in `CloudantClient` and `CouchClientBase` classes.
Deprecate `deleteDB(String dbName, String confirm)` in `CloudantClient` and `CouchClientBase`

reviewer @tomblench 
reviewer @brynh  
