### PR TITLE
50264 queryPage throws an exception for Views that emit value as JSON

### DIFF
--- a/src/main/java/org/lightcouch/View.java
+++ b/src/main/java/org/lightcouch/View.java
@@ -362,8 +362,8 @@ public class View {
         final Page<T> page = new Page<T>();
         final List<T> pageList = new ArrayList<T>();
 
-        final ViewResult<JsonElement, String, T> vr = queryView(JsonElement.class, String.class, classOfT);
-        final List<ViewResult<JsonElement, String, T>.Rows> rows = vr.getRows();
+        final ViewResult<JsonElement, JsonElement, T> vr = queryView(JsonElement.class, JsonElement.class, classOfT);
+        final List<ViewResult<JsonElement, JsonElement, T>.Rows> rows = vr.getRows();
         final int resultRows = rows.size();
         final int offset = vr.getOffset();
         final long totalRows = vr.getTotalRows();

--- a/src/test/resources/design-docs/example/views/boolean_creator_created/map.js
+++ b/src/test/resources/design-docs/example/views/boolean_creator_created/map.js
@@ -1,4 +1,4 @@
 function(doc) {
   emit([doc.contentArray[0].boolean, doc.contentArray[0].creator,
-   doc.contentArray[0].created], null);
+  doc.contentArray[0].created], doc);
 }

--- a/src/test/resources/design-docs/example/views/created_boolean_creator/map.js
+++ b/src/test/resources/design-docs/example/views/created_boolean_creator/map.js
@@ -1,4 +1,4 @@
 function(doc) {
   emit([doc.contentArray[0].created, doc.contentArray[0].boolean,
-   doc.contentArray[0].creator], null);
+   doc.contentArray[0].creator], [doc]);
 }

--- a/src/test/resources/design-docs/example/views/creator_boolean_total/map.js
+++ b/src/test/resources/design-docs/example/views/creator_boolean_total/map.js
@@ -1,4 +1,4 @@
 function(doc) {
  emit([doc.contentArray[0].creator, doc.contentArray[0].boolean,
- doc.contentArray[0].created], null);
+ doc.contentArray[0].created], [doc.title, doc.contentArray[0].total]);
 }


### PR DESCRIPTION
*What*:
The queryPage functionality throws an exception for map functions containing a JSON array or JSON object emitted value.

*How*:
In the View class, the method JsonToObject is called to convert the JSON element for value to the specified Java object class type.  The specified class type for value is always String as seen below where the ViewResult is initialized and calls queryPage (line 365 of org.lightcouch.View class):

```
final ViewResult<JsonElement, String, T> vr = queryView(JsonElement.class, String.class, classOfT);
```

This means that the JsonToObject method will always try and convert the Row's value to a String object. And, in the case of emitted values that are JSON objects or arrays, an exception of either "Expected String but was JSON_ARRAY” or "Expected String but was JSON_OBJECT” is thrown.

To fix this, the value passed in to queryView as a String is changed to JsonElement.  This way, string manipulation or toString will not be used. Also, gson.toJson is used to guarantee that we are sending valid JSON elements through the query functionality (including building the URL).

*Testing*:
Map functions under resources/example/views were changed to have an emit value as a JSON array and a JSON object.  These maps are queried in test cases to assert that the result list is not empty and no exception is thrown.

reviewer @ricellis 
reviewer @mikerhodes 