### PR TITLE
52506 all docs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,6 @@
 # Unreleased
+- [NEW] - Requests for the `_all_docs` endpoint are made via `Database#getAllDocsRequestBuilder()`
+  instead of using a view.
 - [NEW] - Introduced new view query API. More information is available in the javadoc,
   including usage and migration examples. Note the absence of an equivalent for `queryForStream()`.
   If you were using the `queryForStream()` method we would be interested in feedback about your use case.

--- a/README.md
+++ b/README.md
@@ -686,7 +686,7 @@ List all the doc IDs in the database.
 ~~~ java
 
 List<String> allDocIds = db.getAllDocsRequestBuilder().build()
-                          .getRepsonse().getKeys();
+                          .getRepsonse().getDocIds();
 
 ~~~
 

--- a/src/main/java/com/cloudant/client/api/Database.java
+++ b/src/main/java/com/cloudant/client/api/Database.java
@@ -25,7 +25,6 @@ import static com.cloudant.client.org.lightcouch.internal.CouchDbUtil.setEntity;
 import static com.cloudant.client.org.lightcouch.internal.URIBuilder.buildUri;
 
 import com.cloudant.client.api.model.DbInfo;
-import com.cloudant.client.api.model.Document;
 import com.cloudant.client.api.model.FindByIndexOptions;
 import com.cloudant.client.api.model.Index;
 import com.cloudant.client.api.model.IndexField;
@@ -36,6 +35,7 @@ import com.cloudant.client.api.model.Shard;
 import com.cloudant.client.api.views.AllDocsRequestBuilder;
 import com.cloudant.client.api.views.ViewRequestBuilder;
 import com.cloudant.client.internal.views.AllDocsRequestBuilderImpl;
+import com.cloudant.client.internal.views.AllDocsRequestResponse;
 import com.cloudant.client.internal.views.ViewQueryParameters;
 import com.cloudant.client.org.lightcouch.Changes;
 import com.cloudant.client.org.lightcouch.CouchDatabase;
