### PR TITLE
48522 6 execute request

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@
   If you were using the `queryForStream()` method we would be interested in feedback about your use case.
   For example, if you were using the `InputStream` directly for streaming API parsing with an alternative
   JSON library we might be able to make this easier by handling the streams and providing a callback.
+- [BREAKING CHANGE] - Removed Apache HttpClient dependency. API methods that used HttpClient classes
+  (e.g. `executeRequest`) now use `HttpConnection` instead.
 - [BREAKING CHANGE] - Removed version 1.x view query API.
 - [BREAKING CHANGE] - LightCouch classes moved to package com.cloudant.client.org.lightcouch.
   This should only have a visible impact for `CouchDbException` and its subclasses.

--- a/README.md
+++ b/README.md
@@ -38,13 +38,18 @@ dependencies {
 ```
 
 Alternately download the dependencies
-
-* [cloudant.jar](http://search.maven.org/remotecontent?filepath=com/cloudant/cloudant-client/)
-* [HttpClient 4.3.6](http://hc.apache.org/downloads.cgi)
-* [HttpCore 4.3.3](http://hc.apache.org/downloads.cgi)
-* [Commons Codec 1.6](http://commons.apache.org/codec/download_codec.cgi)
-* [Commons Logging 1.1.3](http://commons.apache.org/logging/download_logging.cgi)
-* [Gson 2.2.4](http://code.google.com/p/google-gson/downloads/list)
+* [1.x](https://github.com/cloudant/java-cloudant/tree/maintenance-1.2#installation-and-usage)
+    * [cloudant.jar](http://search.maven.org/remotecontent?filepath=com/cloudant/cloudant-client/)
+    * [HttpClient 4.3.6](http://hc.apache.org/downloads.cgi)
+    * [HttpCore 4.3.3](http://hc.apache.org/downloads.cgi)
+    * [Commons Codec 1.6](http://commons.apache.org/codec/download_codec.cgi)
+    * [Commons Logging 1.1.3](http://commons.apache.org/logging/download_logging.cgi)
+    * [Gson 2.2.4](http://code.google.com/p/google-gson/downloads/list)
+* Master branch (2.0 milestone)
+    * [cloudant.jar](http://search.maven.org/remotecontent?filepath=com/cloudant/cloudant-client/)
+    * [Commons Codec 1.6](http://commons.apache.org/codec/download_codec.cgi)
+    * [Commons IO 2.4](http://commons.apache.org/io/download_io.cgi)
+    * [Gson 2.2.4](http://code.google.com/p/google-gson/downloads/list)
 
 ### Getting Started
 
@@ -345,11 +350,9 @@ List<ReplicationHistory> histories = result.getHistories();
 This API enables extending Cloudant internal API by allowing a user-defined raw HTTP request to execute against a cloudant client.
 ~~~ java
 
-HttpHead head = new HttpHead(dbClient.getDBUri() + "doc-id");
-HttpResponse response = dbClient.executeRequest(head);
-String revision = response.getFirstHeader("ETAG").getValue();
-HttpClientUtils.closeQuietly(response);
-
+HttpConnection head = com.cloudant.http.Http.HEAD(new URL(db.getDBUri() + "doc-id"));
+HttpConnection response = client.executeRequest(head);
+String revision = response.getConnection().getHeaderField("ETAG");
 ~~~
 
 ### com.cloudant.client.api.CloudantClient.uuids()
@@ -922,7 +925,7 @@ CloudantClient cookieBasedClient = new
 ### Advanced Configuration
 
 #### ConnectOptions
-Besides the account and password options, you can add an optional `com.cloudant.client.api.model.ConnectOptions` value, which will initialize HttpClient (the underlying HTTP library) as you need it.
+Besides the account and password options, you can add an optional `com.cloudant.client.api.model.ConnectOptions` value to specify some advanced configuration options.
 
 ~~~ java
 ConnectOptions connectOptions = new ConnectOptions()

--- a/src/main/java/com/cloudant/client/api/CloudantClient.java
+++ b/src/main/java/com/cloudant/client/api/CloudantClient.java
@@ -137,10 +137,6 @@ public class CloudantClient {
 
     CouchDbClient couchDbClient;
 
-    private String accountName;
-    private String loginUsername;
-    private String password;
-
     /**
      * Constructs a new instance of this class and connects to the cloudant server with the
      * specified credentials
@@ -154,8 +150,6 @@ public class CloudantClient {
     public CloudantClient(String account, String loginUsername, String password) {
         super();
         Map<String, String> h = parseAccount(account);
-        this.loginUsername = loginUsername;
-        this.password = password;
 
         doInit(h.get("scheme"),
                 h.get("hostname"),
@@ -181,8 +175,6 @@ public class CloudantClient {
             connectOptions) {
         super();
         Map<String, String> h = parseAccount(account);
-        this.loginUsername = loginUsername;
-        this.password = password;
 
         doInit(h.get("scheme"),
                 h.get("hostname"),
@@ -436,22 +428,6 @@ public class CloudantClient {
 
     // Helper methods
 
-    String getLoginUsername() {
-        return loginUsername;
-    }
-
-    String getPassword() {
-        return password;
-    }
-
-
-    /**
-     * @return the accountName
-     */
-    String getAccountName() {
-        return accountName;
-    }
-
     /**
      * Performs a HTTP GET request.
      *
@@ -477,7 +453,6 @@ public class CloudantClient {
 
     private Map<String, String> parseAccount(String account) {
         assertNotEmpty(account, "accountName");
-        this.accountName = account;
         Map<String, String> h = new HashMap<String, String>();
         if (account.startsWith("http://") || account.startsWith("https://")) {
             // user is specifying a uri

--- a/src/main/java/com/cloudant/client/api/Search.java
+++ b/src/main/java/com/cloudant/client/api/Search.java
@@ -89,12 +89,14 @@ public class Search {
     private Integer limit;
     private boolean includeDocs = false;
     private String bookmark;
+    private CloudantClient client;
     private Database db;
     private URIBuilder uriBuilder;
 
 
-    Search(Database db, String searchIndexId) {
+    Search(CloudantClient client, Database db, String searchIndexId) {
         assertNotEmpty(searchIndexId, "searchIndexId");
+        this.client = client;
         this.db = db;
         String search = searchIndexId;
         if (searchIndexId.contains("/")) {
@@ -119,7 +121,7 @@ public class Search {
         URI uri = uriBuilder.build();
         HttpConnection get = Http.GET(uri);
         get.requestProperties.put("Accept", "application/json");
-        return db.executeRequest(get);
+        return client.couchDbClient.executeToInputStream(get);
     }
 
     /**

--- a/src/main/java/com/cloudant/client/internal/views/ViewRequester.java
+++ b/src/main/java/com/cloudant/client/internal/views/ViewRequester.java
@@ -31,7 +31,7 @@ class ViewRequester {
     static JsonObject executeRequestWithResponseAsJson(ViewQueryParameters parameters,
                                                        HttpConnection request) throws IOException {
         CloudantClient client = parameters.getClient();
-        InputStream response = client.executeRequest(request);
+        InputStream response = client.executeRequest(request).responseAsInputStream();
         return CouchDbUtil.getResponse(response, JsonObject.class, client.getGson());
     }
 }

--- a/src/main/java/com/cloudant/client/org/lightcouch/CouchDbClient.java
+++ b/src/main/java/com/cloudant/client/org/lightcouch/CouchDbClient.java
@@ -45,7 +45,6 @@ import java.net.URI;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.logging.Logger;
 
 
@@ -63,8 +62,6 @@ public class CouchDbClient {
     private URI baseURI;
 
     private Gson gson;
-
-    private Map<String, String> customHeaders;
 
     private List<HttpConnectionRequestInterceptor> requestInterceptors;
     private List<HttpConnectionResponseInterceptor> responseInterceptors;
@@ -401,44 +398,7 @@ public class CouchDbClient {
         return executeToInputStream(connection);
     }
 
-    /**
-     * Performs a HTTP POST request.
-     *
-     * @return Input stream with response
-     */
-    InputStream post(URI uri) {
-        return post(uri, null);
-    }
-
-
     // Helpers
-
-    /**
-     * Validates a HTTP response; on error cases logs status and throws relevant exceptions.
-     *
-     * @param response The HTTP response.
-     */
-    void validate(HttpConnection response) throws IOException {
-        final int code = response.getConnection().getResponseCode();
-        if (code == 200 || code == 201 || code == 202) { // success (ok | created | accepted)
-            return;
-        }
-        String reason = response.getConnection().getResponseMessage();
-        switch (code) {
-            case HttpURLConnection.HTTP_NOT_FOUND: {
-                throw new NoDocumentException(reason);
-            }
-            case HttpURLConnection.HTTP_CONFLICT: {
-                throw new DocumentConflictException(reason);
-            }
-            case HttpURLConnection.HTTP_PRECON_FAILED: {
-                throw new PreconditionFailedException(reason);
-            }
-            default: { // other errors: 400 | 401 | 500 etc.
-                throw new CouchDbException(reason);
-            }
-        }
-    }
 
     /**
      * Sets a {@link GsonBuilder} to create {@link Gson} instance.


### PR DESCRIPTION
*What*
Update the `executeRequest` API for the HTTP replacement

*How*
Use `HttpConnection` instead of `InputStream` so that, for example, status codes and headers can be accessed for custom requests.
Updated the documentation for the new HTTP replacement.

*Testing*
No new tests, existing tests continue to pass.

reviewer @emlaver 
reviewer @tomblench 