### PR TITLE
Defaulted max connections to 6

### DIFF
--- a/src/main/java/org/lightcouch/CouchDbProperties.java
+++ b/src/main/java/org/lightcouch/CouchDbProperties.java
@@ -39,7 +39,8 @@ public class CouchDbProperties {
     // optional
     private int socketTimeout;
     private int connectionTimeout;
-    private int maxConnections;
+    //default to 6 connections
+    private int maxConnections = 6;
     private String proxyHost;
     private int proxyPort;
     private boolean disableSSLAuthentication;


### PR DESCRIPTION
*What*
Increased the default number of max connections to 6 (from 2).

*How*
Added a default value to CouchDbProperties. This makes more sense than adding it to ConnectOptions because that object is only used in non-default cases.

*Testing*
Code exercised by existing tests, no specific testing of the number of connections.

reviewer @rhyshort 