### PR TITLE
3rd PR: Add cookie interceptor from sync-android's com.cloudant.http package

### DIFF
--- a/src/main/java/com/cloudant/client/api/CloudantClient.java
+++ b/src/main/java/com/cloudant/client/api/CloudantClient.java
@@ -32,10 +32,12 @@ import com.cloudant.client.api.views.Key;
 import com.cloudant.client.org.lightcouch.Changes;
 import com.cloudant.client.org.lightcouch.CouchDbClient;
 import com.cloudant.client.org.lightcouch.CouchDbDesign;
+import com.cloudant.client.org.lightcouch.CouchDbException;
 import com.cloudant.client.org.lightcouch.CouchDbProperties;
 import com.cloudant.client.org.lightcouch.Replication;
 import com.cloudant.client.org.lightcouch.Replicator;
 import com.cloudant.client.org.lightcouch.Response;
+import com.cloudant.http.CookieInterceptor;
 import com.cloudant.http.HttpConnection;
 import com.cloudant.http.interceptors.ProxyAuthInterceptor;
 import com.cloudant.http.interceptors.SSLCustomizerInterceptor;
@@ -125,7 +127,7 @@ import java.util.Map;
  *
  * <h2>Replication</h2>
  * Replication {@link Replication account.replication()} and {@link Replicator account.replicator()}
- * 
+ *
  * @author Mario Briggs
  * @since 0.0.1
  */
@@ -159,8 +161,7 @@ public class CloudantClient {
                 new Integer(h.get("port")).intValue(),
                 loginUsername,
                 password,
-                null, //connectoptions
-                null //authcookie
+                null //connectoptions
         );
     }
 
@@ -187,8 +188,7 @@ public class CloudantClient {
                 new Integer(h.get("port")).intValue(),
                 loginUsername,
                 password,
-                connectOptions,
-                null //authcookie
+                connectOptions
         );
     }
 
