### PR TITLE
Added User-Agent to requests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'maven'
 
 group = 'com.cloudant'
 version = '1.0.2-SNAPSHOT'
-
+//note this description is used as the user agent name in the client properties
 description = """java-cloudant"""
 
 sourceCompatibility = 1.6
@@ -45,4 +45,45 @@ task cloudantTest(type: Test, dependsOn: testClasses) {
 
 task cloudantServiceTest(type: Test, dependsOn: testClasses) {
     // Run all tests
+}
+
+//task for generating a client properties file
+class ClientProperties extends DefaultTask {
+
+    //allow this to be configured, default to client.properties
+    File clientPropsPath = new File("client.properties")
+
+    //internal
+    private Properties p = new Properties()
+
+    ClientProperties() {
+        //if there is a generated file already load the values
+        if (clientPropsPath.exists()) {
+            p.load(new FileInputStream(clientPropsPath));
+        }
+    }
+
+    @TaskAction
+    def save() {
+        p.put("user.agent.name", project.description)
+        p.put("user.agent.version", project.version)
+        p.store(new FileOutputStream(clientPropsPath), "User agent information for this client")
+    }
+
+    String getPropertyValue(String key) {
+        return p.getProperty(key)
+    }
+}
+
+//generate a client props file, make the jar task depend on this
+task generateClientPropertiesFile(type: ClientProperties) {
+    clientPropsPath = new File(buildDir, "tmp/client.properties")
+    outputs.upToDateWhen {
+        project.description.equals(getPropertyValue("user.agent.name")) && project.version.equals(getPropertyValue("user.agent.version"))
+    }
+}
+jar.dependsOn generateClientPropertiesFile
+//include the client props in the built jar
+jar {
+    into "META-INF", { from generateClientPropertiesFile.clientPropsPath }
 }

--- a/src/test/java/com/cloudant/tests/util/SingleRequestHttpServer.java
+++ b/src/test/java/com/cloudant/tests/util/SingleRequestHttpServer.java
@@ -1,0 +1,129 @@
+package com.cloudant.tests.util;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.SocketException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.net.ServerSocketFactory;
+
+/**
+ * A very simple HTTP Server that runs on the localhost and can handle a single request.
+ */
+public class SingleRequestHttpServer implements Runnable {
+
+    private ServerSocket serverSocket;
+    private boolean finished;
+    private static final Logger log = Logger.getLogger(SingleRequestHttpServer.class.getName());
+    private static boolean localServerReady;
+    private static final Object lock = new Object();
+
+    private final List<String> input = new ArrayList<String>();
+    private final int port;
+
+    private SingleRequestHttpServer(int port) {
+        this.port = port;
+    }
+
+    public void run() {
+        try {
+            try {
+                serverSocket = ServerSocketFactory.getDefault().createServerSocket(port);
+            } catch (SocketException e) {
+                log.log(Level.SEVERE, "Unable to open server socket", e);
+                finished = true;
+            }
+
+            // Listening to the port
+            log.log(Level.FINE, "Server waiting for connections");
+            Socket socket;
+            synchronized (lock) {
+                localServerReady = true;
+                lock.notify();
+            }
+            socket = serverSocket.accept();
+            localServerReady = false;
+            log.log(Level.INFO, "Server accepted connection");
+
+            BufferedReader r = null;
+            r = new BufferedReader(new InputStreamReader(socket.getInputStream(),
+                    "UTF-8"));
+            String line;
+            while ((line = r.readLine()) != null && !line.isEmpty()) {
+                input.add(line);
+            }
+
+            // Just send a simple success response.
+            BufferedWriter w = new BufferedWriter(new OutputStreamWriter(socket
+                    .getOutputStream()));
+            w.write("HTTP/1.0 200 OK");
+            w.flush();
+            w.close();
+            socket.close();
+        } catch (SocketException e) {
+            log.log(Level.WARNING, "Socket closed", e);
+        } catch (Exception exception) {
+            log.log(Level.SEVERE, "Unexpected exception", exception);
+            finished = true;
+        } finally {
+            closeSocket();
+            log.info("Server stopped");
+        }
+    }
+
+    /**
+     * Get the request input
+     *
+     * @return Collection of Strings one per line of the request input
+     */
+    public Collection<String> getRequestInput() {
+        return input;
+    }
+
+    private synchronized void closeSocket() {
+        localServerReady = false;
+        if (serverSocket != null) {
+            try {
+                serverSocket.close();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+            serverSocket = null;
+        }
+    }
+
+    /**
+     * Block until the server is ready to accept connections
+     */
+    public void waitForServer() {
+        synchronized (lock) {
+            try {
+                while (!localServerReady) {
+                    lock.wait();
+                }
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    /**
+     * Start an HTTPServer instance on a new thread listening on the specified port
+     *
+     * @param port to listen on
+     */
+    public static SingleRequestHttpServer startServer(int port) {
+        SingleRequestHttpServer server = new SingleRequestHttpServer(port);
+        new Thread(server).start();
+        return server;
+    }
+}


### PR DESCRIPTION
*What*
Add a User-Agent header to requests of the form:
java-cloudant/1.0.2 [Java (amd64; Windows 7; 6.1) Oracle Corporation; 1.8.0_45; 1.8.0_45-b14]

*How*
* Generate a client.properties file as part of the build containing the agent name and version
* At runtime read the client.properties and combine with JVM system properties
* Add the string to the client request headers

*Testing*
Added a test that validates the code is generating strings of the expected format

reviewer @emlaver 
reviewer @mikerhodes