### PR TITLE
50101 remove db get

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+- [IMPROVED] Removed unconditional GET request when creating `Database` objects
+  This offered little protection to the developer while performing a hidden HTTP request.
+
 # 1.1.0 (2015-07-31)
 
 - [BREAKING CHANGE] Hostname verification and certificate chain

--- a/src/main/java/com/cloudant/client/api/CloudantClient.java
+++ b/src/main/java/com/cloudant/client/api/CloudantClient.java
@@ -278,7 +278,7 @@ public class CloudantClient {
      * Get a database
      *
      * @param name   name of database to access
-     * @param create flag indicating whether to create the database if doesnt exist.
+     * @param create flag indicating whether to create the database if it does not exist.
      * @return Database object
      */
     public Database database(String name, boolean create) {

--- a/src/main/java/com/cloudant/client/api/Database.java
+++ b/src/main/java/com/cloudant/client/api/Database.java
@@ -64,6 +64,8 @@ import java.util.Set;
 /**
  * Contains a Database Public API implementation.
  *
+ * Methods may throw a {@link NoDocumentException} if the database does not exist.
+ *
  * @author Mario Briggs
  * @since 0.0.1
  */

--- a/src/main/java/org/lightcouch/CouchDatabaseBase.java
+++ b/src/main/java/org/lightcouch/CouchDatabaseBase.java
@@ -62,7 +62,9 @@ public abstract class CouchDatabaseBase {
         this.dbName = name;
         this.client = client;
         this.dbURI = buildUri(client.getBaseUri()).path(name).path("/").build();
-        connect(create);
+        if (create) {
+            create();
+        }
         this.design = new CouchDbDesign(this);
     }
 
@@ -478,22 +480,17 @@ public abstract class CouchDatabaseBase {
     }
 
 
-    private void connect(boolean create) {
-
-        InputStream getresp = null;
+    private void create() {
         HttpResponse putresp = null;
-
         try {
-            getresp = get(dbURI);
-        } catch (NoDocumentException e) { // db doesn't exist
-            if (!create) {
-                throw e;
-            }
             final HttpPut put = new HttpPut(dbURI);
             putresp = client.executeRequest(put);
             log.info(String.format("Created Database: '%s'", dbName));
+        } catch (PreconditionFailedException e) {
+            // The PreconditionFailedException is thrown if the database already existed.
+            // To preserve the behaviour of the previous version, suppress this type of exception.
+            // All other CouchDbExceptions will be thrown.
         } finally {
-            close(getresp);
             close(putresp);
         }
     }

--- a/src/main/java/org/lightcouch/CouchDbClientBase.java
+++ b/src/main/java/org/lightcouch/CouchDbClientBase.java
@@ -485,6 +485,9 @@ public abstract class CouchDbClientBase {
             case HttpStatus.SC_CONFLICT: {
                 throw new DocumentConflictException(reason);
             }
+            case HttpStatus.SC_PRECONDITION_FAILED: {
+                throw new PreconditionFailedException(reason);
+            }
             default: { // other errors: 400 | 401 | 500 etc.
                 throw new CouchDbException(reason += EntityUtils.toString(response.getEntity()));
             }

--- a/src/main/java/org/lightcouch/PreconditionFailedException.java
+++ b/src/main/java/org/lightcouch/PreconditionFailedException.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2015 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package org.lightcouch;
+
+/**
+ * <P>
+ * CouchDbException class for HTTP 412 precondition failed status codes
+ * </P>
+ * <P>
+ * An example of when CouchDB will return a 412 status code is for a
+ * <a href="http://docs.couchdb.org/en/1.6.1/api/database/common.html#put--db">
+ * <code>PUT /{db}</code></a> when the DB already exists.
+ * </P>
+ */
+public class PreconditionFailedException extends CouchDbException {
+    public PreconditionFailedException(String message) {
+        super(message);
+    }
+
+    public PreconditionFailedException(Throwable cause) {
+        super(cause);
+    }
+
+    public PreconditionFailedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/test/java/com/cloudant/tests/CloudantClientTests.java
+++ b/src/test/java/com/cloudant/tests/CloudantClientTests.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import com.cloudant.client.api.CloudantClient;
+import com.cloudant.client.api.Database;
 import com.cloudant.client.api.model.ApiKey;
 import com.cloudant.client.api.model.Membership;
 import com.cloudant.client.api.model.Task;
@@ -22,6 +23,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.lightcouch.CouchDbClient;
 import org.lightcouch.CouchDbException;
+import org.lightcouch.NoDocumentException;
 
 import java.util.List;
 
@@ -156,6 +158,36 @@ public class CloudantClientTests {
                         ".version; jvm.runtime.version]\"",
                 userAgentHeaderMatchedExpectedForm);
 
+    }
+
+    /**
+     * Test a NoDocumentException is thrown when trying an operation on a DB that doesn't exist
+     */
+    @Test(expected = NoDocumentException.class)
+    @Category(RequiresDB.class)
+    public void nonExistentDatabaseException() {
+        //try and get a DB that doesn't exist
+        Database db = cookieBasedClient.database("not_really_there", false);
+        //try an operation against the non-existant DB
+        db.info();
+    }
+
+    /**
+     * Validate that no exception bubbles up when trying to create a DB that already exists
+     */
+    @Test
+    @Category(RequiresDB.class)
+    public void existingDatabaseCreateException() {
+        try {
+            //create a DB for this test
+            cookieBasedClient.createDB("existing");
+
+            //do a get with create true for the already existing DB
+            cookieBasedClient.database("existing", true);
+        } finally {
+            //clean up the DB created by this test
+            cookieBasedClient.deleteDB("existing");
+        }
     }
 
 }

--- a/src/test/java/com/cloudant/tests/CloudantClientTests.java
+++ b/src/test/java/com/cloudant/tests/CloudantClientTests.java
@@ -113,8 +113,6 @@ public class CloudantClientTests {
 
     /**
      * Assert that the User-Agent header is of the expected form.
-     * It would be nice to test that the header is actually added to requests, but we can't
-     * assert that without making assumptions about the underlying client or asserting server-side.
      */
     @Test
     public void testUserAgentHeaderString() {
@@ -124,6 +122,10 @@ public class CloudantClientTests {
                 (userAgentRegex));
     }
 
+    /**
+     * Assert that requests have the User-Agent header added. This test runs a local HTTP server
+     * process that can handle a single request to receive the request and validate the header.
+     */
     @Test
     public void testUserAgentHeaderIsAddedToRequest() {
 
@@ -155,4 +157,5 @@ public class CloudantClientTests {
                 userAgentHeaderMatchedExpectedForm);
 
     }
+
 }


### PR DESCRIPTION
*What*
Remove the `GET` calls to a database as part of the instantiation of `Database` objects

*Why*
Some users repeatedly instantiate `Database` objects. The repeated `GET` calls reduce performance, but offer little benefit. Whilst doing the `GET` does validate that the backing DB exists, the DB could easily be deleted between the object instantiation and any subsequent calls anyway. As such it makes more sense to remove the call to `GET` and allow the `NoDocumentException` to be thrown when calls are made against a `Database` object for which the backing DB has been removed or does not exist, rather than at object instantiation time.

*How*
* Remove the dbUri `GET` calls from the `connect()` method
* Refactor `CouchDatabaseBase` to rename `connect()` to `create()` and call it only when `create=true`
* Wrap 412 responses from create `PUT` calls in a subclass of `CouchDbException` so that `create=true` behaviour remains consistent with the current behaviour, but without the need for the initial `GET` call to check DB existence.

*Testing*
* Added new tests for exception cases
    1. request against non-existent DB
    2. trying to create a DB that already exists
* Calls to `client.database(...)` are repeatedly exercised throughout existing tests

reviewer @rhyshort 
reviewer @tomblench 