### PR TITLE
53085 ssl setters

### DIFF
--- a/src/main/java/com/cloudant/client/api/CloudantClient.java
+++ b/src/main/java/com/cloudant/client/api/CloudantClient.java
@@ -38,6 +38,7 @@ import com.cloudant.client.org.lightcouch.Replicator;
 import com.cloudant.client.org.lightcouch.Response;
 import com.cloudant.http.HttpConnection;
 import com.cloudant.http.interceptors.ProxyAuthInterceptor;
+import com.cloudant.http.interceptors.SSLCustomizerInterceptor;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.reflect.TypeToken;
@@ -522,9 +523,15 @@ public class CloudantClient {
                 props.addRequestInterceptors(new ProxyAuthInterceptor(connectOptions.getProxyUser
                         (), connectOptions.getProxyPassword()));
             }
-            props.disableSSLAuthentication(connectOptions.isSSLAuthenticationDisabled());
-            props.setAuthenticatedModeSSLSocketFactory(connectOptions
-                    .getAuthenticatedModeSSLSocketFactory());
+            if (connectOptions.isSSLAuthenticationDisabled()) {
+                props.addRequestInterceptors(SSLCustomizerInterceptor
+                        .SSL_AUTH_DISABLED_INTERCEPTOR);
+            } else {
+                if (connectOptions.getAuthenticatedModeSSLSocketFactory() != null) {
+                    props.addRequestInterceptors(new SSLCustomizerInterceptor(connectOptions
+                            .getAuthenticatedModeSSLSocketFactory()));
+                }
+            }
         }
         this.client = new CouchDbClient(props);
 

