### PR TITLE
Replace Apache HttpClient with sync-android's com.cloudant.http

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,6 @@ dependencies {
     compile group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.3.3'
     compile group: 'com.google.code.gson', name: 'gson', version: '2.2.4'
     compile group: 'commons-io', name: 'commons-io', version: '2.4'
-    compile group: 'com.google.guava', name: 'guava', version: '17.0'
     testCompile group: 'junit', name: 'junit', version: '4.12'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,8 @@ repositories {
 dependencies {
     compile group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.3.3'
     compile group: 'com.google.code.gson', name: 'gson', version: '2.2.4'
+    compile group: 'commons-io', name: 'commons-io', version: '2.4'
+    compile group: 'com.google.guava', name: 'guava', version: '17.0'
     testCompile group: 'junit', name: 'junit', version: '4.12'
 }
 

--- a/src/main/java/com/cloudant/android/Base64OutputStreamFactory.java
+++ b/src/main/java/com/cloudant/android/Base64OutputStreamFactory.java
@@ -35,7 +35,7 @@ public class Base64OutputStreamFactory {
             }
         } catch (Exception e) {
             // TODO log
-            return null;
+            throw new RuntimeException(e);
         }
     }
 }

--- a/src/main/java/com/cloudant/android/Base64OutputStreamFactory.java
+++ b/src/main/java/com/cloudant/android/Base64OutputStreamFactory.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2015 Cloudant, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.android;
+
+import java.io.OutputStream;
+import java.lang.reflect.Constructor;
+
+/**
+ * Created by tomblench on 07/07/2014.
+ */
+public class Base64OutputStreamFactory {
+    public static OutputStream get(OutputStream os) {
+        try {
+            Class androidBase64 = Class.forName("android.util.Base64OutputStream");
+            if (androidBase64 != null) {
+                Constructor ctor = androidBase64.getDeclaredConstructor(OutputStream.class, int.class);
+                // 2 = android.util.BASE64.NO_WRAP http://developer.android.com/reference/android/util/Base64.html#NO_WRAP
+                return (OutputStream)ctor.newInstance(os, 2);
+            } else {
+                Class c = Class.forName("org.apache.commons.codec.binary.Base64OutputStream");
+                Constructor ctor = c.getDeclaredConstructor(OutputStream.class, boolean.class, int.class, byte[].class);
+                return (OutputStream)ctor.newInstance(os, true, 0, null);
+            }
+        } catch (Exception e) {
+            // TODO log
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/cloudant/http/AgentHelper.java
+++ b/src/main/java/com/cloudant/http/AgentHelper.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2015 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.http;
+
+import com.cloudant.client.org.lightcouch.CouchDbClient;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.Properties;
+
+public class AgentHelper {
+
+    /**
+     * The {@code User-Agent} identifier for this client.
+     */
+    public static final String USER_AGENT;
+
+    //init the string, based on a properties file or fallback to some defaults
+    static {
+        //default to an unknown version java-cloudant-default, but hopefully generate something
+        //more specific from a properties file
+        String ua = "java-cloudant-default";
+        String version = "unknown";
+        final URL url = CouchDbClient.class.getClassLoader().getResource("client.properties");
+        final Properties properties = new Properties();
+        InputStream propStream = null;
+        try {
+            properties.load((propStream = url.openStream()));
+            ua = properties.getProperty("user.agent.name", ua);
+            version = properties.getProperty("user.agent.version", version);
+        } catch (Exception ex) {
+            //swallow exception and keep using default values
+        } finally {
+            if (propStream != null) {
+                try {
+                    propStream.close();
+                } catch (IOException e) {
+                    //can't do anything else
+                }
+            }
+        }
+        USER_AGENT = String.format("%s/%s [Java (%s; %s; %s) %s; %s; %s]",
+                ua,
+                version,
+                System.getProperty("os.arch"),
+                System.getProperty("os.name"),
+                System.getProperty("os.version"),
+                System.getProperty("java.vendor"),
+                System.getProperty("java.version"),
+                System.getProperty("java.runtime.version"));
+    }
+
+}

--- a/src/main/java/com/cloudant/http/CookieInterceptor.java
+++ b/src/main/java/com/cloudant/http/CookieInterceptor.java
@@ -97,7 +97,7 @@ public  class CookieInterceptor implements HttpConnectionRequestInterceptor, Htt
 
     }
 
-     public String getCookie(URL url){
+     private String getCookie(URL url){
         try {
             URL sessionURL = new URL(String.format("%s://%s:%d/_session",
                     url.getProtocol(),

--- a/src/main/java/com/cloudant/http/CookieInterceptor.java
+++ b/src/main/java/com/cloudant/http/CookieInterceptor.java
@@ -96,7 +96,7 @@ public  class CookieInterceptor implements HttpConnectionRequestInterceptor, Htt
         return context;
 
     }
-     //TODO possibly make this public for lightcouch CouchDbClientBase?
+
      public String getCookie(URL url){
         try {
             URL sessionURL = new URL(String.format("%s://%s:%d/_session",

--- a/src/main/java/com/cloudant/http/CookieInterceptor.java
+++ b/src/main/java/com/cloudant/http/CookieInterceptor.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2015 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.http;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.UnsupportedEncodingException;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ *
+ * Adds cookie authentication support to http requests.
+ *
+ * It does this by adding the cookie header for CouchDB
+ * using request interceptor pipeline in {@link HttpConnection}.
+ *
+ * If a response has a response code of 401, it will fetch a cookie from
+ * the server using provided credentials and tell {@link HttpConnection} to reply
+ * the request by setting {@link HttpConnectionInterceptorContext#replayRequest} property to true.
+ *
+ * If the request to get the cookie for use in future request fails with a 401 status code
+ * (or any status that indicates client error) cookie authentication will not be attempted again.
+ *
+ *
+ */
+public  class CookieInterceptor implements HttpConnectionRequestInterceptor, HttpConnectionResponseInterceptor {
+
+    private final static Logger logger = Logger.getLogger(CookieInterceptor.class.getCanonicalName());
+    final String sessionRequestBody;
+    private String cookie = null;
+    private boolean shouldAttemptCookieRequest = true;
+    private final String username;
+
+    /**
+     * Constructs a cookie interceptor.
+     * @param username The username to use when getting the cookie
+     * @param password The password to use when getting the cookie
+     */
+    public CookieInterceptor(String username, String password){
+        this.sessionRequestBody = String.format("name=%s&password=%s",username,password);
+        this.username = username;
+    }
+
+    @Override
+    public HttpConnectionInterceptorContext interceptRequest(HttpConnectionInterceptorContext context) {
+
+        HttpURLConnection connection = context.connection.getConnection();
+
+        if(shouldAttemptCookieRequest) {
+            if (cookie == null) {
+                cookie = getCookie(connection.getURL());
+            }
+            connection.setRequestProperty("Cookie", cookie);
+        }
+
+        return context;
+    }
+
+    @Override
+    public HttpConnectionInterceptorContext interceptResponse(HttpConnectionInterceptorContext context) {
+        HttpURLConnection connection = context.connection.getConnection();
+        try {
+            if (context.connection.getConnection().getResponseCode() == 401) {
+                //we need to get a new cookie
+                cookie = getCookie(connection.getURL());
+                //don't resend request, failed to get cookie
+                if(cookie != null) {
+                    context.replayRequest = true;
+                } else {
+                    context.replayRequest = false;
+                }
+            }
+        } catch (IOException e) {
+            logger.log(Level.SEVERE, "Failed to get response code from request",e);
+        }
+        return context;
+
+    }
+     //TODO possibly make this public for lightcouch CouchDbClientBase?
+     public String getCookie(URL url){
+        try {
+            URL sessionURL = new URL(String.format("%s://%s:%d/_session",
+                    url.getProtocol(),
+                    url.getHost(),
+                    url.getPort()));
+
+            HttpConnection conn = Http.POST(sessionURL, "application/x-www-form-urlencoded");
+            conn.setRequestBody(sessionRequestBody);
+            HttpURLConnection connection = conn.execute().getConnection();
+            String cookieHeader = connection.getHeaderField("Set-Cookie");
+            int responseCode = connection.getResponseCode();
+
+            if(responseCode / 100 == 2){
+
+                if(sessionHasStarted(connection.getInputStream())) {
+                    return cookieHeader.substring(0, cookieHeader.indexOf(";"));
+                } else {
+                    return null;
+                }
+
+            } else if(responseCode == 401){
+                shouldAttemptCookieRequest  = false;
+                logger.severe("Credentials are incorrect, cookie authentication will not be" +
+                        " attempted again by this interceptor object");
+            } else if (responseCode / 100 == 5){
+                logger.log(Level.SEVERE,
+                        "Failed to get cookie from server, response code %s, cookie auth",
+                        responseCode);
+            }  else {
+                // catch any other response code
+                logger.log(Level.SEVERE,
+                        "Failed to get cookie from server, response code %s, " +
+                                "cookie authentication will not be attempted again",
+                        responseCode);
+                shouldAttemptCookieRequest = false;
+            }
+
+        } catch (MalformedURLException e) {
+            logger.log(Level.SEVERE,"Failed to create URL for _session endpoint",e);
+        } catch (UnsupportedEncodingException e) {
+            logger.log(Level.SEVERE, "Failed to encode cookieRequest body", e);
+        } catch (IOException e) {
+            logger.log(Level.SEVERE, "Failed to read cookie response header", e);
+        }
+        return null;
+    }
+
+    private boolean sessionHasStarted(InputStream responseStream){
+        //check the response body
+        Gson gson = new Gson();
+        //Map<String,Object> jsonResponse = gson.fromJson(new InputStreamReader(responseStream));
+        JsonObject jsonResponse = gson.fromJson(new InputStreamReader(responseStream), JsonObject.class);
+
+        // only check for ok:true, https://issues.apache.org/jira/browse/COUCHDB-1356
+        // means we cannot check that the name returned is the one we sent.
+       //return jsonResponse.containsKey("ok") && (Boolean) jsonResponse.get("ok");
+        return jsonResponse != null && jsonResponse.has("ok")
+                && !jsonResponse.get("ok").isJsonNull();
+
+    }
+}

--- a/src/main/java/com/cloudant/http/Http.java
+++ b/src/main/java/com/cloudant/http/Http.java
@@ -1,0 +1,103 @@
+//  Copyright (c) 2015 IBM Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+
+package com.cloudant.http;
+
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URL;
+
+/**
+ * Created by tomblench on 23/03/15.
+ */
+
+/**
+ * Factory methods for obtaining <code>HttpConnection</code>s.
+ *
+ * @see com.cloudant.http.HttpConnection
+ */
+public class Http {
+
+    // high level http operations, URL and URI flavoured
+
+    public static HttpConnection GET(URL url)
+    {
+        return connect("GET", url, null);
+    }
+
+    public static HttpConnection GET(URI uri)
+    {
+        return connect("GET", uri, null);
+    }
+
+    public static HttpConnection PUT(URL url,
+                                     String contentType)
+    {
+        return connect("PUT", url, contentType);
+    }
+
+    public static HttpConnection PUT(URI uri,
+                                     String contentType)
+    {
+        return connect("PUT", uri, contentType);
+    }
+
+    public static HttpConnection POST(URL url,
+                                      String contentType)
+    {
+        return connect("POST", url, contentType);
+    }
+
+    public static HttpConnection POST(URI uri,
+                                      String contentType)
+    {
+        return connect("POST", uri, contentType);
+    }
+
+    public static HttpConnection DELETE(URL url)
+    {
+        return connect("DELETE", url, null);
+    }
+
+    public static HttpConnection DELETE(URI uri)
+    {
+        return connect("DELETE", uri, null);
+    }
+
+    public static HttpConnection HEAD(URL url)
+    {
+        return connect("HEAD", url, null);
+    }
+
+    public static HttpConnection HEAD(URI uri)
+    {
+        return connect("HEAD", uri, null);
+    }
+
+    // low level http operations
+
+    public static HttpConnection connect(String requestMethod,
+                                         URL url,
+                                         String contentType) {
+        return new HttpConnection(requestMethod, url, contentType);
+    }
+
+    public static HttpConnection connect(String requestMethod,
+                                         URI uri,
+                                         String contentType) {
+        try {
+            return new HttpConnection(requestMethod, uri.toURL(), contentType);
+        } catch (MalformedURLException mue) {
+            return null;
+        }
+    }
+
+
+}

--- a/src/main/java/com/cloudant/http/HttpConnection.java
+++ b/src/main/java/com/cloudant/http/HttpConnection.java
@@ -10,7 +10,8 @@
 
 package com.cloudant.http;
 
-import org.apache.commons.codec.binary.Base64OutputStream;
+import com.cloudant.android.Base64OutputStreamFactory;
+
 import org.apache.commons.io.IOUtils;
 
 import java.io.ByteArrayInputStream;
@@ -184,8 +185,7 @@ public class HttpConnection  {
                 connection.setRequestProperty("User-Agent", AgentHelper.USER_AGENT);
                 if (url.getUserInfo() != null) {
                     ByteArrayOutputStream baos = new ByteArrayOutputStream();
-                    //Using apache's Base64 instead of sync's Base64OutputStreamFactory
-                    OutputStream bos = new Base64OutputStream(baos, true, 0, null);
+                    OutputStream bos = Base64OutputStreamFactory.get(baos);
                     bos.write(url.getUserInfo().getBytes());
                     bos.flush();
                     bos.close();

--- a/src/main/java/com/cloudant/http/HttpConnection.java
+++ b/src/main/java/com/cloudant/http/HttpConnection.java
@@ -10,8 +10,6 @@
 
 package com.cloudant.http;
 
-import com.cloudant.client.org.lightcouch.CouchDbClient;
-
 import org.apache.commons.codec.binary.Base64OutputStream;
 import org.apache.commons.io.IOUtils;
 
@@ -183,7 +181,7 @@ public class HttpConnection  {
                     connection.setRequestProperty(key, requestProperties.get(key));
                 }
 
-                connection.setRequestProperty("User-Agent", CouchDbClient.USER_AGENT);
+                connection.setRequestProperty("User-Agent", AgentHelper.USER_AGENT);
                 if (url.getUserInfo() != null) {
                     ByteArrayOutputStream baos = new ByteArrayOutputStream();
                     //Using apache's Base64 instead of sync's Base64OutputStreamFactory
@@ -335,4 +333,5 @@ public class HttpConnection  {
     public void disconnect() {
         connection.disconnect();
     }
+
 }

--- a/src/main/java/com/cloudant/http/HttpConnection.java
+++ b/src/main/java/com/cloudant/http/HttpConnection.java
@@ -1,0 +1,367 @@
+//  Copyright (c) 2015 IBM Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+
+package com.cloudant.http;
+
+import com.google.common.io.Resources;
+
+import org.apache.commons.codec.binary.Base64OutputStream;
+import org.apache.commons.io.IOUtils;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.UnsupportedEncodingException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Properties;
+import java.util.logging.Logger;
+
+
+/**
+ * Created by tomblench on 23/03/15.
+ */
+
+/**
+ * <p>
+ * A wrapper for <code>HttpURLConnection</code>s.
+ * </p>
+ *
+ * <p>
+ * Provides some convenience methods for making requests and sending/receiving data as streams,
+ * strings, or byte arrays.
+ * </p>
+ *
+ * <p>
+ * Typical usage:
+ * </p>
+ *
+ * <pre>
+ * HttpConnection hc = new HttpConnection("POST", "application/json", new URL("http://somewhere"));
+ * hc.requestProperties.put("x-some-header", "some-value");
+ * hc.setRequestBody("{\"hello\": \"world\"});
+ * String result = hc.execute().responseAsString();
+ * // get the underlying HttpURLConnection if you need to do something a bit more advanced:
+ * int response = hc.getConnection().getResponseCode();
+ * hc.disconnect();
+ * </pre>
+ *
+ * <p>
+ * <b>Important:</b> this class is not thread-safe and <code>HttpConnection</code>s should not be
+ * shared across threads.
+ * </p>
+ *
+ * @see java.net.HttpURLConnection
+ */
+public class HttpConnection  {
+
+    private static final Logger logger = Logger.getLogger(HttpConnection.class.getCanonicalName());
+    private final String requestMethod;
+    public final URL url;
+    private final String contentType;
+
+    // created in executeInternal
+    private HttpURLConnection connection;
+
+    // set by the various setRequestBody() methods
+    private InputStream input;
+    private long inputLength;
+
+    public final HashMap<String, String> requestProperties;
+
+    private static String userAgent = getUserAgent();
+
+    public final List<HttpConnectionRequestInterceptor> requestInterceptors;
+    public final List<HttpConnectionResponseInterceptor> responseInterceptors;
+
+    private int numberOfRetries = 10;
+
+
+    public HttpConnection(String requestMethod,
+                          URL url,
+                          String contentType) {
+        this.requestMethod = requestMethod;
+        this.url = url;
+        this.contentType = contentType;
+        this.requestProperties = new HashMap<String, String>();
+        this.requestInterceptors = new LinkedList<HttpConnectionRequestInterceptor>();
+        this.responseInterceptors = new LinkedList<HttpConnectionResponseInterceptor>();
+    }
+
+    /**
+     * Sets the number of times this request can be retried.
+     * This method <strong>must</strong> be called before {@link #execute()}
+     * @param numberOfRetries the number of times this request can be retried.
+     * @return an {@link HttpConnection} for method chaining 
+     */
+    public HttpConnection setNumberOfRetries(int numberOfRetries){
+        this.numberOfRetries = numberOfRetries;
+        return this;
+    }
+
+    /**
+     * Set the String of request body data to be sent to the server.
+     * @param input String of request body data to be sent to the server
+     * @return an {@link HttpConnection} for method chaining 
+     */
+    public HttpConnection setRequestBody(final String input) {
+        try {
+            this.input = new ByteArrayInputStream(input.getBytes("UTF-8"));
+            // input is in bytes, not characters
+            this.inputLength = input.getBytes().length;
+        } catch (UnsupportedEncodingException e) {
+            // This should never happen as every implementation of the java platform is required
+            // to support UTF-8.
+        }
+        return this;
+    }
+
+    /**
+     * Set the byte array of request body data to be sent to the server.
+     * @param input byte array of request body data to be sent to the server
+     * @return an {@link HttpConnection} for method chaining 
+     */
+    public HttpConnection setRequestBody(final byte[] input) {
+        this.input = new ByteArrayInputStream(input);
+        this.inputLength = input.length;
+        return this;
+    }
+
+    /**
+     * Set the InputStream of request body data to be sent to the server.
+     * @param input InputStream of request body data to be sent to the server
+     * @return an {@link HttpConnection} for method chaining 
+     */
+    public HttpConnection setRequestBody(InputStream input) {
+        this.input = input;
+        // -1 signals inputLength unknown
+        this.inputLength = -1;
+        return this;
+    }
+
+    /**
+     * Set the InputStream of request body data, of known length, to be sent to the server.
+     * @param input InputStream of request body data to be sent to the server
+     * @param inputLength Length of request body data to be sent to the server, in bytes
+     * @return an {@link HttpConnection} for method chaining 
+     */
+    public HttpConnection setRequestBody(InputStream input, long inputLength) {
+        this.input = input;
+        this.inputLength = inputLength;
+        return this;
+    }
+
+    /**
+     * <p>
+     * Execute request without returning data from server.
+     * </p>
+     * <p>
+     * Call {@code responseAsString}, {@code responseAsBytes}, or {@code responseAsInputStream}
+     * after {@code execute} if the response body is required.
+     * </p>
+     * @return An {@link HttpConnection} which can be used to obtain the response body
+     * @throws IOException if there was a problem writing data to the server
+     */
+    public HttpConnection execute() throws IOException {
+            boolean retry = true;
+            int n = numberOfRetries;
+            while (retry && n-- > 0) {
+
+                System.setProperty("http.keepAlive", "false");
+
+                connection = (HttpURLConnection) url.openConnection();
+                for (String key : requestProperties.keySet()) {
+                    connection.setRequestProperty(key, requestProperties.get(key));
+                }
+
+                connection.setRequestProperty("User-Agent", userAgent);
+                if (url.getUserInfo() != null) {
+                    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                    //Using apache's Base64 instead of sync's Base64OutputStreamFactory
+                    OutputStream bos = new Base64OutputStream(baos, true, 0, null);
+                    bos.write(url.getUserInfo().getBytes());
+                    bos.flush();
+                    bos.close();
+                    String encodedAuth = baos.toString();
+                    connection.setRequestProperty("Authorization", String.format("Basic %s", encodedAuth));
+                }
+
+
+                // always read the result, so we can retrieve the HTTP response code
+                connection.setDoInput(true);
+                connection.setRequestMethod(requestMethod);
+                if (contentType != null) {
+                    connection.setRequestProperty("Content-type", contentType);
+                }
+
+                HttpConnectionInterceptorContext currentContext = new HttpConnectionInterceptorContext(this);
+
+                for (HttpConnectionRequestInterceptor requestInterceptor : requestInterceptors) {
+                    currentContext = requestInterceptor.interceptRequest(currentContext);
+                }
+
+                if (input != null) {
+                    connection.setDoOutput(true);
+                    if (inputLength != -1) {
+                        // TODO on 1.7 upwards this method takes a long, otherwise int
+                        connection.setFixedLengthStreamingMode((int) this.inputLength);
+                    } else {
+                        // TODO some situations where we can't do chunking, like multipart/related
+                        /// https://issues.apache.org/jira/browse/COUCHDB-1403
+                        connection.setChunkedStreamingMode(1024);
+                    }
+
+                    // See "8.2.3 Use of the 100 (Continue) Status" in http://tools.ietf.org/html
+                    // /rfc2616
+                    // Attempting to write to the connection's OutputStream may cause an exception to be
+                    // thrown. This is useful because it avoids sending large request bodies (such as
+                    // attachments) if the server is going to reject our request. Reasons for rejecting
+                    // requests could be 401 Unauthorized (eg cookie needs to be refreshed), etc.
+                    connection.setRequestProperty("Expect", "100-continue");
+
+                    int bufSize = 1024;
+                    int nRead = 0;
+                    byte[] buf = new byte[bufSize];
+                    InputStream is = input;
+                    OutputStream os = connection.getOutputStream();
+
+                    while ((nRead = is.read(buf)) >= 0) {
+                        os.write(buf, 0, nRead);
+                    }
+                    os.flush();
+                    // we do not call os.close() - on some JVMs this incurs a delay of several seconds
+                    // see http://stackoverflow.com/questions/19860436
+                }
+
+                for (HttpConnectionResponseInterceptor responseInterceptor : responseInterceptors) {
+                    currentContext = responseInterceptor.interceptResponse(currentContext);
+                }
+
+                // retry flag is set from the final step in the response interceptRequest pipeline
+                retry = currentContext.replayRequest;
+
+                if (n == 0) {
+                    logger.info("Maximum number of retries reached");
+                }
+            }
+            // return ourselves to allow method chaining
+            return this;
+        }
+
+    /**
+     * <p>
+     * Return response body data from server as a String.
+     * </p>
+     * <p>
+     * <b>Important:</b> you must call <code>execute()</code> before calling this method.
+     * </p>
+     * @return String of response body data from server, if any
+     * @throws IOException if there was a problem reading data from the server
+     */
+    public String responseAsString() throws IOException {
+        if (connection == null) {
+            throw new IOException("Attempted to read response from server before calling execute()");
+        }
+        InputStream is = connection.getInputStream();
+        String string = IOUtils.toString(is);
+        is.close();
+        connection.disconnect();
+        return string;
+    }
+
+    /**
+     * <p>
+     * Return response body data from server as a byte array.
+     * </p>
+     * <p>
+     * <b>Important:</b> you must call <code>execute()</code> before calling this method.
+     * </p>
+     * @return Byte array of response body data from server, if any
+     * @throws IOException if there was a problem reading data from the server
+     */
+    public byte[] responseAsBytes() throws IOException {
+        if (connection == null) {
+            throw new IOException("Attempted to read response from server before calling execute()");
+        }
+        InputStream is = connection.getInputStream();
+        byte[] bytes = IOUtils.toByteArray(is);
+        is.close();
+        connection.disconnect();
+        return bytes;
+    }
+
+    /**
+     * <p>
+     * Return response body data from server as an InputStream.
+     * </p>
+     * <p>
+     * <b>Important:</b> you must call <code>execute()</code> before calling this method.
+     * </p>
+     * @return InputStream of response body data from server, if any
+     * @throws IOException if there was a problem reading data from the server
+     */
+    public InputStream responseAsInputStream() throws IOException {
+        if (connection == null) {
+            throw new IOException("Attempted to read response from server before calling execute()");
+        }
+        InputStream is = connection.getInputStream();
+        return is;
+    }
+
+    /**
+     * Get the underlying HttpURLConnection object, allowing clients to set/get properties not
+     * exposed here.
+     * @return HttpURLConnection the underlying {@link HttpURLConnection} object
+     */
+    public HttpURLConnection getConnection() {
+        return connection;
+    }
+
+    /**
+     * Disconnect the underlying HttpURLConnection. Equivalent to calling:
+     * <code>
+     * getConnection.disconnect()
+     * </code>
+     */
+    public void disconnect() {
+        connection.disconnect();
+    }
+
+    private static String getUserAgent() {
+        String userAgent;
+        String ua = getUserAgentFromResource();
+        {
+            userAgent = String.format("%s Java (%s; %s; %s)",
+                    ua,
+                    System.getProperty("os.arch"),
+                    System.getProperty("os.name"),
+                    System.getProperty("os.version"));
+        }
+        return userAgent;
+    }
+
+    private static String getUserAgentFromResource() {
+        final String defaultUserAgent = "CloudantSync";
+        final URL url = HttpConnection.class.getClassLoader().getResource("mazha.properties");
+        final Properties properties = new Properties();
+        try {
+            //Resources.asByteSource(url) deprecated and removed in Guava 18.0
+            properties.load(Resources.newInputStreamSupplier(url).getInput());
+            return properties.getProperty("user.agent", defaultUserAgent);
+        } catch (Exception ex) {
+            return defaultUserAgent;
+        }
+    }
+}

--- a/src/main/java/com/cloudant/http/HttpConnection.java
+++ b/src/main/java/com/cloudant/http/HttpConnection.java
@@ -10,6 +10,8 @@
 
 package com.cloudant.http;
 
+import com.cloudant.client.org.lightcouch.CouchDbClient;
+
 import org.apache.commons.codec.binary.Base64OutputStream;
 import org.apache.commons.io.IOUtils;
 
@@ -24,7 +26,6 @@ import java.net.URL;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Properties;
 import java.util.logging.Logger;
 
 
@@ -78,8 +79,6 @@ public class HttpConnection  {
     private long inputLength;
 
     public final HashMap<String, String> requestProperties;
-
-    private static String userAgent = getUserAgent();
 
     public final List<HttpConnectionRequestInterceptor> requestInterceptors;
     public final List<HttpConnectionResponseInterceptor> responseInterceptors;
@@ -184,7 +183,7 @@ public class HttpConnection  {
                     connection.setRequestProperty(key, requestProperties.get(key));
                 }
 
-                connection.setRequestProperty("User-Agent", userAgent);
+                connection.setRequestProperty("User-Agent", CouchDbClient.USER_AGENT);
                 if (url.getUserInfo() != null) {
                     ByteArrayOutputStream baos = new ByteArrayOutputStream();
                     //Using apache's Base64 instead of sync's Base64OutputStreamFactory
@@ -335,30 +334,5 @@ public class HttpConnection  {
      */
     public void disconnect() {
         connection.disconnect();
-    }
-
-    private static String getUserAgent() {
-        String userAgent;
-        String ua = getUserAgentFromResource();
-        {
-            userAgent = String.format("%s Java (%s; %s; %s)",
-                    ua,
-                    System.getProperty("os.arch"),
-                    System.getProperty("os.name"),
-                    System.getProperty("os.version"));
-        }
-        return userAgent;
-    }
-
-    private static String getUserAgentFromResource() {
-        final String defaultUserAgent = "JavaCloudant";
-        final URL url = HttpConnection.class.getClassLoader().getResource("mazha.properties");
-        final Properties properties = new Properties();
-        try {
-            properties.load(url.openStream());
-            return properties.getProperty("user.agent", defaultUserAgent);
-        } catch (Exception ex) {
-            return defaultUserAgent;
-        }
     }
 }

--- a/src/main/java/com/cloudant/http/HttpConnection.java
+++ b/src/main/java/com/cloudant/http/HttpConnection.java
@@ -10,8 +10,6 @@
 
 package com.cloudant.http;
 
-import com.google.common.io.Resources;
-
 import org.apache.commons.codec.binary.Base64OutputStream;
 import org.apache.commons.io.IOUtils;
 
@@ -353,12 +351,11 @@ public class HttpConnection  {
     }
 
     private static String getUserAgentFromResource() {
-        final String defaultUserAgent = "CloudantSync";
+        final String defaultUserAgent = "JavaCloudant";
         final URL url = HttpConnection.class.getClassLoader().getResource("mazha.properties");
         final Properties properties = new Properties();
         try {
-            //Resources.asByteSource(url) deprecated and removed in Guava 18.0
-            properties.load(Resources.newInputStreamSupplier(url).getInput());
+            properties.load(url.openStream());
             return properties.getProperty("user.agent", defaultUserAgent);
         } catch (Exception ex) {
             return defaultUserAgent;

--- a/src/main/java/com/cloudant/http/HttpConnectionInterceptorContext.java
+++ b/src/main/java/com/cloudant/http/HttpConnectionInterceptorContext.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2015 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package com.cloudant.http;
+
+/**
+ * Created by tomblench on 30/03/15.
+ */
+public class HttpConnectionInterceptorContext {
+
+    public boolean replayRequest;
+    public final HttpConnection connection;
+
+    /**
+     * Constructor
+     * @param connection HttpConnection
+     */
+    public HttpConnectionInterceptorContext(HttpConnection connection) {
+        this.replayRequest = false;
+        this.connection = connection;
+    }
+
+    /**
+     * Shallow copy constructor
+     * @param other Context to copy
+     */
+    public HttpConnectionInterceptorContext(HttpConnectionInterceptorContext other) {
+        this.replayRequest = other.replayRequest;
+        this.connection = other.connection;
+
+    }
+
+}

--- a/src/main/java/com/cloudant/http/HttpConnectionRequestInterceptor.java
+++ b/src/main/java/com/cloudant/http/HttpConnectionRequestInterceptor.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2015 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package com.cloudant.http;
+
+/**
+ * Created by tomblench on 30/03/15.
+ */
+
+import java.net.HttpURLConnection;
+
+/**
+
+ A Request Interceptor is run before the request is made to the server. It can use headers to add support
+ for other authentication methods, for example cookie authentication. See
+ {@link CookieInterceptor#interceptRequest(HttpConnectionInterceptorContext)} for an example.
+
+
+ Interceptors are executed in a pipeline and modify the context in a serial fashion.
+ */
+
+
+public interface HttpConnectionRequestInterceptor {
+
+    /**
+     * Intercept the request.
+     * This method <strong>must not</strong> do any of the following:
+     * <ul>
+     *     <li>Return null</li>
+     *     <li>Call methods on the underlying {@link java.net.HttpURLConnection} which
+     *     initiate a request such as {@link HttpURLConnection#getResponseCode()}</li>
+     * </ul>
+     * @param context Input context
+     * @return Output context
+     */
+    HttpConnectionInterceptorContext interceptRequest(HttpConnectionInterceptorContext context);
+
+}

--- a/src/main/java/com/cloudant/http/HttpConnectionResponseInterceptor.java
+++ b/src/main/java/com/cloudant/http/HttpConnectionResponseInterceptor.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2015 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.http;
+
+/**
+ A Response Interceptor is run after the response is obtained from the
+ server but before the output stream is returned to the original client. The Response
+ Interceptor enables two main behaviours:
+<ul>
+  <li>Modifying the response for every request</li>
+
+ <li> Replaying a (potentially modified) request by reacting to the
+ response.</li>
+ </ul>
+
+ Interceptors are executed in a pipeline and modify the context in a serial fashion.
+ */
+public interface HttpConnectionResponseInterceptor {
+
+    /**
+     * Intercept the response
+     *
+     * This method <strong>must not</strong> do any of the following
+     * <ul>
+     *     <li>Return null</li>
+     *     <li>Read the response stream</li>
+     * </ul>
+     * @param context Input context
+     * @return Output context
+     */
+    HttpConnectionInterceptorContext interceptResponse(HttpConnectionInterceptorContext context);
+}


### PR DESCRIPTION
*What*
This is the first part in a series of PRs for replacing the current http dependency of Apache’s `httpclient` with sync-android's `HttpURLConnection`.  Migrating to HttpUrlConnection is required for us to use java-cloudant within sync-android.

*How*
- Move required classes over from sync’s http package
- Call `org.apache.commons.codec.binary.Base64OutputStream` directly instead of sync-android's `Base64OutputStreamFactory`:
  https://github.com/cloudant/java-cloudant/blob/48522-1-add-http-classes/src/main/java/com/cloudant/http/HttpConnection.java#L193

- Add required dependencies in build.gradle 

*Tests*
No tests required.

FogBugz: 48522

reviewer @ricellis 
reviewer @tomblench 
reviewer @rhyshort 