@@ -408,7 +408,8 @@ public class Database {
      */
     public AllDocsRequestBuilder getAllDocsRequestBuilder() {
         return new AllDocsRequestBuilderImpl(new ViewQueryParameters<String,
-                        Document.Revision>(client, this, "", "", String.class, Document.Revision.class) {
+                AllDocsRequestResponse.Revision>(client, this, "", "", String.class,
+                AllDocsRequestResponse.Revision.class) {
             protected URIBuilder getViewURIBuilder() {
                 return URIBuilder.buildUri(db.getDBUri()).path("_all_docs");
             }

--- a/src/main/java/com/cloudant/client/api/model/Document.java
+++ b/src/main/java/com/cloudant/client/api/model/Document.java
@@ -29,21 +29,4 @@ public class Document extends com.cloudant.client.org.lightcouch.Document {
         super.addAttachment(name, attachment.getAttachement());
     }
 
-    /*
-     * Object representation of rev field from a JSON object.
-     * <P>
-     * A convenience to allow deserialization of _all_docs JSON revision object data.
-     * </P>
-     */
-    public static final class Revision {
-
-        private String rev;
-
-        /**
-         * @return the value of the document rev field
-         */
-        public String get() {
-            return rev;
-        }
-    }
 }

--- a/src/main/java/com/cloudant/client/api/views/AllDocsRequest.java
+++ b/src/main/java/com/cloudant/client/api/views/AllDocsRequest.java
@@ -14,32 +14,29 @@
 
 package com.cloudant.client.api.views;
 
+import java.io.IOException;
+
 /**
- * Interface for building an unpaginated _all_docs request.
- * <P>
- * Example usage:
- * </P>
- * <pre>
- * {@code
- *
- * AllDocsRequest allDocsRequest =
- * //get a request builder for the "_all_docs" endpoint
- * db.getAllDocsRequestBuilder()
- *
- *   //set any other required parameters e.g. doc id of "foo" or "bar"
- *   .keys("foo", "bar")
- *
- *   //build the request
- *   .build();
- * }
- * </pre>
+ * The AllDocsRequest is used for getting an AllDocsResponse
  */
-public interface AllDocsRequestBuilder extends RequestBuilder<AllDocsRequestBuilder>,
-        SettableViewParameters.Unpaginated<String, AllDocsRequestBuilder> {
+public interface AllDocsRequest {
 
     /**
-     * @return the built AllDocsRequest
+     * Performs the request and returns the response.
+     * <P>
+     * Example usage:
+     * </P>
+     * <pre>
+     * {@code
+     * AllDocsResponse response = db.getAllDocsRequestBuilder()
+     *                              .build()
+     *                              .getResponse();
+     * }
+     * </pre>
+     *
+     * @return the response object
+     * @throws IOException
      * @since 2.0.0
      */
-    AllDocsRequest build();
+    AllDocsResponse getResponse() throws IOException;
 }

--- a/src/main/java/com/cloudant/client/api/views/AllDocsResponse.java
+++ b/src/main/java/com/cloudant/client/api/views/AllDocsResponse.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2015 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.client.api.views;
+
+import com.cloudant.client.api.model.Document;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Encapsulates a response from an _all_docs request.
+ * <P>
+ * Provides methods to facilitate processing of the response.
+ * </P>
+ *
+ * @since 2.0.0
+ */
+public interface AllDocsResponse {
+
+    /**
+     * @return a list of Document objects from the _all_docs request
+     * @throws IllegalStateException if include_docs was {@code false}
+     * @since 2.0.0
+     */
+    List<Document> getDocs();
+
+    /**
+     * Gets a map of the document id and revision for each result in the _all_docs request.
+     *
+     * @return a map with an entry for each document, key of _id and value of _rev
+     * @since 2.0.0
+     */
+    Map<String, String> getIdsAndRevs();
+
+    /**
+     * Deserializes the included full content of result documents to a list of the specified type.
+     *
+     * @param docType the class type to deserialize the JSON document to
+     * @param <D>     the type of the document
+     * @return the deserialized document
+     * @throws IllegalStateException if include_docs was {@code false}
+     * @since 2.0.0
+     */
+    <D> List<D> getDocsAs(Class<D> docType);
+
+    /**
+     * @return a list of the document ids
+     */
+    List<String> getDocIds();
+
+}

--- a/src/main/java/com/cloudant/client/internal/views/AllDocsRequestBuilderImpl.java
+++ b/src/main/java/com/cloudant/client/internal/views/AllDocsRequestBuilderImpl.java
@@ -14,14 +14,15 @@
 
 package com.cloudant.client.internal.views;
 
-import com.cloudant.client.api.model.Document;
+import com.cloudant.client.api.views.AllDocsRequest;
 import com.cloudant.client.api.views.AllDocsRequestBuilder;
-import com.cloudant.client.api.views.ViewRequest;
 
-public class AllDocsRequestBuilderImpl extends CommonViewRequestBuilder<String, Document.Revision,
+public class AllDocsRequestBuilderImpl extends CommonViewRequestBuilder<String,
+        AllDocsRequestResponse.Revision,
         AllDocsRequestBuilder> implements AllDocsRequestBuilder {
 
-    public AllDocsRequestBuilderImpl(ViewQueryParameters<String, Document.Revision> parameters) {
+    public AllDocsRequestBuilderImpl(ViewQueryParameters<String, AllDocsRequestResponse.Revision>
+                                             parameters) {
         super(parameters);
     }
 
@@ -31,7 +32,7 @@ public class AllDocsRequestBuilderImpl extends CommonViewRequestBuilder<String, 
     }
 
     @Override
-    public ViewRequest<String, Document.Revision> build() {
-        return new ViewRequestImpl<String, Document.Revision>(viewQueryParameters);
+    public AllDocsRequest build() {
+        return new AllDocsRequestResponse(viewQueryParameters);
     }
 }

--- a/src/main/java/com/cloudant/client/internal/views/AllDocsRequestResponse.java
+++ b/src/main/java/com/cloudant/client/internal/views/AllDocsRequestResponse.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2015 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.client.internal.views;
+
+import com.cloudant.client.api.model.Document;
+import com.cloudant.client.api.views.AllDocsRequest;
+import com.cloudant.client.api.views.AllDocsResponse;
+import com.cloudant.client.api.views.ViewRequest;
+import com.cloudant.client.api.views.ViewResponse;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * This class wraps a ViewRequest and ViewResponse for easier processing of _all_docs requests and
+ * responses.
+ */
+public class AllDocsRequestResponse implements AllDocsRequest, AllDocsResponse {
+
+    private final ViewRequest<String, Revision> request;
+    private ViewResponse<String, Revision> response = null;
+
+    AllDocsRequestResponse(ViewQueryParameters<String, Revision> parameters) {
+        request = new ViewRequestImpl<String, Revision>(parameters);
+    }
+
+
+    @Override
+    public AllDocsResponse getResponse() throws IOException {
+        response = request.getResponse();
+        return this;
+    }
+
+    @Override
+    public List<Document> getDocs() {
+        return response.getDocs();
+    }
+
+    @Override
+    public Map<String, String> getIdsAndRevs() {
+        Map<String, String> docIdsAndRevs = new HashMap<String, String>();
+        for (ViewResponse.Row<String, Revision> row : response.getRows()) {
+            docIdsAndRevs.put(row.getKey(), row.getValue().get());
+        }
+        return docIdsAndRevs;
+    }
+
+    @Override
+    public <D> List<D> getDocsAs(Class<D> docType) {
+        return response.getDocsAs(docType);
+    }
+
+    @Override
+    public List<String> getDocIds() {
+        return response.getKeys();
+    }
+
+    /*
+         * Object representation of rev field from a JSON object.
+         * <P>
+         * A convenience to allow deserialization of _all_docs JSON revision object data.
+         * </P>
+         */
+    public static final class Revision {
+
+        private String rev;
+
+        /**
+         * @return the value of the document rev field
+         */
+        public String get() {
+            return rev;
+        }
+    }
+}

--- a/src/test/java/com/cloudant/tests/ViewsTest.java
+++ b/src/test/java/com/cloudant/tests/ViewsTest.java
@@ -25,7 +25,6 @@ import static org.junit.Assert.assertTrue;
 
 import com.cloudant.client.api.CloudantClient;
 import com.cloudant.client.api.Database;
-import com.cloudant.client.api.model.Document;
 import com.cloudant.client.api.views.Key;
 import com.cloudant.client.api.views.ViewMultipleRequest;
 import com.cloudant.client.api.views.ViewRequest;
@@ -654,14 +653,13 @@ public class ViewsTest {
     public void allDocs() throws Exception {
         init();
         db.save(new Foo());
-        List<String> allDocIds = db.getAllDocsRequestBuilder().build().getResponse().getKeys();
+        List<String> allDocIds = db.getAllDocsRequestBuilder().build().getResponse().getDocIds();
         assertThat(allDocIds.size(), not(0));
-        List<Document.Revision> allDocRevs = db.getAllDocsRequestBuilder().build().getResponse()
-                .getValues();
-        assertThat(allDocIds.size(), not(0));
-        for (Document.Revision rev : allDocRevs) {
-            System.out.println(rev.get());
-            assertNotNull("The document _rev value should not be null", rev.get());
+        Map<String, String> idsAndRevs = db.getAllDocsRequestBuilder().build().getResponse()
+                .getIdsAndRevs();
+        assertThat(idsAndRevs.size(), not(0));
+        for (Map.Entry<String, String> doc : idsAndRevs.entrySet()) {
+            assertNotNull("The document _rev value should not be null", doc.getValue());
         }
     }
 


### PR DESCRIPTION
*What*
Use custom interfaces for `_all_docs` requests and responses.

*Why*
Feedback from #90 suggested that it was confusing to have `View*` interfaces to handle `_all_docs` requests.

*How*
Add interfaces for `AllDocsRequest` and `AllDocsResponse` that expose simpler methods for handling an `_all_docs` response.
Since `_all_docs` returns view like structures anyway the implementation is still backed by `View*` objects, but additionally complexity is hidden from the end user (e.g. typing as this is constant for `_all_docs`).

*Testing*
Updated `ViewsTest#allDocs()` to use new methods.

reviewer @rhyshort 
reviewer @tomblench 