@@ -196,20 +196,17 @@ public class CloudantClient {
      * Constructs a new instance of this class and connects to the cloudant account with the
      * specified credentials
      *
-     * @param account    For cloudant.com, the cloudant account to connect to. For Cloudant
-     *                   local, the server URL
-     * @param authCookie The cookie obtained from last login
+     * @param account For cloudant.com, the cloudant account to connect to. For Cloudant
+     *                local, the server URL
      */
-    public CloudantClient(String account, String authCookie) {
+    public CloudantClient(String account) {
         super();
         Map<String, String> h = parseAccount(account);
-        assertNotEmpty(authCookie, "AuthCookie");
 
         doInit(h.get("scheme"),
                 h.get("hostname"),
                 new Integer(h.get("port")).intValue(),
-                null, null, null,
-                authCookie
+                null, null, null
         );
     }
 
@@ -220,18 +217,16 @@ public class CloudantClient {
      * @param account        For cloudant.com, the cloudant account to connect to. For Cloudant
      *                       local, the server URL
      * @param account        The cloudant account to connect to
-     * @param authCookie     The cookie obtained from last login
      * @param connectOptions optional properties to connect e.g connectionTime,socketTimeout,etc
      */
-    public CloudantClient(String account, String authCookie, ConnectOptions connectOptions) {
+    public CloudantClient(String account, ConnectOptions connectOptions) {
         super();
         Map<String, String> h = parseAccount(account);
-        assertNotEmpty(authCookie, "AuthCookie");
 
         doInit(h.get("scheme"),
                 h.get("hostname"),
                 new Integer(h.get("port")).intValue(),
-                null, null, connectOptions, authCookie);
+                null, null, connectOptions);
     }
 
     /**
@@ -241,7 +236,7 @@ public class CloudantClient {
      */
     public ApiKey generateApiKey() {
         URI uri = buildUri(getBaseUri()).path("_api/v2/api_keys").build();
-        InputStream response =  client.post(uri, null);
+        InputStream response = client.post(uri, null);
         return getResponse(response, ApiKey.class, getGson());
     }
 
@@ -498,20 +493,27 @@ public class CloudantClient {
      * @param loginUsername
      * @param password
      * @param connectOptions
-     * @param authCookie
      */
     private void doInit(String scheme, String hostname, int port,
-                        String loginUsername, String password, ConnectOptions connectOptions,
-                        String authCookie) {
+                        String loginUsername, String password, ConnectOptions connectOptions) {
 
-        CouchDbProperties props;
-        if (authCookie == null) {
-            props = new CouchDbProperties(scheme, hostname, port,
-                    loginUsername, password);
+        CouchDbProperties props = new CouchDbProperties(scheme, hostname, port);
 
+        if (loginUsername != null && password != null) {
+            //make interceptor if both username and password are not null
+
+            //Create cookie interceptor and set in HttpConnection interceptors
+            CookieInterceptor cookieInterceptor = new CookieInterceptor(loginUsername, password);
+
+            props.addRequestInterceptors(cookieInterceptor);
+            props.addResponseInterceptors(cookieInterceptor);
         } else {
-            props = new CouchDbProperties(scheme, hostname, port,
-                    authCookie);
+            //If username or password is null, throw an exception
+            if (loginUsername != null || password != null) {
+                //Username and password both have to contain values
+                throw new CouchDbException("Either a username and password must be provided, or " +
+                        "both values must be null. Please check the credentials and try again.");
+            }
         }
 
         if (connectOptions != null) {

--- a/src/main/java/com/cloudant/client/org/lightcouch/CouchDbClient.java
+++ b/src/main/java/com/cloudant/client/org/lightcouch/CouchDbClient.java
@@ -78,15 +78,8 @@ public class CouchDbClient {
 
         this.gson = GsonHelper.initGson(new GsonBuilder()).create();
         final String path = props.getPath() != null ? props.getPath() : "";
-        //Add username and password if authentication info exists
-        if (props.getUserInfo() != null && !props.getUserInfo().isEmpty()) {
-            this.baseURI = buildUri().scheme(props.getProtocol()).userInfo(props.getUserInfo())
-                    .host(props.getHost()).port(props.getPort())
-                    .path("/").path(path).build();
-        } else {
-            this.baseURI = buildUri().scheme(props.getProtocol()).host(props.getHost()).port(props
-                    .getPort()).path("/").path(path).build();
-        }
+        this.baseURI = buildUri().scheme(props.getProtocol()).host(props.getHost()).port(props
+                .getPort()).path("/").path(path).build();
 
         proxyUrl = props.getProxyURL();
 

--- a/src/main/java/com/cloudant/client/org/lightcouch/CouchDbProperties.java
+++ b/src/main/java/com/cloudant/client/org/lightcouch/CouchDbProperties.java
@@ -57,22 +57,10 @@ public class CouchDbProperties {
         // default constructor
     }
 
-    public CouchDbProperties(String protocol, String host, int port,
-                             String authCookie) {
+    public CouchDbProperties(String protocol, String host, int port) {
         this.protocol = protocol;
         this.host = host;
         this.port = port;
-        this.authCookie = authCookie;
-    }
-
-    public CouchDbProperties(String protocol,
-                             String host, int port, String username, String password) {
-
-        this.protocol = protocol;
-        this.host = host;
-        this.port = port;
-        this.username = username;
-        this.password = password;
     }
 
     public String getProtocol() {
@@ -91,14 +79,6 @@ public class CouchDbProperties {
         return port;
     }
 
-    public String getUsername() {
-        return username;
-    }
-
-    public String getPassword() {
-        return password;
-    }
-
     public int getSocketTimeout() {
         return socketTimeout;
     }
@@ -113,15 +93,6 @@ public class CouchDbProperties {
 
     public URL getProxyURL() {
         return proxyURL;
-    }
-
-    //Retrieve user’s credentials in URI format
-    public String getUserInfo() {
-        if(username != null && password != null) {
-            return String.format("%s:%s", username, password);
-        } else {
-            return null;
-        }
     }
 
     public CouchDbProperties setProtocol(String protocol) {
@@ -172,14 +143,6 @@ public class CouchDbProperties {
     public CouchDbProperties setProxyURL(URL proxyURL) {
         this.proxyURL = proxyURL;
         return this;
-    }
-
-    public String getAuthCookie() {
-        return authCookie;
-    }
-
-    public void setAuthCookie(String authCookie) {
-        this.authCookie = authCookie;
     }
 
     public void clearPassword() {

--- a/src/main/java/com/cloudant/client/org/lightcouch/internal/URIBuilder.java
+++ b/src/main/java/com/cloudant/client/org/lightcouch/internal/URIBuilder.java
@@ -38,7 +38,6 @@ public class URIBuilder {
     private final StringBuilder query = new StringBuilder();
     /* key=value params */
     private final Params qParams = new Params();
-    private String userInfo = "";
 
     public static URIBuilder buildUri() {
         return new URIBuilder();
@@ -46,14 +45,8 @@ public class URIBuilder {
 
     public static URIBuilder buildUri(URI uri) {
         URIBuilder builder;
-        if(uri.getUserInfo() != null && !uri.getUserInfo().isEmpty()) {
-            builder = URIBuilder.buildUri().scheme(uri.getScheme())
-                    .userInfo(uri.getUserInfo()).host(uri.getHost())
-                    .port(uri.getPort()).path(uri.getPath());
-        } else {
-            builder = URIBuilder.buildUri().scheme(uri.getScheme())
-                    .host(uri.getHost()).port(uri.getPort()).path(uri.getPath());
-        }
+        builder = URIBuilder.buildUri().scheme(uri.getScheme())
+                .host(uri.getHost()).port(uri.getPort()).path(uri.getPath());
         return builder;
     }
 
@@ -74,12 +67,7 @@ public class URIBuilder {
             }
             String q = (queryBuilder.length() == 0) ? "" : "?" + queryBuilder.toString();
             String uriString;
-            if(userInfo != null && !userInfo.isEmpty()) {
-                uriString = String.format("%s://%s@%s:%s%s%s", scheme, userInfo, host, port,
-                        path, q);
-            } else {
-                uriString = String.format("%s://%s:%s%s%s", scheme, host, port, path, q);
-            }
+            uriString = String.format("%s://%s:%s%s%s", scheme, host, port, path, q);
             return new URI(uriString);
         } catch (URISyntaxException e) {
             throw new IllegalArgumentException(e);
@@ -94,13 +82,8 @@ public class URIBuilder {
         try {
             String q = (query.length() == 0) ? "" : "?" + query;
             String uri = "";
-            if(userInfo != null) {
-                uri = String.format("%s://%s@%s:%s%s%s%s", scheme, userInfo, host, port, path,
-                        encodedPath, q);
-            } else {
-                uri = String.format("%s://%s:%s%s%s%s", scheme, host, port, path, encodedPath,
-                        q);
-            }
+            uri = String.format("%s://%s:%s%s%s%s", scheme, host, port, path, encodedPath,
+                    q);
             return new URI(uri);
         } catch (URISyntaxException e) {
             throw new IllegalArgumentException(e);
@@ -124,11 +107,6 @@ public class URIBuilder {
 
     public URIBuilder path(String path) {
         this.path += path;
-        return this;
-    }
-
-    public URIBuilder userInfo(String userInfo) {
-        this.userInfo += userInfo;
         return this;
     }
 

--- a/src/test/java/com/cloudant/tests/CloudantClientTests.java
+++ b/src/test/java/com/cloudant/tests/CloudantClientTests.java
@@ -36,10 +36,8 @@ import com.cloudant.tests.util.TestLog;
 
 import org.apache.commons.io.IOUtils;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -112,27 +110,6 @@ public class CloudantClientTests {
 
         Membership membership = cookieBasedClient.getMembership();
         assertNotNull(membership);
-    }
-
-    //TODO Enable in next PR with cookie interceptor changes
-    @Ignore
-    @Test
-    @Category(RequiresDB.class)
-    public void cookieNegativeTest() {
-        String cookie = "";//account.getCookie() + "XXX";
-        boolean exceptionRaised = true;
-        try {
-            new CloudantClient(
-                    CloudantClientHelper.SERVER_URI.toString(), cookie).getAllDbs();
-            exceptionRaised = false;
-        } catch (CouchDbException e) {
-            if (e.getMessage().contains("Forbidden")) {
-                exceptionRaised = true;
-            }
-        }
-        if (exceptionRaised == false) {
-            Assert.fail("could connect to cloudant with random AuthSession cookie");
-        }
     }
 
     private final String userAgentRegex = "java-cloudant/[^\\s]+ " +

--- a/src/test/java/com/cloudant/tests/HttpTest.java
+++ b/src/test/java/com/cloudant/tests/HttpTest.java
@@ -1,0 +1,79 @@
+package com.cloudant.tests;
+
+import com.cloudant.client.api.CloudantClient;
+import com.cloudant.client.org.lightcouch.internal.URIBuilder;
+import com.cloudant.http.CookieInterceptor;
+import com.cloudant.http.HttpConnection;
+import com.cloudant.test.main.RequiresCloudant;
+import com.cloudant.tests.util.CloudantClientResource;
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.URL;
+
+public class HttpTest {
+
+    private String data = "{\"hello\":\"world\"}";
+
+    @ClassRule
+    public static CloudantClientResource clientResource = new CloudantClientResource();
+    private CloudantClient account = clientResource.get();
+
+    //NOTE: This test doesn't work with specified couch servers,
+    // the URL will always include the creds specified for the test
+    //
+    // A couchdb server needs to be set and running with the correct
+    // security settings, the database *must* not be public, it *must*
+    // be named cookie_test
+    //
+    @Test
+    @Category(RequiresCloudant.class)
+    public void testCookieAuthWithoutRetry() throws IOException {
+
+        //Create cookie_test db
+        account.createDB("cookie_test");
+
+        CookieInterceptor interceptor = new CookieInterceptor(CloudantClientHelper.COUCH_USERNAME,
+                CloudantClientHelper.COUCH_PASSWORD);
+
+        URL cookie_test = URIBuilder.buildUri(account.getBaseUri())
+                .path("cookie_test").build().toURL();
+
+        HttpConnection conn = new HttpConnection("POST", cookie_test,
+                "application/json");
+        conn.responseInterceptors.add(interceptor);
+        conn.requestInterceptors.add(interceptor);
+        ByteArrayInputStream bis = new ByteArrayInputStream(data.getBytes());
+
+        // nothing read from stream
+        Assert.assertEquals(bis.available(), data.getBytes().length);
+
+        conn.setRequestBody(bis);
+        conn.execute();
+
+        // stream was read to end
+        Assert.assertEquals(bis.available(), 0);
+        Assert.assertEquals(2, conn.getConnection().getResponseCode() / 100);
+
+        //check the json
+        Gson gson = new Gson();
+        JsonObject response = gson.fromJson(new InputStreamReader(conn.getConnection()
+                .getInputStream()), JsonObject.class);
+
+        Assert.assertTrue(response.has("ok"));
+        Assert.assertTrue(response.get("ok").getAsBoolean());
+        Assert.assertTrue(response.has("id"));
+        Assert.assertTrue(response.has("rev"));
+
+        //Clean up database created
+        account.deleteDB("cookie_test");
+    }
+}


### PR DESCRIPTION
*What*
This is the third part of the PR series for replacing the http dependency from Apache’s httpclient to Java’s HttpURLConnection. This part focuses on updating and enabling the cookie interceptor.  

*How*
- Add cookie interceptor in CloudantClient
- Remove CouchDbProperties constructor with username and password
- Use request and response interceptors for adding cookie
- Remove getters for username and password
- Remove cookieNegativeTest
- Add HttpTest class with cookie auth test case
- Add category RequiresCloudant to testCookieAuthWithoutRetry test case
- Remove all calls to URI's userInfo from lightcouch classes
- Remove getUserInfo in HttpConnection
- Remove current auth cookie code
- Improved error handling when PR 111 is complete
- Update code style

*Testing*
Add cookie authentication test from sync-android’s HttpTest.

reviewer @ricellis
reviewer @tomblench 