### PR TITLE
Added options for additional debug information

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,9 @@ dependencies {
     testCompile group: 'junit', name: 'junit', version: '4.8.2'
 }
 
+//include variable debug info in the compiled classes
+compileJava.options.debugOptions.debugLevel = "source,lines,vars"
+
 tasks.withType(Test) {
     // pick up properties named test.* from command line, gradle.properties first
     System.properties.each { prop ->


### PR DESCRIPTION
*What*
Added debug options to the java compilation

*Why*
Improve the debug experience; fixes #52 

*How*
Added gradle compileJava debug options

*Testing*
Validated that additional debug information is present in compiled jars

reviewer @rhyshort 
reviewer @emlaver 