### PR TITLE
52852 timeout defaults

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
+# Unreleased
+- [CHANGED] Added default of 5 minutes for both connection and socket timeouts instead of waiting forever.
+- [IMPROVED] Upgraded Apache HttpClient from 4.3.3 to 4.3.6.
+
 # 1.2.1 (2015-09-14)
 - [FIXED] `org.apache.http.conn.UnsupportedSchemeException: http protocol is not supported`
-  when using a proxy server with `http` and a server with `https`
+  when using a proxy server with `http` and a server with `https`.
 
 # 1.2.0 (2015-09-10)
 - [FIXED] `NullPointerException` when parsing `{doc: null}` JSON in search or view results.

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ dependencies {
 Alternately download the dependencies
 
 * [cloudant.jar](http://search.maven.org/remotecontent?filepath=com/cloudant/cloudant-client/)
-* [HttpClient 4.3.3](http://hc.apache.org/downloads.cgi)
-* [HttpCore 4.3.2](http://hc.apache.org/downloads.cgi)
+* [HttpClient 4.3.6](http://hc.apache.org/downloads.cgi)
+* [HttpCore 4.3.3](http://hc.apache.org/downloads.cgi)
 * [Commons Codec 1.6](http://commons.apache.org/codec/download_codec.cgi)
 * [Commons Logging 1.1.3](http://commons.apache.org/logging/download_logging.cgi)
 * [Gson 2.2.4](http://code.google.com/p/google-gson/downloads/list)

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ repositories {
     mavenCentral()
 }
 dependencies {
-    compile group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.3.3'
+    compile group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.3.6'
     compile group: 'com.google.code.gson', name: 'gson', version: '2.2.4'
     testCompile group: 'junit', name: 'junit', version: '4.8.2'
 }

--- a/src/main/java/org/lightcouch/CouchDbProperties.java
+++ b/src/main/java/org/lightcouch/CouchDbProperties.java
@@ -36,9 +36,9 @@ public class CouchDbProperties {
 
     private String authCookie;
 
-    // optional
-    private int socketTimeout;
-    private int connectionTimeout;
+    // optional, default to 5 minutes
+    private int socketTimeout = 300000;
+    private int connectionTimeout = 300000;
     //default to 6 connections
     private int maxConnections = 6;
     private String proxyHost;


### PR DESCRIPTION
*What*
Add default socket and connection timeouts

*Why*
Having an infinite timeout can cause the client to hang by blocking the connection pool if a response is not received.

*How*
Set 5 minute timeouts as defaults in `CouchDbProperties`.
Upgrade Apache HttpClient from 4.3.3 to 4.3.6 to get a handshake socket timeout fix.

*Testing*
Existing tests pass against local and the Cloudant service.

reviewer @rhyshort 
reviewer @brynh 