### PR TITLE
48522 unicode tests

### DIFF
--- a/src/test/java/com/cloudant/tests/ChangeNotificationsTest.java
+++ b/src/test/java/com/cloudant/tests/ChangeNotificationsTest.java
@@ -49,7 +49,7 @@ public class ChangeNotificationsTest {
     public static CloudantClientResource clientResource = new CloudantClientResource();
 
     @Rule
-    public DatabaseResource dbResource = new DatabaseResource(clientResource.get());
+    public DatabaseResource dbResource = new DatabaseResource(clientResource);
 
     private Database db;
 

--- a/src/test/java/com/cloudant/tests/util/DatabaseResource.java
+++ b/src/test/java/com/cloudant/tests/util/DatabaseResource.java
@@ -25,12 +25,29 @@ import java.util.Locale;
 
 public class DatabaseResource extends ExternalResource {
 
-    private final CloudantClient client;
+    private final CloudantClientResource clientResource;
+    private CloudantClient client;
     private String databaseName = Utils.generateUUID();
     private Database database;
 
-    public DatabaseResource(CloudantClient client) {
-        this.client = client;
+    /**
+     * Create a database resource from the specified clientResource. Note that if the resources
+     * are at the same level (i.e. Rule or ClassRule) then a RuleChain is required to guarantee
+     * the client is set up before the database e.g.
+     * <pre>
+     * {@code
+     *    public static final CloudantClientResource clientResource = new CloudantClientResource();
+     *    public static final DatabaseResource dbResource = new DatabaseResource(clientResource);
+     *    @ClassRule
+     *    public static final RuleChain CHAIN = RuleChain.outerRule(clientResource).around
+     *    (dbResource);
+     * }
+     * </pre>
+     *
+     * @param clientResource
+     */
+    public DatabaseResource(CloudantClientResource clientResource) {
+        this.clientResource = clientResource;
     }
 
     @Override
@@ -60,6 +77,7 @@ public class DatabaseResource extends ExternalResource {
 
     @Override
     public void before() {
+        client = clientResource.get();
         database = client.database(databaseName, true);
     }
 

--- a/src/test/java/com/cloudant/tests/util/TestLog.java
+++ b/src/test/java/com/cloudant/tests/util/TestLog.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2015 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.tests.util;
+
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+import java.util.logging.Logger;
+
+public class TestLog implements TestRule {
+
+    //default to a logger name for this class, but replace when the rule is applied
+    public Logger logger = Logger.getLogger(TestLog.class.getName());
+
+    @Override
+    public Statement apply(final Statement base, Description description) {
+        //set a logger for the name of the test class
+        logger = Logger.getLogger(description.getClassName());
+        return base;
+    }
+
+}


### PR DESCRIPTION
*What*
Refactor the unicode tests for the new HTTP API.

*How*
Replace usage of the Apache HTTP classes in the test methods.
Fix print lines with logging.
Update the test to use the new JUnit rules.

*Testing*
The tests pass after the refactor.

reviewer @emlaver 
reviewer @tomblench 