### PR TITLE
View's queryPage doesn't seem to handle multi-value values

### DIFF
--- a/src/test/java/com/cloudant/tests/Foo.java
+++ b/src/test/java/com/cloudant/tests/Foo.java
@@ -1,5 +1,7 @@
 package com.cloudant.tests;
 
+import com.google.gson.JsonArray;
+
 import org.lightcouch.Attachment;
 
 import java.util.Arrays;
@@ -18,6 +20,7 @@ public class Foo {
 
     private String title;
     private String content;
+    private JsonArray contentArray;
     private int position;
     private List<String> tags;
     private int[] complexDate;
@@ -53,6 +56,10 @@ public class Foo {
 
     public String getContent() {
         return content;
+    }
+
+    public JsonArray getContentArray() {
+        return contentArray;
     }
 
     public int getPosition() {
@@ -97,6 +104,10 @@ public class Foo {
 
     public void setContent(String content) {
         this.content = content;
+    }
+
+    public void setContentArray(JsonArray content) {
+        this.contentArray = content;
     }
 
     public void setPosition(int position) {

--- a/src/test/resources/design-docs/example/views/boolean/map.js
+++ b/src/test/resources/design-docs/example/views/boolean/map.js
@@ -1,0 +1,3 @@
+function(doc) {
+  emit(doc.contentArray[0].boolean, null);
+}

--- a/src/test/resources/design-docs/example/views/boolean_creator_created/map.js
+++ b/src/test/resources/design-docs/example/views/boolean_creator_created/map.js
@@ -1,0 +1,4 @@
+function(doc) {
+  emit([doc.contentArray[0].boolean, doc.contentArray[0].creator,
+   doc.contentArray[0].created], null);
+}

--- a/src/test/resources/design-docs/example/views/created/map.js
+++ b/src/test/resources/design-docs/example/views/created/map.js
@@ -1,0 +1,3 @@
+function(doc) {
+ emit([doc.contentArray[0].created, doc.contentArray[0].created]);
+}

--- a/src/test/resources/design-docs/example/views/created_boolean_creator/map.js
+++ b/src/test/resources/design-docs/example/views/created_boolean_creator/map.js
@@ -1,0 +1,4 @@
+function(doc) {
+  emit([doc.contentArray[0].created, doc.contentArray[0].boolean,
+   doc.contentArray[0].creator], null);
+}

--- a/src/test/resources/design-docs/example/views/created_total/map.js
+++ b/src/test/resources/design-docs/example/views/created_total/map.js
@@ -1,0 +1,3 @@
+function(doc) {
+ emit([doc.contentArray[0].created, doc.contentArray[0].total], null);
+}

--- a/src/test/resources/design-docs/example/views/creator_boolean_total/map.js
+++ b/src/test/resources/design-docs/example/views/creator_boolean_total/map.js
@@ -1,0 +1,4 @@
+function(doc) {
+ emit([doc.contentArray[0].creator, doc.contentArray[0].boolean,
+ doc.contentArray[0].created], null);
+}

--- a/src/test/resources/design-docs/example/views/creator_created/map.js
+++ b/src/test/resources/design-docs/example/views/creator_created/map.js
@@ -1,0 +1,3 @@
+function(doc) {
+ emit([doc.contentArray[0].creator, doc.contentArray[0].created], null);
+}

--- a/src/test/resources/design-docs/example/views/doc_title/map.js
+++ b/src/test/resources/design-docs/example/views/doc_title/map.js
@@ -1,0 +1,5 @@
+function(doc){
+  if(doc.Type == 'Foo' && doc.title){
+    emit([doc.title, doc.contentArray[0].boolean], null);
+  }
+}

--- a/src/test/resources/design-docs/example/views/quotes_created/map.js
+++ b/src/test/resources/design-docs/example/views/quotes_created/map.js
@@ -1,0 +1,3 @@
+function(doc) {
+ emit([doc.contentArray[0].quotes, doc.contentArray[0].created], null);
+}

--- a/src/test/resources/design-docs/example/views/spaces_created/map.js
+++ b/src/test/resources/design-docs/example/views/spaces_created/map.js
@@ -1,0 +1,3 @@
+function(doc) {
+ emit([doc.contentArray[0].spaces, doc.contentArray[0].created], null);
+}

--- a/src/test/resources/design-docs/example/views/total_created/map.js
+++ b/src/test/resources/design-docs/example/views/total_created/map.js
@@ -1,0 +1,3 @@
+function(doc) {
+ emit([doc.contentArray[0].total, doc.contentArray[0].created], null);
+}


### PR DESCRIPTION
*What:*
View’s queryPage doesn’t seem to handle multi-value values (FB 48355)
The queryPage method doesn’t handle views that emit keys such as [“uuid”, 100].

#39 DB view key varargs needs parameter typing (FB 48532)
The key, start key, and end key methods are not able to handle complex keys.  One example is a complex key with multiple integer values i.e. key(2011 10, 15).

*How:*
The queryView method in View’s queryPage had a hard cast of String.  This would cause an exception if an integer value existed in a key from the result rows. To fix this:
The String parameter was changed to Object class to allow for other data types. 
If the key in the result rows is an array of multiple values (i.e. startkey=[“uuid”,100]), the array will be converted into one string and then be added as a property for the page parameters.

View’s query had a similar problem where multiple number value keys were not property handled when building the URI.  During testing, if a string and integer value existed in a key array, then the URI would be properly created. If the key only contained an array of numbers, then it would throw an exception. 
The fix required a statement in getKeyAsJson to check whether the multi value key array was exactly one value and an instance of the Number class.

*Testing:*
An existing test case under ViewsTest (byComplexKey) was modified to use the new multi value change.
New test cases were added to ViewsTest:
Assert that result list is not empty using multi value keys in both View’s query and queryPage method.
Run tests with multi value key arrays from one to three values

reviewer @ricellis 
reviewer @mikerhodes 