### PR TITLE
Added support for use_index option

### DIFF
--- a/src/main/java/com/cloudant/client/api/Database.java
+++ b/src/main/java/com/cloudant/client/api/Database.java
@@ -907,6 +907,11 @@ public class Database {
                     .append("\"r\": ")
                     .append(options.getReadQuorum());
         }
+        if (options.getUseIndex() != null) {
+            finalbody.append(",")
+                    .append("\"use_index\": ")
+                    .append(options.getUseIndex());
+        }
         finalbody.append("}");
 
         return finalbody.toString();

--- a/src/main/java/com/cloudant/client/api/model/FindByIndexOptions.java
+++ b/src/main/java/com/cloudant/client/api/model/FindByIndexOptions.java
@@ -32,6 +32,7 @@ public class FindByIndexOptions {
     private List<IndexField> sort = new ArrayList<IndexField>();
     private List<String> fields = new ArrayList<String>();
     private Integer readQuorum;
+    private String useIndex = null;
 
     /**
      * @param limit limit the number of results return
@@ -78,6 +79,27 @@ public class FindByIndexOptions {
         return this;
     }
 
+    /**
+     * Specify a specific index to run the query against
+     *
+     * @param designDocument set the design document to use
+     */
+    public FindByIndexOptions useIndex(String designDocument) {
+        this.useIndex = "\"" + designDocument + "\"";
+        return this;
+    }
+
+    /**
+     * Specify a specific index to run the query against
+     *
+     * @param designDocument set the design document to use
+     * @param indexName set the index name to use
+     */
+    public FindByIndexOptions useIndex(String designDocument, String indexName) {
+        this.useIndex = "[\"" + designDocument + "\",\"" + indexName + "\"]";
+        return this;
+    }
+
     public List<String> getFields() {
         return fields;
     }
@@ -96,6 +118,10 @@ public class FindByIndexOptions {
 
     public Integer getReadQuorum() {
         return readQuorum;
+    }
+
+    public String getUseIndex() {
+        return useIndex;
     }
 
 }

--- a/src/test/java/com/cloudant/tests/IndexTests.java
+++ b/src/test/java/com/cloudant/tests/IndexTests.java
@@ -127,6 +127,35 @@ public class IndexTests {
             assertNotNull(m.getMovie_year());
         }
 
+        //check find by using index design doc
+        db.findByIndex(new GsonBuilder().create().toJson(selector), Movie.class, new
+                FindByIndexOptions().sort(new IndexField("Movie_year", SortOrder.desc))
+                .fields("Movie_name").fields("Movie_year")
+                .limit(1)
+                .skip(1)
+                .readQuorum(2).useIndex("Movie_year"));
+        assertNotNull(movies);
+        assert (movies.size() == 1);
+        for (Movie m : movies) {
+            assertNotNull(m.getMovie_name());
+            assertNotNull(m.getMovie_year());
+        }
+
+        //check find by using index design doc and index name
+        db.findByIndex(new GsonBuilder().create().toJson(selector), Movie.class, new
+                FindByIndexOptions().sort(new IndexField("Movie_year", SortOrder.desc))
+                .fields("Movie_name").fields("Movie_year")
+                .limit(1)
+                .skip(1)
+                .readQuorum(2).useIndex("Movie_year", "Movie_year"));
+        assertNotNull(movies);
+        assert (movies.size() == 1);
+        for (Movie m : movies) {
+            assertNotNull(m.getMovie_name());
+            assertNotNull(m.getMovie_year());
+        }
+
+
         db.deleteIndex("Person_name", "Person_name");
         db.deleteIndex("Movie_year", "Movie_year");
     }


### PR DESCRIPTION
*What*
Add support for the Cloudant Query use_index option.

*How*
Add new getters/setters to FindByIndexOptions and append new option to body of `/db/_find` request

*Testing*
Added use of new options in IndexTests.indexTestsAll()

reviewer @rhyshort 
reviewer @emlaver 