### PR TITLE
Additional http test cases

### DIFF
--- a/src/test/java/com/cloudant/tests/ClientLoadTest.java
+++ b/src/test/java/com/cloudant/tests/ClientLoadTest.java
@@ -54,7 +54,7 @@ public class ClientLoadTest {
         ConnectOptions connectionoptions = new ConnectOptions();
         connectionoptions.setMaxConnections(MAX_CONNECTIONS);
 
-        dbClient = new CloudantClient(CloudantClientHelper.SERVER_URI.toString(),
+        dbClient = new CloudantClient(CloudantClientHelper.SERVER_URI,
                 CloudantClientHelper.COUCH_USERNAME,
                 CloudantClientHelper.COUCH_PASSWORD, connectionoptions);
         db = dbClient.database("lightcouch-db-load", true);

--- a/src/test/java/com/cloudant/tests/HttpTest.java
+++ b/src/test/java/com/cloudant/tests/HttpTest.java
@@ -1,23 +1,34 @@
 package com.cloudant.tests;
 
 import com.cloudant.client.api.CloudantClient;
-import com.cloudant.client.org.lightcouch.internal.URIBuilder;
 import com.cloudant.http.CookieInterceptor;
 import com.cloudant.http.HttpConnection;
+import com.cloudant.http.interceptors.BasicAuthInterceptor;
 import com.cloudant.test.main.RequiresCloudant;
 import com.cloudant.tests.util.CloudantClientResource;
+import com.cloudant.tests.util.DatabaseResource;
+import com.cloudant.tests.util.SimpleHttpServer;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 
 import org.junit.Assert;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.LineNumberReader;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.net.ProtocolException;
 import java.net.URL;
+import java.util.regex.Pattern;
 
 public class HttpTest {
 
@@ -25,7 +36,92 @@ public class HttpTest {
 
     @ClassRule
     public static CloudantClientResource clientResource = new CloudantClientResource();
-    private CloudantClient account = clientResource.get();
+    @Rule
+    public final DatabaseResource dbResource = new DatabaseResource(clientResource);
+
+    private final CloudantClient account = clientResource.get();
+
+    /*
+     * Test "Expect: 100-Continue" header works as expected
+     * See "8.2.3 Use of the 100 (Continue) Status" in http://tools.ietf.org/html/rfc2616
+     * We expect the precondition of having a valid DB name to have failed, and therefore, the body
+     * data will not have been written.
+     *
+     * NB this behaviour is only supported on certain JDKs - so we have to make a weaker set of
+     * asserts. If it is supported, we expect execute() to throw an exception and then nothing will
+     * have been read from the stream. If it is not supported, execute() will not throw and we
+     * cannot make any assumptions about how much of the stream has been read (remote side may close
+     * whilst we are still writing).
+     */
+    @Test
+    public void testExpect100Continue() throws IOException {
+        String no_such_database = clientResource.getBaseURIWithUserInfo() + "/no_such_database";
+        HttpConnection conn = new HttpConnection("POST", new URL(no_such_database),
+                "application/json");
+        ByteArrayInputStream bis = new ByteArrayInputStream(data.getBytes());
+
+        // nothing read from stream
+        Assert.assertEquals(bis.available(), data.getBytes().length);
+
+        conn.setRequestBody(bis);
+        boolean thrown = false;
+        try {
+            conn.execute();
+        } catch (ProtocolException pe) {
+            // ProtocolException with message "Server rejected operation" on JDK 1.7
+            thrown = true;
+        }
+
+        if (thrown) {
+            // still nothing read from stream
+            Assert.assertEquals(bis.available(), data.getBytes().length);
+        }
+    }
+
+    /*
+     * Basic test that we can write a document body by POSTing to a known database
+     */
+    @Test
+    public void testWriteToServerOk() throws Exception {
+        HttpConnection conn = new HttpConnection("POST", new URL(dbResource.getDbURIWithUserInfo()),
+                "application/json");
+        ByteArrayInputStream bis = new ByteArrayInputStream(data.getBytes());
+
+        // nothing read from stream
+        Assert.assertEquals(bis.available(), data.getBytes().length);
+
+        conn.setRequestBody(bis);
+        conn.execute();
+
+        // stream was read to end
+        Assert.assertEquals(bis.available(), 0);
+    }
+
+    /*
+     * Basic test to check that an IOException is thrown when we attempt to get the response
+     * without first calling execute()
+     */
+    @Test
+    public void testReadBeforeExecute() throws Exception {
+        HttpConnection conn = new HttpConnection("POST", new URL(dbResource.getDbURIWithUserInfo()),
+                "application/json");
+        ByteArrayInputStream bis = new ByteArrayInputStream(data.getBytes());
+
+        // nothing read from stream
+        Assert.assertEquals(bis.available(), data.getBytes().length);
+
+        conn.setRequestBody(bis);
+        try {
+            conn.responseAsString();
+            Assert.fail("IOException not thrown as expected");
+        } catch (IOException ioe) {
+            ; // "Attempted to read response from server before calling execute()"
+        }
+
+        // stream was not read because execute() was not called
+        Assert.assertEquals(bis.available(), data.getBytes().length);
+    }
+
 
     //NOTE: This test doesn't work with specified couch servers,
     // the URL will always include the creds specified for the test
@@ -37,17 +133,10 @@ public class HttpTest {
     @Test
     @Category(RequiresCloudant.class)
     public void testCookieAuthWithoutRetry() throws IOException {
-
-        //Create cookie_test db
-        account.createDB("cookie_test");
-
         CookieInterceptor interceptor = new CookieInterceptor(CloudantClientHelper.COUCH_USERNAME,
                 CloudantClientHelper.COUCH_PASSWORD);
 
-        URL cookie_test = URIBuilder.buildUri(account.getBaseUri())
-                .path("cookie_test").build().toURL();
-
-        HttpConnection conn = new HttpConnection("POST", cookie_test,
+        HttpConnection conn = new HttpConnection("POST", dbResource.get().getDBUri().toURL(),
                 "application/json");
         conn.responseInterceptors.add(interceptor);
         conn.requestInterceptors.add(interceptor);
@@ -72,8 +161,43 @@ public class HttpTest {
         Assert.assertTrue(response.get("ok").getAsBoolean());
         Assert.assertTrue(response.has("id"));
         Assert.assertTrue(response.has("rev"));
+    }
 
-        //Clean up database created
-        account.deleteDB("cookie_test");
+    /**
+     * Test that adding the Basic Authentication interceptor to HttpConnection
+     * will complete with a response code of 200.  The response input stream
+     * is expected to hold the newly created document's id and rev.
+     */
+    @Test
+    @Category(RequiresCloudant.class)
+    public void testBasicAuth() throws IOException {
+        BasicAuthInterceptor interceptor =
+                new BasicAuthInterceptor(CloudantClientHelper.COUCH_USERNAME
+                        + ":" + CloudantClientHelper.COUCH_PASSWORD);
+
+        HttpConnection conn = new HttpConnection("POST", dbResource.get().getDBUri().toURL(),
+                "application/json");
+        conn.requestInterceptors.add(interceptor);
+        ByteArrayInputStream bis = new ByteArrayInputStream(data.getBytes());
+
+        // nothing read from stream
+        Assert.assertEquals(bis.available(), data.getBytes().length);
+
+        conn.setRequestBody(bis);
+        conn.execute();
+
+        // stream was read to end
+        Assert.assertEquals(bis.available(), 0);
+        Assert.assertEquals(2, conn.getConnection().getResponseCode() / 100);
+
+        //check the json
+        Gson gson = new Gson();
+        JsonObject response = gson.fromJson(new InputStreamReader(conn.getConnection()
+                .getInputStream()), JsonObject.class);
+
+        Assert.assertTrue(response.has("ok"));
+        Assert.assertTrue(response.get("ok").getAsBoolean());
+        Assert.assertTrue(response.has("id"));
+        Assert.assertTrue(response.has("rev"));
     }
 }

--- a/src/test/java/com/cloudant/tests/ReplicateBaseTest.java
+++ b/src/test/java/com/cloudant/tests/ReplicateBaseTest.java
@@ -48,14 +48,14 @@ public class ReplicateBaseTest {
     protected static String db2URI;
 
     @Before
-    public void setUp() {
+    public void setUp() throws Exception {
 
         db1 = db1Resource.get();
-        db1URI = CloudantClientHelper.SERVER_URI + "/" + db1Resource.getDatabaseName();
+        db1URI = db1Resource.getDbURIWithUserInfo();
         db1.syncDesignDocsWithDb();
 
         db2 = db2Resource.get();
-        db2URI = CloudantClientHelper.SERVER_URI + "/" + db2Resource.getDatabaseName();
+        db2URI = db2Resource.getDbURIWithUserInfo();
         db2.syncDesignDocsWithDb();
     }
 

--- a/src/test/java/com/cloudant/tests/SslAuthenticationTest.java
+++ b/src/test/java/com/cloudant/tests/SslAuthenticationTest.java
@@ -146,7 +146,7 @@ public class SslAuthenticationTest {
         ConnectOptions connectionOptions = new ConnectOptions();
         connectionOptions.setSSLAuthenticationDisabled(false);
 
-        dbClient = new CloudantClient(CloudantClientHelper.SERVER_URI.toString(),
+        dbClient = new CloudantClient(CloudantClientHelper.SERVER_URI,
                 CloudantClientHelper.COUCH_USERNAME,
                 CloudantClientHelper.COUCH_PASSWORD,
                 connectionOptions);
@@ -166,7 +166,7 @@ public class SslAuthenticationTest {
         ConnectOptions connectionOptions = new ConnectOptions();
         connectionOptions.setSSLAuthenticationDisabled(true);
 
-        dbClient = new CloudantClient(CloudantClientHelper.SERVER_URI.toString(),
+        dbClient = new CloudantClient(CloudantClientHelper.SERVER_URI,
                 CloudantClientHelper.COUCH_USERNAME,
                 CloudantClientHelper.COUCH_PASSWORD,
                 connectionOptions);

--- a/src/test/java/com/cloudant/tests/util/CloudantClientResource.java
+++ b/src/test/java/com/cloudant/tests/util/CloudantClientResource.java
@@ -35,4 +35,14 @@ public class CloudantClientResource extends ExternalResource {
     public CloudantClient get() {
         return this.client;
     }
+
+    /**
+     * Get the base URI of the client with credentials included which is useful for example for
+     * replication.
+     *
+     * @return String representation of the URI
+     */
+    public String getBaseURIWithUserInfo() {
+        return CloudantClientHelper.SERVER_URI_WITH_USER_INFO;
+    }
 }

--- a/src/test/java/com/cloudant/tests/util/DatabaseResource.java
+++ b/src/test/java/com/cloudant/tests/util/DatabaseResource.java
@@ -93,4 +93,15 @@ public class DatabaseResource extends ExternalResource {
     public String getDatabaseName() {
         return this.databaseName;
     }
+
+    /**
+     * Get a string representation of the URI for the specified DB resource that includes
+     * credentials. This is needed for replication cases where the DB needs to be able to obtain
+     * creds for the DB.
+     *
+     * @return the URI for the DB with creds
+     */
+    public String getDbURIWithUserInfo() throws Exception {
+        return clientResource.getBaseURIWithUserInfo() + "/" + getDatabaseName();
+    }
 }

--- a/src/test/java/com/cloudant/tests/util/Utils.java
+++ b/src/test/java/com/cloudant/tests/util/Utils.java
@@ -134,11 +134,13 @@ public class Utils {
                     .replicatorDocId(replicatorDocId)
                     .find();
 
-            //Check if replicator doc is completed or if continuous replication is triggered
-            if (replicatorDoc != null && replicatorDoc.getReplicationState() != null
-                    && (replicatorDoc.getReplicationState().equalsIgnoreCase(status))) {
-
-                finished = true;
+            //Check if replicator doc is in specified state
+            String state;
+            if (replicatorDoc != null && (state = replicatorDoc.getReplicationState()) != null) {
+                //if we've reached the status or we reached an error then we are finished
+                if (state.equalsIgnoreCase(status) || state.equalsIgnoreCase("error")) {
+                    finished = true;
+                }
             }
             //double the delay for the next iteration
             delay *= 2;


### PR DESCRIPTION
*What*
Several test cases were added from sync-android's HttpTest and a new basic authentication test

*How*
- Removed user info from CloudantClientHelper SERVER_URL to ensure cookie interceptor is used for testing
- Added new method to ensure user info is provided in replication URLs and HttpTest URLs for tests

*Testing*
Test cases:
- testWriteToServerOk
- testExpect100Continue
- testReadBeforeExecute
- testCookieAuthWithoutRetry
- testBasicAuth

reviewer @ricellis 
reviewer @emlaver
reviewer @tomblench 