### PR TITLE
Handle doc:null in Search and View's query results

### DIFF
--- a/src/main/java/org/lightcouch/View.java
+++ b/src/main/java/org/lightcouch/View.java
@@ -156,10 +156,12 @@ public class View {
             List<T> list = new ArrayList<T>();
             for (JsonElement jsonElem : jsonArray) {
                 JsonElement elem = jsonElem.getAsJsonObject();
+                T t = null;
                 if (Boolean.TRUE.equals(this.includeDocs)) {
-                    elem = jsonElem.getAsJsonObject().get("doc");
+                    t = JsonToObject(gson, elem, "doc", classOfT);
+                } else {
+                    t = this.gson.fromJson(elem, classOfT);
                 }
-                T t = this.gson.fromJson(elem, classOfT);
                 list.add(t);
             }
             return list;

--- a/src/main/java/org/lightcouch/internal/CouchDbUtil.java
+++ b/src/main/java/org/lightcouch/internal/CouchDbUtil.java
@@ -87,7 +87,16 @@ final public class CouchDbUtil {
     // JSON
 
     public static <T> T JsonToObject(Gson gson, JsonElement elem, String key, Class<T> classType) {
-        return gson.fromJson(elem.getAsJsonObject().get(key), classType);
+        if(elem != null && !elem.isJsonNull()) {
+            JsonElement keyElem = elem.getAsJsonObject().get(key);
+            if(keyElem != null && !keyElem.isJsonNull()) {
+                return gson.fromJson(elem.getAsJsonObject().get(key), classType);
+            } else {
+                return null;
+            }
+        } else {
+            return null;
+        }
     }
 
     /**

--- a/src/test/java/com/cloudant/tests/CouchDbUtilTest.java
+++ b/src/test/java/com/cloudant/tests/CouchDbUtilTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2015 IBM Corp. All rights reserved.
+ * Copyright 2002-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.cloudant.tests;
+
+
+import static org.junit.Assert.assertEquals;
+import static org.lightcouch.internal.CouchDbUtil.JsonToObject;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+import org.junit.Test;
+
+public class CouchDbUtilTest {
+
+    /**
+     * Assert that if doc's value in JSON object
+     * is null, the result from JsonToObject
+     * will be null and no exception occurs.
+     */
+    @Test
+    public void mockQueryResultWithNullDocValue() {
+        String queryResult = "{\"doc\":null}";
+
+        Gson gson = new Gson();
+        JsonObject jsonFromSearchQuery = new JsonParser()
+                .parse(queryResult).getAsJsonObject();
+        JsonObject mockResult = JsonToObject(gson, jsonFromSearchQuery, "doc", JsonObject.class);
+
+        assertEquals(null, mockResult);
+    }
+}

--- a/src/test/java/com/cloudant/tests/SearchTests.java
+++ b/src/test/java/com/cloudant/tests/SearchTests.java
@@ -2,6 +2,7 @@ package com.cloudant.tests;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.lightcouch.internal.CouchDbUtil.JsonToObject;
 
 import com.cloudant.client.api.CloudantClient;
 import com.cloudant.client.api.Database;
@@ -10,6 +11,9 @@ import com.cloudant.client.api.model.DesignDocument;
 import com.cloudant.client.api.model.SearchResult;
 import com.cloudant.client.api.model.SearchResult.SearchResultRows;
 import com.cloudant.test.main.RequiresCloudant;
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -136,7 +140,6 @@ public class SearchTests {
         assertEquals(rslt.getRanges().get("min_length").get("large"), new Long(2));
 
     }
-
 
     @Test
     public void sortTest() {


### PR DESCRIPTION
*What*
The java-cloudant library appears to be exploding because it's having a problem de-serialising results of a search query with include_docs=true where one of the values for the "doc" field appears to be null.

*How*
Add logic to catch null values in JsonToObject method.  If the value of the doc is null, return null.

*Tests*
Cases added in SearchTests and ViewsTest.
Assert that the results contain the doc' null value and no ClassCastException occurs.

FogBugz: 50044

reviewer @ricellis 
reviewer @mikerhodes 