### PR TITLE
52580 changes test

### DIFF
--- a/src/test/java/com/cloudant/tests/ChangeNotificationsTest.java
+++ b/src/test/java/com/cloudant/tests/ChangeNotificationsTest.java
@@ -20,19 +20,21 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 
 import com.cloudant.client.api.Changes;
-import com.cloudant.client.api.CloudantClient;
 import com.cloudant.client.api.Database;
 import com.cloudant.client.api.model.ChangesResult;
 import com.cloudant.client.api.model.ChangesResult.Row;
 import com.cloudant.client.api.model.DbInfo;
 import com.cloudant.client.api.model.Response;
 import com.cloudant.test.main.RequiresDB;
+import com.cloudant.tests.util.CloudantClientResource;
+import com.cloudant.tests.util.DatabaseResource;
 import com.google.gson.JsonObject;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.junit.After;
 import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -42,22 +44,19 @@ import java.util.List;
 public class ChangeNotificationsTest {
 
     private static final Log log = LogFactory.getLog(ChangeNotificationsTest.class);
-    private static Database db;
-    private CloudantClient account;
 
+    @ClassRule
+    public static CloudantClientResource clientResource = new CloudantClientResource();
+
+    @Rule
+    public DatabaseResource dbResource = new DatabaseResource(clientResource.get());
+
+    private Database db;
 
     @Before
-    public void setUp() {
-        account = CloudantClientHelper.getClient();
-        db = account.database("lightcouch-db-test", true);
+    public void setup() {
+        db = dbResource.get();
     }
-
-    @After
-    public void tearDown() {
-        account.deleteDB("lightcouch-db-test");
-        account.shutdown();
-    }
-
 
     @Test
     public void changes_normalFeed() {

--- a/src/test/java/com/cloudant/tests/util/CloudantClientResource.java
+++ b/src/test/java/com/cloudant/tests/util/CloudantClientResource.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2015 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.tests.util;
+
+import com.cloudant.client.api.CloudantClient;
+import com.cloudant.tests.CloudantClientHelper;
+
+import org.junit.rules.ExternalResource;
+
+public class CloudantClientResource extends ExternalResource {
+    private CloudantClient client;
+
+    @Override
+    public void before() {
+        client = CloudantClientHelper.getClient();
+    }
+
+    @Override
+    public void after() {
+        client.shutdown();
+    }
+
+    public CloudantClient get() {
+        return this.client;
+    }
+}

--- a/src/test/java/com/cloudant/tests/util/DatabaseResource.java
+++ b/src/test/java/com/cloudant/tests/util/DatabaseResource.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2015 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.tests.util;
+
+import com.cloudant.client.api.CloudantClient;
+import com.cloudant.client.api.Database;
+
+import org.junit.rules.ExternalResource;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+import java.util.Locale;
+
+public class DatabaseResource extends ExternalResource {
+
+    private final CloudantClient client;
+    private String databaseName = Utils.generateUUID();
+    private Database database;
+
+    public DatabaseResource(CloudantClient client) {
+        this.client = client;
+    }
+
+    @Override
+    public Statement apply(Statement base, Description description) {
+        String testClassName = description.getClassName();
+        String testMethodName = description.getMethodName();
+        String uniqueSuffix = Utils.generateUUID();
+        databaseName = sanitizeDbName(testClassName + "-" + (testMethodName == null ? "" :
+                testMethodName + "-") + uniqueSuffix);
+        return super.apply(base, description);
+    }
+
+    /**
+     * The database must start with a letter and can only contain lowercase letters (a-z), digits
+     * (0-9) and the following characters _, $, (, ), +, -, and /.
+     *
+     * @param name to sanitize
+     * @return sanitized name
+     */
+    private static String sanitizeDbName(String name) {
+        //lowercase to remove any caps that will not be permitted
+        name = name.toLowerCase(Locale.ENGLISH);
+        //replace any characters that are not permitted with underscores
+        name = name.replaceAll("[^a-z0-9_\\$\\(\\)\\+\\-/]", "_");
+        return name;
+    }
+
+    @Override
+    public void before() {
+        database = client.database(databaseName, true);
+    }
+
+    @Override
+    public void after() {
+        client.deleteDB(databaseName);
+    }
+
+    public Database get() {
+        return this.database;
+    }
+
+}


### PR DESCRIPTION
*What*
Use uniquely named databases for `ChangeNotificationsTest` to try and resolve intermittent `NoDocumentException` failures in the travis checks, which appear to be caused by overlap of a single database.

*How*
Create JUnit `ExternalResource` types for both the `CloudantClient` and `Database` objects. This allows `before` and `after` methods to be applied at either the test method or test class level by using the `@Rule` and `@ClassRule` annotations respectively. It has the advantage of keeping the setup and
teardown code for these resources in a single place, allowing for easier enforcement of test best practice (such as using a unique name for a `Database`).
Refactor the `ChangeNotificationsTest` to use these resources.

*Testing*
Existing `ChangeNotificationsTest` pass.

reviewer @tomblench 
reviewer @emlaver 