### PR TITLE
Added test resources to replicate tests

### DIFF
--- a/src/test/java/com/cloudant/tests/ReplicateBaseTest.java
+++ b/src/test/java/com/cloudant/tests/ReplicateBaseTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2015 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.tests;
+
+import com.cloudant.client.api.CloudantClient;
+import com.cloudant.client.api.Database;
+import com.cloudant.tests.util.CloudantClientResource;
+import com.cloudant.tests.util.DatabaseResource;
+
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+
+public class ReplicateBaseTest {
+
+    @ClassRule
+    public static CloudantClientResource clientResource = new CloudantClientResource();
+    protected CloudantClient account = clientResource.get();
+
+    @Rule
+    public DatabaseResource db1Resource = new DatabaseResource(account);
+    @Rule
+    public DatabaseResource db2Resource = new DatabaseResource(account);
+
+    protected Database db1;
+
+    protected Database db2;
+
+    protected static String db1URI;
+    protected static String db2URI;
+
+    @Before
+    public void setUp() {
+
+        db1 = db1Resource.get();
+        db1URI = CloudantClientHelper.SERVER_URI + "/" + db1Resource.getDatabaseName();
+        db1.syncDesignDocsWithDb();
+
+        db2 = db2Resource.get();
+        db2URI = CloudantClientHelper.SERVER_URI + "/" + db2Resource.getDatabaseName();
+        db2.syncDesignDocsWithDb();
+    }
+}

--- a/src/test/java/com/cloudant/tests/ReplicationTest.java
+++ b/src/test/java/com/cloudant/tests/ReplicationTest.java
@@ -20,8 +20,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
-import com.cloudant.client.api.CloudantClient;
-import com.cloudant.client.api.Database;
 import com.cloudant.client.api.model.ReplicationResult;
 import com.cloudant.client.api.model.ReplicationResult.ReplicationHistory;
 import com.cloudant.client.api.views.Key;
@@ -29,53 +27,15 @@ import com.cloudant.client.api.views.ViewResponse;
 import com.cloudant.test.main.RequiresDB;
 import com.cloudant.tests.util.Utils;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
 
 @Category(RequiresDB.class)
-public class ReplicationTest {
-    private static final Log log = LogFactory.getLog(ReplicationTest.class);
-
-    private static Properties props;
-    private static Database db1;
-
-    private static Database db2;
-
-    private static String db1URI;
-    private static String db2URI;
-    private CloudantClient account;
-
-    @Before
-    public void setUp() {
-        account = CloudantClientHelper.getClient();
-
-        db1 = account.database("lightcouch-db-test", true);
-        db1URI = CloudantClientHelper.SERVER_URI.toString() + "/lightcouch-db-test";
-
-
-        db2 = account.database("lightcouch-db-test-2", true);
-
-        db1.syncDesignDocsWithDb();
-        db2.syncDesignDocsWithDb();
-
-        db2URI = CloudantClientHelper.SERVER_URI.toString() + "/lightcouch-db-test-2";
-    }
-
-    @After
-    public void tearDown() {
-        account.deleteDB("lightcouch-db-test");
-        account.deleteDB("lightcouch-db-test-2");
-        account.shutdown();
-    }
+public class ReplicationTest extends ReplicateBaseTest {
 
     @Test
     public void replication() {

--- a/src/test/java/com/cloudant/tests/ReplicatorTest.java
+++ b/src/test/java/com/cloudant/tests/ReplicatorTest.java
@@ -18,8 +18,6 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.junit.Assert.assertThat;
 
-import com.cloudant.client.api.CloudantClient;
-import com.cloudant.client.api.Database;
 import com.cloudant.client.api.model.ReplicatorDocument;
 import com.cloudant.client.api.model.Response;
 import com.cloudant.client.api.views.Key;
@@ -27,50 +25,15 @@ import com.cloudant.client.api.views.ViewResponse;
 import com.cloudant.test.main.RequiresDB;
 import com.cloudant.tests.util.Utils;
 
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
 
 @Category(RequiresDB.class)
-public class ReplicatorTest {
-
-    private static Properties props;
-    private static Database db1;
-
-    private static Database db2;
-
-    private static String db1URI;
-    private static String db2URI;
-    private CloudantClient account;
-
-    @Before
-    public void setUp() {
-        account = CloudantClientHelper.getClient();
-        db1 = account.database("lightcouch-db-test", true);
-        db1URI = CloudantClientHelper.SERVER_URI.toString() + "/lightcouch-db-test";
-
-
-        db2 = account.database("lightcouch-db-test-2", true);
-        db1.syncDesignDocsWithDb();
-        db2.syncDesignDocsWithDb();
-
-
-        db2URI = CloudantClientHelper.SERVER_URI.toString() + "/lightcouch-db-test-2";
-
-    }
-
-    @After
-    public void tearDown() {
-        account.deleteDB("lightcouch-db-test");
-        account.deleteDB("lightcouch-db-test-2");
-        account.shutdown();
-    }
+public class ReplicatorTest extends ReplicateBaseTest {
 
     @Test
     public void replication() throws Exception {

--- a/src/test/java/com/cloudant/tests/util/DatabaseResource.java
+++ b/src/test/java/com/cloudant/tests/util/DatabaseResource.java
@@ -72,4 +72,7 @@ public class DatabaseResource extends ExternalResource {
         return this.database;
     }
 
+    public String getDatabaseName() {
+        return this.databaseName;
+    }
 }


### PR DESCRIPTION
*What*
Dynamically name the databases used by the Replicate tests.

*Why*
Prevent intermittent issues with tests stepping on each other's resources.

*How*
Add a supertype with common setup for the tests that utilizes the JUnit `Rule` based resources.

*Testing*
No new tests, but these tests still pass.

reviewer @brynh 