### PR TITLE
Made URIBuilder query replace existing parameters

### DIFF
--- a/src/main/java/org/lightcouch/internal/URIBuilder.java
+++ b/src/main/java/org/lightcouch/internal/URIBuilder.java
@@ -147,7 +147,7 @@ public class URIBuilder {
      * @return The updated {@link URIBuilder} object.
      */
     public URIBuilder query(String name, Object value) {
-        return query(name, value, false);
+        return query(name, value, true);
 
     }
 


### PR DESCRIPTION
*What*
Replace rather than append existing parameters when using the `URIBuilder.query(String name, Object value)` method 

*How*
Call `true` not `false` for the replace argument.

*Testing*
All existing tests continue to pass.

reviewer @brynh 
