### PR TITLE
49843 cloudant tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,3 +120,4 @@ $ ./gradlew cloudantServiceTest
 ```
 
 Note: you will need a Cloudant account to run tests against the Cloudant service.
+Additionally the ReplicatorTest cases require the `_replicator` DB to exist.

--- a/src/test/java/com/cloudant/tests/IndexTests.java
+++ b/src/test/java/com/cloudant/tests/IndexTests.java
@@ -37,7 +37,7 @@ public class IndexTests {
         com.cloudant.client.api.Replication r = account.replication();
         r.source("https://examples.cloudant.com/movies-demo");
         r.createTarget(true);
-        r.target("https://" + CloudantClientHelper.SERVER_URI.toString() + "/movies-demo");
+        r.target(CloudantClientHelper.SERVER_URI.toString() + "/movies-demo");
         r.trigger();
         db = account.database("movies-demo", false);
 


### PR DESCRIPTION
*What*
Fixed Replicator and Index tests that were failing against the Cloudant service.

*How*
Remove extraneous prefix from IndexTest
Update documentation to make it clear that the _replicator DB must exist.

*Testing*
Fixes apply to existing tests.

reviewer @rhyshort 
