### PR TITLE
51118 proxy auth

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# Unreleased
+- [IMPROVED] Added Basic Auth for HTTP proxies. Configure via `ConnectOption#setProxyUser`
+  and `ConnectOptions#setProxyPassword`.
+
 # 1.2.2 (2015-10-01)
 - [CHANGED] Added default of 5 minutes for both connection and socket timeouts instead of waiting forever.
 - [IMPROVED] Upgraded Apache HttpClient from 4.3.3 to 4.3.6.

--- a/README.md
+++ b/README.md
@@ -960,8 +960,10 @@ ConnectOptions connectOptions = new ConnectOptions()
                                         .setSocketTimeout(50)
                                         .setConnectionTimeout(50)
                                         .setMaxConnections(100)
-                                        .setProxyHost("http://localhost")
+                                        .setProxyHost("localhost")
                                         .setProxyPort(8080)
+                                        .setProxyUser("exampleProxyUser")
+                                        .setProxyPassword("exampleProxyPassword")
                                         .setSSLAuthenticationDisabled(true);
  CloudantClient client = new CloudantClient("cloudant.com","test","password",
                                                   connectOptions );

--- a/src/main/java/com/cloudant/client/api/CloudantClient.java
+++ b/src/main/java/com/cloudant/client/api/CloudantClient.java
@@ -535,6 +535,8 @@ public class CloudantClient {
 
             props.setProxyHost(connectOptions.getProxyHost());
             props.setProxyPort(connectOptions.getProxyPort());
+            props.setProxyUser(connectOptions.getProxyUser());
+            props.setProxyPassword(connectOptions.getProxyPassword());
             props.disableSSLAuthentication(connectOptions.isSSLAuthenticationDisabled());
             props.setAuthenticatedModeSSLSocketFactory(connectOptions
                     .getAuthenticatedModeSSLSocketFactory());

--- a/src/main/java/com/cloudant/client/api/model/ConnectOptions.java
+++ b/src/main/java/com/cloudant/client/api/model/ConnectOptions.java
@@ -15,6 +15,8 @@ public class ConnectOptions {
 
     private String proxyHost;
     private int proxyPort;
+    private String proxyUser;
+    private String proxyPassword;
     private boolean isSSLAuthenticationDisabled;
     private SSLSocketFactory authenticatedModeSSLSocketFactory;
 
@@ -44,6 +46,16 @@ public class ConnectOptions {
 
     public ConnectOptions setProxyPort(int proxyPort) {
         this.proxyPort = proxyPort;
+        return this;
+    }
+
+    public ConnectOptions setProxyUser(String proxyUser) {
+        this.proxyUser = proxyUser;
+        return this;
+    }
+
+    public ConnectOptions setProxyPassword(String proxyPassword) {
+        this.proxyPassword = proxyPassword;
         return this;
     }
 
@@ -92,6 +104,14 @@ public class ConnectOptions {
 
     public int getProxyPort() {
         return proxyPort;
+    }
+
+    public String getProxyUser() {
+        return proxyUser;
+    }
+
+    public String getProxyPassword() {
+        return proxyPassword;
     }
 
     /**

--- a/src/main/java/org/lightcouch/CouchDbClient.java
+++ b/src/main/java/org/lightcouch/CouchDbClient.java
@@ -205,19 +205,30 @@ public class CouchDbClient extends CouchDbClientBase {
                     .setDefaultRequestConfig(RequestConfig.custom()
                             .setSocketTimeout(props.getSocketTimeout())
                             .setConnectTimeout(props.getConnectionTimeout()).build());
+
+            //set up a credsProvider, but it will only be used if creds have been supplied
+            CredentialsProvider credsProvider = new BasicCredentialsProvider();
+            boolean credsProviderUsed = false;
             if (props.getProxyHost() != null) {
                 clientBuilder.setProxy(new HttpHost(props.getProxyHost(), props.getProxyPort()));
+                if (props.getProxyUser() != null) {
+                    credsProviderUsed = true;
+                    credsProvider.setCredentials(new AuthScope(props.getProxyHost(), props
+                            .getProxyPort()), new UsernamePasswordCredentials(props.getProxyUser
+                            (), props.getProxyPassword()));
+                }
             }
             clientBuilder.setDefaultCookieStore(cookies); // use AUTH cookies
             if (props.getUsername() != null) {
+                credsProviderUsed = true;
                 // this one is for non account endpoints.
-                CredentialsProvider credsProvider = new BasicCredentialsProvider();
                 credsProvider.setCredentials(new AuthScope(props.getHost(),
                                 props.getPort()),
                         new UsernamePasswordCredentials(props.getUsername(),
                                 props.getPassword()));
+            }
+            if (credsProviderUsed) {
                 clientBuilder.setDefaultCredentialsProvider(credsProvider);
-                //props.clearPassword();
             }
             registerInterceptors(clientBuilder);
             return clientBuilder.build();

--- a/src/main/java/org/lightcouch/CouchDbProperties.java
+++ b/src/main/java/org/lightcouch/CouchDbProperties.java
@@ -43,6 +43,8 @@ public class CouchDbProperties {
     private int maxConnections = 6;
     private String proxyHost;
     private int proxyPort;
+    private String proxyUser;
+    private String proxyPassword;
     private boolean disableSSLAuthentication;
     private SSLSocketFactory authenticatedModeSSLSocketFactory;
 
@@ -112,6 +114,14 @@ public class CouchDbProperties {
         return proxyPort;
     }
 
+    public String getProxyUser() {
+        return proxyUser;
+    }
+
+    public String getProxyPassword() {
+        return proxyPassword;
+    }
+
     public CouchDbProperties setProtocol(String protocol) {
         this.protocol = protocol;
         return this;
@@ -164,6 +174,16 @@ public class CouchDbProperties {
 
     public CouchDbProperties setProxyPort(int proxyPort) {
         this.proxyPort = proxyPort;
+        return this;
+    }
+
+    public CouchDbProperties setProxyUser(String proxyUser) {
+        this.proxyUser = proxyUser;
+        return this;
+    }
+
+    public CouchDbProperties setProxyPassword(String proxyPassword) {
+        this.proxyPassword = proxyPassword;
         return this;
     }
 


### PR DESCRIPTION
*What*
Add proxy authentication options

*How*
Add proxy user name and password options to ConnectOptions.
Configure the credentials provider for the proxy host.
This is taken from the [proxy-auth](https://github.com/cloudant/java-cloudant/tree/proxy-auth) branch, but adjusted slightly for the latest 1.2 maintenance.

reviewer @emlaver 
reviewer @tomblench 