### PR TITLE
48522 service test fixes

### DIFF
--- a/src/main/java/com/cloudant/http/HttpConnection.java
+++ b/src/main/java/com/cloudant/http/HttpConnection.java
@@ -184,9 +184,6 @@ public class HttpConnection  {
                 } else {
                     connection = (HttpURLConnection) url.openConnection();
                 }
-                for (String key : requestProperties.keySet()) {
-                    connection.setRequestProperty(key, requestProperties.get(key));
-                }
 
                 connection.setRequestProperty("User-Agent", AgentHelper.USER_AGENT);
                 if (url.getUserInfo() != null) {
@@ -204,6 +201,12 @@ public class HttpConnection  {
 
                 for (HttpConnectionRequestInterceptor requestInterceptor : requestInterceptors) {
                     currentContext = requestInterceptor.interceptRequest(currentContext);
+                }
+
+                //set request properties after interceptors, in case the interceptors have added
+                // to the properties map
+                for (String key : requestProperties.keySet()) {
+                    connection.setRequestProperty(key, requestProperties.get(key));
                 }
 
                 if (input != null) {

--- a/src/main/java/com/cloudant/http/interceptors/BasicAuthInterceptor.java
+++ b/src/main/java/com/cloudant/http/interceptors/BasicAuthInterceptor.java
@@ -33,7 +33,7 @@ public class BasicAuthInterceptor implements HttpConnectionRequestInterceptor {
         this(userinfo, "Authorization");
     }
 
-    public BasicAuthInterceptor(String userinfo, String authHeader) {
+    protected BasicAuthInterceptor(String userinfo, String authHeader) {
         this.encodedAuth = encodedCreds(userinfo);
         this.authHeader = authHeader;
     }
@@ -41,7 +41,7 @@ public class BasicAuthInterceptor implements HttpConnectionRequestInterceptor {
     @Override
     public HttpConnectionInterceptorContext interceptRequest(HttpConnectionInterceptorContext
                                                                      context) {
-        context.connection.requestProperties.put("Authorization", String.format("Basic %s",
+        context.connection.requestProperties.put(authHeader, String.format("Basic %s",
                 encodedAuth));
         return context;
     }

--- a/src/test/java/com/cloudant/tests/CloudantClientTests.java
+++ b/src/test/java/com/cloudant/tests/CloudantClientTests.java
@@ -299,4 +299,22 @@ public class CloudantClientTests {
             server.stop();
         }
     }
+
+    /**
+     * This tests that a CouchDbException is thrown if the user is null, but the password is
+     * supplied.
+     */
+    @Test(expected = CouchDbException.class)
+    public void nullUser() {
+        new CloudantClient("http://192.0.2.0", null, ":0-myPassword");
+    }
+
+    /**
+     * This tests that a CouchDbException is thrown if the user is supplied, but the password is
+     * null.
+     */
+    @Test(expected = CouchDbException.class)
+    public void nullPassword() {
+        new CloudantClient("http://192.0.2.0", "user", null);
+    }
 }

--- a/src/test/java/com/cloudant/tests/ReplicateBaseTest.java
+++ b/src/test/java/com/cloudant/tests/ReplicateBaseTest.java
@@ -14,8 +14,14 @@
 
 package com.cloudant.tests;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.junit.Assert.assertThat;
+
 import com.cloudant.client.api.CloudantClient;
 import com.cloudant.client.api.Database;
+import com.cloudant.client.api.views.Key;
+import com.cloudant.client.api.views.ViewResponse;
 import com.cloudant.tests.util.CloudantClientResource;
 import com.cloudant.tests.util.DatabaseResource;
 
@@ -51,5 +57,12 @@ public class ReplicateBaseTest {
         db2 = db2Resource.get();
         db2URI = CloudantClientHelper.SERVER_URI + "/" + db2Resource.getDatabaseName();
         db2.syncDesignDocsWithDb();
+    }
+
+    protected void assertConflictsNotZero(Database db) throws Exception {
+        ViewResponse<Key.ComplexKey, String> conflicts = db.getViewRequestBuilder
+                ("conflicts", "conflict").newRequest(Key.Type.COMPLEX, String.class).build()
+                .getResponse();
+        assertThat(conflicts.getRows().size(), is(not(0)));
     }
 }

--- a/src/test/java/com/cloudant/tests/ReplicationTest.java
+++ b/src/test/java/com/cloudant/tests/ReplicationTest.java
@@ -14,7 +14,6 @@
  */
 package com.cloudant.tests;
 
-import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
@@ -22,8 +21,6 @@ import static org.junit.Assert.assertTrue;
 
 import com.cloudant.client.api.model.ReplicationResult;
 import com.cloudant.client.api.model.ReplicationResult.ReplicationHistory;
-import com.cloudant.client.api.views.Key;
-import com.cloudant.client.api.views.ViewResponse;
 import com.cloudant.test.main.RequiresDB;
 import com.cloudant.tests.util.Utils;
 
@@ -45,6 +42,8 @@ public class ReplicationTest extends ReplicateBaseTest {
                 .target(db2URI)
                 .trigger();
 
+        assertTrue("The replication should complete ok", result.isOk());
+
         List<ReplicationHistory> histories = result.getHistories();
         assertThat(histories.size(), not(0));
     }
@@ -54,13 +53,15 @@ public class ReplicationTest extends ReplicateBaseTest {
         Map<String, Object> queryParams = new HashMap<String, Object>();
         queryParams.put("somekey1", "value 1");
 
-        account.replication()
+        ReplicationResult result = account.replication()
                 .createTarget(true)
                 .source(db1URI)
                 .target(db2URI)
                 .filter("example/example_filter")
                 .queryParams(queryParams)
                 .trigger();
+
+        assertTrue("The replication should complete ok", result.isOk());
     }
 
     @Test
@@ -83,31 +84,22 @@ public class ReplicationTest extends ReplicateBaseTest {
     @Test
     public void replication_conflict() throws Exception {
         String docId = Utils.generateUUID();
-        Foo foodb1 = new Foo(docId, "title");
-        Foo foodb2 = null;
+        Foo foodb1 = new Foo(docId, "titleX");
+        Foo foodb2 = new Foo(docId, "titleY");
 
-        foodb1 = new Foo(docId, "titleX");
-
+        //save Foo(X) in DB1
         db1.save(foodb1);
+        //save Foo(Y) in DB2
+        db2.save(foodb2);
 
-        account.replication().source(db1URI)
+        //replicate with DB1 with DB2
+        ReplicationResult result = account.replication().source(db1URI)
                 .target(db2URI).trigger();
 
-        foodb2 = Utils.findDocumentWithRetries(db2, docId, Foo.class, 20);
-        foodb2.setTitle("titleY");
-        db2.update(foodb2);
+        assertTrue("The replication should complete ok", result.isOk());
 
-        foodb1 = Utils.findDocumentWithRetries(db1, docId, Foo.class, 20);
-        foodb1.setTitle("titleZ");
-        db1.update(foodb1);
-
-        account.replication().source(db1URI)
-                .target(db2URI).trigger();
-
-        ViewResponse<Key.ComplexKey, String> conflicts = db2.getViewRequestBuilder
-                ("conflicts", "conflict").newRequest(Key.Type.COMPLEX, String.class).build()
-                .getResponse();
-
-        assertThat(conflicts.getRows().size(), is(not(0)));
+        //we replicated with a doc with the same ID but different content in each DB, we should get
+        //a conflict
+        assertConflictsNotZero(db2);
     }
 }

--- a/src/test/java/com/cloudant/tests/SslAuthenticationTest.java
+++ b/src/test/java/com/cloudant/tests/SslAuthenticationTest.java
@@ -55,9 +55,6 @@ public class SslAuthenticationTest {
         }
     };
 
-    private static String DUMMY_USERNAME = "username";
-    private static String DUMMY_PASSWORD = "password";
-
     /**
      * Check the exception chain is as expected when the SSL host name authentication fails
      * to be sure we got a CouchDbException for the reason we expect.
@@ -84,8 +81,6 @@ public class SslAuthenticationTest {
         connectionOptions.setSSLAuthenticationDisabled(true);
 
         dbClient = new CloudantClient(server.getUrl(),
-                DUMMY_USERNAME,
-                DUMMY_PASSWORD,
                 connectionOptions);
 
         // Make an arbitrary connection to the DB.
@@ -109,8 +104,6 @@ public class SslAuthenticationTest {
         CouchDbException thrownException = null;
         try {
             dbClient = new CloudantClient(server.getUrl(),
-                    DUMMY_USERNAME,
-                    DUMMY_PASSWORD,
                     connectionOptions);
 
             // Make an arbitrary connection to the DB.
@@ -132,9 +125,7 @@ public class SslAuthenticationTest {
 
         CouchDbException thrownException = null;
         try {
-            dbClient = new CloudantClient(server.getUrl(),
-                    DUMMY_USERNAME,
-                    DUMMY_PASSWORD);
+            dbClient = new CloudantClient(server.getUrl());
 
             // Make an arbitrary connection to the DB.
             dbClient.getAllDbs();


### PR DESCRIPTION
*What*
A series of fixes for the tests to ensure they pass against the Cloudant service

*How*
Ensure interceptors are invoked by using `client.executeRequest` instead of calling `execute` directly on `HttpConnection` objects.
Fix the `Proxy-Authorization` header and make sure the test actually does an assert.
Remove redundant code from the SSL tests.
Fixed intermittent issues in the replication tests.
New tests for not specifying both user and password.

*Testing*
The tests pass against local CouchDB and the Cloudant service.

reviewer @emlaver 
reviewer @tomblench 