--- a/src/main/java/com/cloudant/client/org/lightcouch/CouchDbProperties.java
+++ b/src/main/java/com/cloudant/client/org/lightcouch/CouchDbProperties.java
@@ -23,8 +23,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import javax.net.ssl.SSLSocketFactory;
-
 /**
  * Represents configuration properties for connecting to CouchDB.
  *
@@ -49,8 +47,6 @@ public class CouchDbProperties {
     //default to 6 connections
     private int maxConnections = 6;
     private URL proxyURL;
-    private boolean disableSSLAuthentication;
-    private SSLSocketFactory authenticatedModeSSLSocketFactory;
 
     private List<HttpConnectionRequestInterceptor> requestInterceptors = new ArrayList
             <HttpConnectionRequestInterceptor>();
@@ -189,57 +185,6 @@ public class CouchDbProperties {
     public void clearPassword() {
         setPassword("");
         setPassword(null);
-    }
-
-    /**
-     * Enables/disables hostname verification, certificate chain validation,
-     * and the use of the optional
-     * {@link #getAuthenticatedModeSSLSocketFactory()}.
-     *
-     * @param disabled set to true to disable or false to enable.
-     * @return the updated {@link CouchDbProperties} object.
-     * @see #isSSLAuthenticationDisabled
-     */
-    public CouchDbProperties disableSSLAuthentication(boolean disabled) {
-        this.disableSSLAuthentication = disabled;
-        return this;
-    }
-
-    /**
-     * @return true if hostname verification, certificate chain validation,
-     * and the use of the optional
-     * {@link #getAuthenticatedModeSSLSocketFactory()} are disabled, or
-     * false otherwise.
-     * @see #disableSSLAuthentication(boolean)
-     */
-    public boolean isSSLAuthenticationDisabled() {
-        return disableSSLAuthentication;
-    }
-
-    /**
-     * Returns the SSLSocketFactory that gets used when connecting to
-     * CouchDB over a <code>https</code> URL, when SSL authentication is
-     * enabled.
-     *
-     * @return An SSLSocketFactory, or <code>null</code>, which stands for
-     *         the default SSLSocketFactory of the JRE.
-     * @see #setAuthenticatedModeSSLSocketFactory(javax.net.ssl.SSLSocketFactory)
-     */
-    public SSLSocketFactory getAuthenticatedModeSSLSocketFactory() {
-        return authenticatedModeSSLSocketFactory;
-    }
-
-    /**
-     * Specifies the SSLSocketFactory to use when connecting to CouchDB
-     * over a <code>https</code> URL, when SSL authentication is enabled.
-     *
-     * @param factory An SSLSocketFactory, or <code>null</code> for the
-     *                default SSLSocketFactory of the JRE.
-     * @see #getAuthenticatedModeSSLSocketFactory()
-     */
-    public CouchDbProperties setAuthenticatedModeSSLSocketFactory(SSLSocketFactory factory) {
-        this.authenticatedModeSSLSocketFactory = factory;
-        return this;
     }
 
     public List<HttpConnectionRequestInterceptor> getRequestInterceptors() {

--- a/src/main/java/com/cloudant/http/interceptors/SSLCustomizerInterceptor.java
+++ b/src/main/java/com/cloudant/http/interceptors/SSLCustomizerInterceptor.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2015 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.http.interceptors;
+
+import com.cloudant.http.HttpConnectionInterceptorContext;
+import com.cloudant.http.HttpConnectionRequestInterceptor;
+
+import java.net.HttpURLConnection;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSession;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+
+public class SSLCustomizerInterceptor implements HttpConnectionRequestInterceptor {
+
+    public static final SSLCustomizerInterceptor SSL_AUTH_DISABLED_INTERCEPTOR = new
+            SSLCustomizerInterceptor(getAllTrustingSSLSocketFactory(), new
+            AllowAllHostnameVerifier());
+
+    private static final Logger LOGGER = Logger.getLogger(SSLCustomizerInterceptor.class.getName());
+    private final SSLSocketFactory sslSocketFactory;
+    private final HostnameVerifier hostnameVerifier;
+
+    public SSLCustomizerInterceptor(HostnameVerifier hostnameVerifier) {
+        this(null, hostnameVerifier);
+    }
+
+    public SSLCustomizerInterceptor(SSLSocketFactory sslSocketFactory) {
+        this(sslSocketFactory, null);
+    }
+
+    public SSLCustomizerInterceptor(SSLSocketFactory sslSocketFactory, HostnameVerifier
+            hostnameVerifier) {
+        this.sslSocketFactory = sslSocketFactory;
+        this.hostnameVerifier = hostnameVerifier;
+    }
+
+    @Override
+    public HttpConnectionInterceptorContext interceptRequest(HttpConnectionInterceptorContext
+                                                                     context) {
+
+        HttpURLConnection connection = context.connection.getConnection();
+        if (connection instanceof HttpsURLConnection) {
+            HttpsURLConnection secureConnection = (HttpsURLConnection) connection;
+            if (sslSocketFactory != null) {
+                secureConnection.setSSLSocketFactory(sslSocketFactory);
+            }
+            if (hostnameVerifier != null) {
+                secureConnection.setHostnameVerifier(hostnameVerifier);
+            }
+        }
+        return context;
+    }
+
+    private static final class AllowAllHostnameVerifier implements HostnameVerifier {
+
+        @Override
+        public boolean verify(String s, SSLSession sslSession) {
+            return true;
+        }
+    }
+
+    private static SSLSocketFactory getAllTrustingSSLSocketFactory() {
+        try {
+            SSLContext sslContext = SSLContext.getInstance("TLS");
+            sslContext.init(null, new TrustManager[]{new X509TrustManager() {
+                @Override
+                public void checkClientTrusted(X509Certificate[] x509Certificates, String s) throws
+                        CertificateException {
+                    //NO-OP everything trusted
+                }
+
+                @Override
+                public void checkServerTrusted(X509Certificate[] x509Certificates, String s) throws
+                        CertificateException {
+                    //NO-OP everything trusted
+                }
+
+                @Override
+                public X509Certificate[] getAcceptedIssuers() {
+                    //trust all issuers
+                    return null;
+                }
+            }}, new SecureRandom());
+
+            return sslContext.getSocketFactory();
+        } catch (NoSuchAlgorithmException nsae) {
+            LOGGER.log(Level.SEVERE, "An error occurred instantiating the SSL authentication " +
+                    "disabled interceptor", nsae);
+        } catch (KeyManagementException kme) {
+            LOGGER.log(Level.SEVERE, "An error occurred instantiating the SSL authentication " +
+                    "disabled interceptor", kme);
+        }
+        return null;
+    }
+}

--- a/src/test/java/com/cloudant/tests/SslAuthenticationTest.java
+++ b/src/test/java/com/cloudant/tests/SslAuthenticationTest.java
@@ -27,7 +27,6 @@ import org.apache.commons.logging.LogFactory;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -45,8 +44,6 @@ import javax.net.ssl.SSLServerSocket;
 import javax.net.ssl.SSLServerSocketFactory;
 import javax.net.ssl.SSLSocket;
 
-//TODO Enable in next PR with Rich's 53085-ssl-setters branch
-@Ignore
 public class SslAuthenticationTest {
 
     private static final Log log = LogFactory.getLog(SslAuthenticationTest.class);
@@ -203,7 +200,6 @@ public class SslAuthenticationTest {
      */
     @Test
     public void localSslAuthenticationDisabled() {
-        //TODO ConnectOptions needs redesign for HttpConnection
         ConnectOptions connectionOptions = new ConnectOptions();
         connectionOptions.setSSLAuthenticationDisabled(true);
 


### PR DESCRIPTION
*What*
Enable SSL customization for `HttpsUrlConnection`.

*How*
Create a `SSLCustomizerInterceptor` that sets appropriate socket factories for `HttpsUrlConnections`.
Initialize an appropriate interceptor based on provided `ConnectOptions`.

*Testing*
Re-enabled the `SslAuthenticationTest`.

reviewer @emlaver 
reviewer @rhyshort