### PR TITLE
ReplicationTest improvements

### DIFF
--- a/src/test/java/com/cloudant/tests/ReplicatorTest.java
+++ b/src/test/java/com/cloudant/tests/ReplicatorTest.java
@@ -145,11 +145,11 @@ public class ReplicatorTest {
         // we need the replication to finish before continuing
         Utils.waitForReplicatorToComplete(account, response.getId());
 
-        foodb2 = db2.find(Foo.class, docId);
+        foodb2 = Utils.findDocumentWithRetries(db2, docId, Foo.class, 20);
         foodb2.setTitle("titleY");
         db2.update(foodb2);
 
-        foodb1 = db1.find(Foo.class, docId);
+        foodb1 = Utils.findDocumentWithRetries(db1, docId, Foo.class, 20);
         foodb1.setTitle("titleZ");
         db1.update(foodb1);
 


### PR DESCRIPTION
*What*
Improve the `ReplicationTest` and `ReplicatorTest`

*Why*
There are two problems with these tests:

1. The test `com.cloudant.tests.ReplicationTest#replicatorDB` is incorrectly using a replicator document instead of triggering a replication. This is a duplication of the equivalent test method in `ReplicatorTest`.
2. The tests `com.cloudant.tests.Replicat*Test#replication_conflict` nearly always fails when running against the Cloudant service. When running against a cluster trying to instantly read back a document that was just saved may not be successful depending on which node the request gets routed to.

*How*
* Rename the `replicatorDB` test to `replicateDatabaseUsingReplicationTrigger` and change the content to use `replication` not `replicator` (which is already covered in the `ReplicatorTest` class)
* Improve resiliency of `replication_conflict` to eventual consistency by adding a `findDocumentWithRetries` to try again a few times to read back the document if it initially is not found.

*Testing*
These are test modifications that pass on a local CouchDB and against the Cloudant service.

reviewer @brynh 
reviewer @tomblench 