### PR TITLE
47056 query previous page with descending view

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,12 +6,13 @@
   `setSSLAuthenticationDisabled(true)` can be called on the `ConnectOptions`
   object before you pass it to the `CloudantClient` constructor.
 - [NEW] New API for deleting databases, `CloudantClient.deleteDB(String name)`
-- [Deprecated] Deprecated `CloudantClient.deleteDB(String name, String confirm)`
-  API.
+- [FIX] Fixed querying of next/previous page in a descending view.
 - [FIX] Fixed handling of non-ASCII characters when the platform's
   default charset is not UTF-8.
 - [FIX] Fixed encoding of `+`, `=` and `&` characters when they are used
   in the query part of a URL.
+- [Deprecated] Deprecated `CloudantClient.deleteDB(String name, String confirm)`
+  API.
 
 # 1.0.1 (2015-02-04)
 

--- a/src/main/java/org/lightcouch/Params.java
+++ b/src/main/java/org/lightcouch/Params.java
@@ -92,4 +92,25 @@ public class Params {
     public void addAll(Params params) {
         this.params.addAll(params.params);
     }
+
+    /**
+     * If this object already contains a parameter whose name matches {@code name}, replace the
+     * existing value with {@code value} for the first instance of parameter {@code name}.
+     * Otherwise, add a parameter with the new {@code name} and {@code value}.
+     * @param name The name of the parameter to replace/add.
+     * @param value The new value of the parameter.
+     */
+    public void replaceOrAdd(String name, String value) {
+        boolean found = false;
+        for (Param param : params) {
+            if (param.getKey().equals(name)) {
+                param.setValue(value);
+                found = true;
+                break;
+            }
+        }
+        if (!found) {
+            addParam(name, value);
+        }
+    }
 }

--- a/src/main/java/org/lightcouch/internal/URIBuilder.java
+++ b/src/main/java/org/lightcouch/internal/URIBuilder.java
@@ -115,10 +115,37 @@ public class URIBuilder {
         return this;
     }
 
-    public URIBuilder query(String name, Object value) {
-        if (name != null && value != null)
-            this.qParams.addParam(name, value.toString());
+    /**
+     * Add the given {@code name} and {@code value} to the query parameters or replace
+     * the existing query parameter matching {@code name} with one with the new {@code value}.
+     * @param name The name of the parameter to add/replace.
+     * @param value The value of the parameter.
+     * @param replace set to true to replace the value of an existing query parameter matching
+     *               {@code name}, or false to add a new one. Note that if this is true and there
+     *               is no parameter matching {@code name}, the parameter will be added.
+     * @return The updated {@link URIBuilder} object.
+     */
+    public URIBuilder query(String name, Object value, boolean replace) {
+        if (name != null && value != null) {
+            if (replace) {
+                this.qParams.replaceOrAdd(name, value.toString());
+            } else {
+                this.qParams.addParam(name, value.toString());
+            }
+        }
         return this;
+
+    }
+
+    /**
+     * Add the given {@code name} and {@code value} to the query parameters.
+     * @param name The name to add.
+     * @param value The value to add.
+     * @return The updated {@link URIBuilder} object.
+     */
+    public URIBuilder query(String name, Object value) {
+        return query(name, value, false);
+
     }
 
     /** @deprecated Use {@link #query(String, Object)} instead. */


### PR DESCRIPTION
Fixes FB#47056

When using a descending view, `queryPreviousPage` didn't go to the previous page. Also, when calling `queryNextPage` after `queryPreviousPage`, the paging was incorrect.  This PR fixes these paging issues.

A new flag `pagingForwards` has been added to track changes in paging direction, so we know when the paging direction has changed.

`queryNextPage` and `queryPreviousPage` have been refactored to reduce code duplication as there were only minor differences between the methods.

*TESTING*
Tests have been added to verify the paging is correct in ascending and descending views, with multiple changes of direction of paging.

reviewer @mikerhodes
reviewer @rhyshort 