### PR TITLE
117 url encode session

### DIFF
--- a/src/main/java/com/cloudant/client/api/CloudantClient.java
+++ b/src/main/java/com/cloudant/client/api/CloudantClient.java
@@ -37,7 +37,7 @@ import com.cloudant.client.org.lightcouch.CouchDbProperties;
 import com.cloudant.client.org.lightcouch.Replication;
 import com.cloudant.client.org.lightcouch.Replicator;
 import com.cloudant.client.org.lightcouch.Response;
-import com.cloudant.http.CookieInterceptor;
+import com.cloudant.http.interceptors.CookieInterceptor;
 import com.cloudant.http.HttpConnection;
 import com.cloudant.http.interceptors.ProxyAuthInterceptor;
 import com.cloudant.http.interceptors.SSLCustomizerInterceptor;

--- a/src/main/java/com/cloudant/http/HttpConnectionRequestInterceptor.java
+++ b/src/main/java/com/cloudant/http/HttpConnectionRequestInterceptor.java
@@ -17,6 +17,8 @@ package com.cloudant.http;
  * Created by tomblench on 30/03/15.
  */
 
+import com.cloudant.http.interceptors.CookieInterceptor;
+
 import java.net.HttpURLConnection;
 
 /**

--- a/src/test/java/com/cloudant/tests/util/Utils.java
+++ b/src/test/java/com/cloudant/tests/util/Utils.java
@@ -18,6 +18,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertEquals;
 
 import com.cloudant.client.api.CloudantClient;
 import com.cloudant.client.api.Database;
@@ -189,5 +190,22 @@ public class Utils {
             }
         }
         throw new Exception("Retries exceeded");
+    }
+
+    /**
+     * Test utility that splits a string and asserts that the expected number of separators were
+     * found. Expected number is for separators, but the assertion is done on parts, so this
+     * method is not safe for strings that end in their separator sequence.
+     *
+     * @param toSplit        the string to split
+     * @param splitOn        the separator string
+     * @param expectedNumber the expected number of separators
+     * @return
+     */
+    public static String[] splitAndAssert(String toSplit, String splitOn, int expectedNumber) {
+        String[] parts = toSplit.split(splitOn);
+        assertEquals("There should be " + expectedNumber + " instances of " + splitOn + " in the " +
+                "content", expectedNumber + 1, parts.length);
+        return parts;
     }
 }


### PR DESCRIPTION
*What*
Fixes #117 - encode the username and password of the `_session` request.

*How*
Apply `x-www-form-urlencoded` encoding to the user and password fields.

*Testing*
Added new test to check encoding.

reviewer @emlaver 
reviewer @rhyshort 