### PR TITLE
Added default ports

### DIFF
--- a/src/main/java/com/cloudant/client/api/CloudantClient.java
+++ b/src/main/java/com/cloudant/client/api/CloudantClient.java
@@ -32,6 +32,7 @@ import com.cloudant.client.api.views.Key;
 import com.cloudant.client.org.lightcouch.Changes;
 import com.cloudant.client.org.lightcouch.CouchDbClient;
 import com.cloudant.client.org.lightcouch.CouchDbDesign;
+import com.cloudant.client.org.lightcouch.CouchDbException;
 import com.cloudant.client.org.lightcouch.CouchDbProperties;
 import com.cloudant.client.org.lightcouch.Replication;
 import com.cloudant.client.org.lightcouch.Replicator;
@@ -47,6 +48,7 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPut;
 import org.apache.http.client.methods.HttpRequestBase;
 
+import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.EnumSet;
@@ -505,12 +507,17 @@ public class CloudantClient {
             // user is specifying a uri
             try {
                 URI uri = new URI(account);
-                uri.getPort();
+                int port = uri.getPort();
+                if (port < 0) {
+                    port = uri.toURL().getDefaultPort();
+                }
                 h.put("scheme", uri.getScheme());
                 h.put("hostname", uri.getHost());
-                h.put("port", new Integer(uri.getPort()).toString());
+                h.put("port", new Integer(port).toString());
             } catch (URISyntaxException e) {
-
+                throw new CouchDbException(e);
+            } catch (MalformedURLException e2) {
+                throw new CouchDbException(e2);
             }
         } else {
             h.put("scheme", "https");

--- a/src/test/java/com/cloudant/tests/CloudantClientTests.java
+++ b/src/test/java/com/cloudant/tests/CloudantClientTests.java
@@ -14,6 +14,7 @@
 
 package com.cloudant.tests;
 
+import static junit.framework.TestCase.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -22,6 +23,9 @@ import com.cloudant.client.api.Database;
 import com.cloudant.client.api.model.ApiKey;
 import com.cloudant.client.api.model.Membership;
 import com.cloudant.client.api.model.Task;
+import com.cloudant.client.org.lightcouch.CouchDbClient;
+import com.cloudant.client.org.lightcouch.CouchDbException;
+import com.cloudant.client.org.lightcouch.NoDocumentException;
 import com.cloudant.test.main.RequiresCloudant;
 import com.cloudant.test.main.RequiresCloudantService;
 import com.cloudant.test.main.RequiresDB;
@@ -35,9 +39,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import com.cloudant.client.org.lightcouch.CouchDbClient;
-import com.cloudant.client.org.lightcouch.CouchDbException;
-import com.cloudant.client.org.lightcouch.NoDocumentException;
 
 import java.util.List;
 
@@ -202,6 +203,15 @@ public class CloudantClientTests {
             //clean up the DB created by this test
             cookieBasedClient.deleteDB("existing");
         }
+    }
+
+    @Test
+    public void testDefaultPorts() {
+        CloudantClient c = new CloudantClient("http://192.0.2.0", null, (String) null);
+        assertEquals("The http port should be 80", 80, c.getBaseUri().getPort());
+
+        c = new CloudantClient("https://192.0.2.0", null, (String) null);
+        assertEquals("The http port should be 443", 443, c.getBaseUri().getPort());
     }
 
 }


### PR DESCRIPTION
*What*
Set the port to a default value if it is not supplied in the URL
Fixes #113

*How*
Check if the port value was supplied in the URL and if not get the default for the protocol.

*Testing*
Added new test to assert default ports for `http` and `https` URLs.

reviewer @emlaver 
reviewer @rhyshort 