### PR TITLE
122 doc updates

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,10 +19,9 @@
   This should only have a visible impact for `CouchDbException` and its subclasses.
 - [BREAKING CHANGE] Removed DbDesign class and replaced with DesignDocumentManager.
   If you were using the `getFromDesk` method, convert your design document directory to javascript
-  files and use `DesignDocumentManager.fromFile(File)` or
-  `DesignDocumentManager.fromDirectory(File)`.
+  files and use `DesignDocumentManager.fromFile(File)` or `DesignDocumentManager.fromDirectory(File)`.
   More information is available in the javadoc, including usage for de-serializing design document
-  javascript files to DesignDocument objects.
+  javascript files to `DesignDocument` objects.
 - [FIX] Use the default port for the protocol when a client instance is created from a URL without
   specifying a port.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 # Unreleased
+- [NEW] `DesignDocument.MapReduce` now has a setter for the `dbcopy` field.
 - [NEW] Requests for the `_all_docs` endpoint are made via `Database#getAllDocsRequestBuilder()`
   instead of using a view.
 - [NEW] Introduced new view query API. More information is available in the javadoc,
@@ -7,9 +8,12 @@
   For example, if you were using the `InputStream` directly for streaming API parsing with an alternative
   JSON library we might be able to make this easier by handling the streams and providing a callback.
 - [NEW] Optional OkHttp dependency for per CloudantClient instance connection pooling.
+- [BREAKING CHANGE] Removed `Database.batch(Object)` method.
 - [BREAKING CHANGE] JVM `http.maxConnections` configured pool is used by default for connection pooling.
 - [BREAKING CHANGE] Removed Apache HttpClient dependency. API methods that used HttpClient classes
   (e.g. `executeRequest`) now use `HttpConnection` instead.
+- [BREAKING CHANGE] `CloudantClient` public constructors and `ConnectionOptions` have been removed.
+  `'CloudantClient` instances are now created and have options configured using `ClientBuilder`.
 - [BREAKING CHANGE] Removed version 1.x view query API.
 - [BREAKING CHANGE] LightCouch classes moved to package com.cloudant.client.org.lightcouch.
   This should only have a visible impact for `CouchDbException` and its subclasses.
@@ -19,6 +23,8 @@
   `DesignDocumentManager.fromDirectory(File)`.
   More information is available in the javadoc, including usage for de-serializing design document
   javascript files to DesignDocument objects.
+- [FIX] Use the default port for the protocol when a client instance is created from a URL without
+  specifying a port.
 
 # 1.2.3 (2015-10-14)
 - [NEW] Added Basic Auth for HTTP proxies. Configure via `ConnectOption#setProxyUser`

--- a/README.md
+++ b/README.md
@@ -1,36 +1,35 @@
 # Cloudant Java Client
 [![Build Status](https://travis-ci.org/cloudant/java-cloudant.svg?branch=master)](https://travis-ci.org/cloudant/java-cloudant)
 
-This README applies to the unreleased **master** branch.
-[**See the version 1.x README**](https://github.com/cloudant/java-cloudant/tree/maintenance-1.2).
+This is the official Cloudant library for Java.
 
-This is the official Cloudant library for Java
+This README applies to the **master** branch.
+[**See the version 1.x README**](https://github.com/cloudant/java-cloudant/tree/maintenance-1.2).
 
 * [Installation and Usage](#installation-and-usage)
 * [Getting Started](#getting-started)
-* [API Reference](#api-reference)
-* [Advanced Configuration](#advanced-configuration)
-  * [Connection Options](#connectoptions)
-  * [Custom GSON serialization](#custom-gson-serialization)
-  * [Resource Sharing](#resource-sharing)
-  * [J2EE](#j2ee)
+* [API Reference (javadoc)](http://www.javadoc.io/doc/com.cloudant/cloudant-client/)
+* [Related Documentation](#related-documentation)
 * [Development](#development)
-  * [Test Suite](#tests)
-  * [License](#license)
+    * [Contributing](CONTRIBUTING.md)
+    * [Test Suite](CONTRIBUTING.md#running-the-tests)
+    * [Using in Other Projects](#using-in-other-projects)
+    * [License](#license)
+    * [Issues](#issues)
 
 ## Installation and Usage
 
 Gradle:
 ```groovy
 dependencies {
-    compile group: 'com.cloudant', name: 'cloudant-client', version: '1.2.3'
+    compile group: 'com.cloudant', name: 'cloudant-client', version: '2.0.0'
 }
 ```
 
 Gradle with optional `okhttp-urlconnection` dependency:
 ```groovy
 dependencies {
-    compile group: 'com.cloudant', name: 'cloudant-client', version: '1.2.3'
+    compile group: 'com.cloudant', name: 'cloudant-client', version: '2.0.0'
     compile group: 'com.squareup.okhttp', name: 'okhttp-urlconnection', version: '2.5.0'
 }
 ```
@@ -40,7 +39,7 @@ Maven:
 <dependency>
   <groupId>com.cloudant</groupId>
   <artifactId>cloudant-client</artifactId>
-  <version>1.2.3</version>
+  <version>2.0.0</version>
 </dependency>
 ~~~
 
@@ -50,7 +49,7 @@ Maven with optional `okhttp-urlconnection` dependency:
 <dependency>
   <groupId>com.cloudant</groupId>
   <artifactId>cloudant-client</artifactId>
-  <version>1.2.3</version>
+  <version>2.0.0</version>
 </dependency>
 
 <dependency>
@@ -60,952 +59,102 @@ Maven with optional `okhttp-urlconnection` dependency:
 </dependency>
 ~~~
 
-Alternately download the dependencies
-* [1.x](https://github.com/cloudant/java-cloudant/tree/maintenance-1.2#installation-and-usage)
-    * [cloudant.jar](http://search.maven.org/remotecontent?filepath=com/cloudant/cloudant-client/)
-    * [HttpClient 4.3.6](http://hc.apache.org/downloads.cgi)
-    * [HttpCore 4.3.3](http://hc.apache.org/downloads.cgi)
-    * [Commons Codec 1.6](http://commons.apache.org/codec/download_codec.cgi)
-    * [Commons Logging 1.1.3](http://commons.apache.org/logging/download_logging.cgi)
-    * [Gson 2.2.4](http://code.google.com/p/google-gson/downloads/list)
-* Master branch (2.0 milestone)
-    * [cloudant.jar](http://search.maven.org/remotecontent?filepath=com/cloudant/cloudant-client/)
-    * [Commons Codec 1.6](http://commons.apache.org/codec/download_codec.cgi)
-    * [Commons IO 2.4](http://commons.apache.org/io/download_io.cgi)
-    * [Gson 2.2.4](http://code.google.com/p/google-gson/downloads/list)
-    * [OkHttp 2.5.0](http://square.github.io/okhttp/#download) (OPTIONAL - note: to use this dependency requires Java 1.7 minimum)
+Although Gradle or Maven dependency management is preferred it is also possible to download the dependencies individually to add to a classpath:
+* [cloudant.jar](http://search.maven.org/remotecontent?filepath=com/cloudant/cloudant-client/)
+* [Commons Codec 1.6](http://commons.apache.org/codec/download_codec.cgi)
+* [Commons IO 2.4](http://commons.apache.org/io/download_io.cgi)
+* [Gson 2.2.4](http://code.google.com/p/google-gson/downloads/list)
+* [OkHttp 2.5.0](http://square.github.io/okhttp/#download) (OPTIONAL - note: to use this dependency requires Java 1.7 minimum)
 
-### Getting Started
+## Getting Started
 
-Now it's time to begin doing real work with Cloudant and Java. For working code samples of any of the API's please go to our Test suite.
+This section contains a simple example of creating a `com.cloudant.client.api.CloudantClient` instance and interacting with Cloudant.
 
-Initialize your Cloudant connection by constructing a *com.cloudant.client.api.CloudantClient* . If you are connecting the managed service on cloudant.com, supply the *account* to connect to, *api key* ( if using an API key, otherwise pass in the account for this parameter also) and *password*. If you are connecting to Cloudant Local supply its URL, the *userName or Apikey* and  *password*
+For further examples and more advanced use cases [see the javadoc](http://www.javadoc.io/doc/com.cloudant/cloudant-client/) for the version you are using.
+The source code for the tests in this github project also contains many examples of API usage.
 
-Connecting to the managed service at cloudant.com example
 ~~~ java
-String password = System.getProperty("cloudant_password");
-CloudantClient client = new CloudantClient("mdb","mdb",password);
+// Create a new CloudantClient instance for account endpoint example.cloudant.com
+CloudantClient client = ClientBuilder.account("example")
+                                     .username()
+                                     .password()
+                                     .build();
 
-System.out.println("Connected to Cloudant");
+// Note: for Cloudant Local use:
+// ClientBuilder.url(new URL("yourCloudantLocalAddress.example"))
+//              .username()
+//              .password()
+//              .build();
+
+// Show the server version
 System.out.println("Server Version: " + client.serverVersion());
 
+// Get a List of all the databases this Cloudant account
 List<String> databases = client.getAllDbs();
 System.out.println("All my databases : ");
 for ( String db : databases ) {
 	System.out.println(db);
 }
-~~~
 
-Connecting to Cloudant Local example
-~~~ java
-String password = System.getProperty("cloudant_password");
-CloudantClient client = new CloudantClient("https://9.149.23.12","mdb",password);
+// Working with data
 
-System.out.println("Connected to Cloudant");
-System.out.println("Server Version: " + client.serverVersion());
-
-List<String> databases = client.getAllDbs();
-System.out.println("All my databases : ");
-for ( String db : databases ) {
-	System.out.println(db);
-}
-~~~
-
-Output:
-
-    Connected to cloudant
-    Server version = 1.0.2
-    All my databases: example_db, jasons_stuff, scores
-
-When you instantiate a `CloudantClient`, you are authenticating with cloudant using the [cookie authentication](http://guide.couchdb.org/editions/1/en/security.html#cookies) functionality.
-
-* If you instantiate the `CloudantClient` with an ID and password then the cookie is automatically renewed when it expires.
-* Alternatively, if you instantiate by using an existing auth cookie string then the `CloudantClient` instance will be unable to make successful requests after that cookie has expired. To continue making requests you will need to create a new `CloudantClient` instance.
-
-## Complete example
-
-Here is simple but complete example of working with data:
-
-~~~ java
-
-String password = System.getProperty("cloudant_password");
-CloudantClient client = new CloudantClient("mdb","mdb",password);
-
-// Clean up the database we created previously.
-client.deleteDB("alice");
+// Delete a database we created previously.
+client.deleteDB("example_db");
 
 // Create a new database.
-client.createDB("alice");
+client.createDB("example_db");
 
-// specify the database we are going to use
-Database db = client.database("alice", false);
+// Get a Database instance to interact with, but don't create it if it doesn't already exist
+Database db = client.database("example_db", false);
 
-// and insert a document in it
-db.save(new Rabbit(true));
-System.out.println("You have inserted the Rabbit");
-Rabbit r = db.find(Rabbit.class,"rabbit");
-System.out.println(r);
+// A Java type that can be serialized to JSON
+public class ExampleDocument {
+  private String _id = "example_id";
+  private String _rev = null;
+  private boolean isExample;
 
-   ...
-public class Rabbit {
-	private boolean crazy;
-	private String _id = "rabbit";
+  public ExampleDocument(boolean isExample) {
+    this.isExample = isExample;
+  }
 
-	public Rabbit(boolean isCrazy) {
-		crazy = isCrazy;
-	}
-
-	public String toString() {
-		return " { id : " + _id + ", rev : " + _rev + ", crazy : " + crazy + "}";
-	}
+  public String toString() {
+    return "{ id: " + _id + ",\nrev: " + _rev + ",\nisExample: " + isExample + "\n}";
+  }
 }
-~~~
 
-If you run this example, you will see:
+// Create an ExampleDocument and save it in the database
+db.save(new ExampleDocument(true));
+System.out.println("You have inserted the document");
 
-    you have inserted the rabbit.
-    { crazy: true,
-      id: rabbit,
-      rev: 1-6e4cb465d49c0368ac3946506d26335d
-    }
-
-## API Reference
-
-- [Initialization](#initialization)
-- [Authorization](#authorization)
-- [Server Functions](#server-functions)
-	- [CloudantClient.createDB(name)](#comcloudantclientapicloudantclientcreatedbname)
-	- [CloudantClient.database(name, create)](#comcloudantclientapicloudantclientdatabasenamecreate)
-	- [CloudantClient.deleteDB(name)](#comcloudantclientapicloudantclientdeletedbname)
-	- [CloudantClient.getAllDbs()](#comcloudantclientapicloudantclientgetalldbs)
-	- [CloudantClient.getMembership()](#comcloudantclientapicloudantclientgetmembership)
-	- [CloudantClient.getActiveTasks()](#comcloudantclientapicloudantclientgetactivetasks)
-	- [CloudantClient.replicator()](#comcloudantclientapicloudantclientreplicator)
-	- [CloudantClient.replication()](#comcloudantclientapicloudantclientreplication )
-	- [CloudantClient.executeRequest()](#comcloudantclientapicloudantclientexecuterequest)
-	- [CloudantClient.uuids(number)](#comcloudantclientapicloudantclientuuids)
-	- [CloudantClient.getServerVersion()](#comcloudantclientapicloudantclientgetserverversion)
-- [Database Functions](#database-functions)
-	- [Database.changes()](#comcloudantclientapidatabasechanges)
-	- [Database.getShard(documentId)](#comcloudantclientapidatabasegetsharddocumentid)
-	- [Database.info()](#comcloudantclientapidatabasedatabaseinfo)
-	- [Database.setPermissions()](#comcloudantclientapidatabasesetpermissions)
-	- [Database.ensureFullCommit()](#comcloudantclientapidatabaseensurefullcommit)
-- [Document Functions](#document-functions)
-	- [Database.save(object)](#comcloudantclientapidatabasesaveobject)
-	- [Database.save(object,writeQuorum)](#comcloudantclientapidatabasesaveobjectwritequorum)
-	- [Database.post(object)](#comcloudantclientapidatabasepostobject)
-	- [Database.post(object,writeQuorum)](#comcloudantclientapidatabasepostobjectwritequorum)
-	- [Database.saveAttachment(inputStream,name,contentType)](#comcloudantclientapidatabasesaveattachmentinputstreamnamecontenttype)
-	- [Database.saveAttachment(inputStream,name,contentType,docId,docRev)](#comcloudantclientapidatabasesaveattachmentinputstreamnamecontenttypedociddocrev)
-	- [Database.batch(obect)](#comcloudantclientapidatabasebatchobject)
-	- [Database.find(doc-id)](#comcloudantclientapidatabasefinddoc-id)
-	- [Database.find(doc-id,rev)](#comcloudantclientapidatabasefinddoc-idrev)
-	- [Database.find(class,doc-id)](#comcloudantclientapidatabasefindclassdoc-id)
-	- [Database.find(class,doc-id,rev-id)](#comcloudantclientapidatabasefindclassdoc-idrev-id)
-	- [Database.find(class,doc-id,params)](#comcloudantclientapidatabasefindclassdoc-idparams)
-	- [Database.findAny(class,uri)](#comcloudantclientapidatabasefindanyclassuri)
-	- [Database.contains(doc-id)](#comcloudantclientapidatabasecontainsdoc-id)
-	- [Database.update(object)](#comcloudantclientapidatabaseupdateobject)
-	- [Database.update(object,writeQuorum)](#comcloudantclientapidatabaseupdateobjectwritequorum)
-	- [Database.remove(object)](#comcloudantclientapidatabaseremoveobject)
-	- [Database.remove(doc-id,rev-id)](#comcloudantclientapidatabaseremovedoc-idrev-id)
-	- [Database.invokeUpdateHandler(updateHandlerUri,docId,query)](#comcloudantclientapidatabaseinvokeupdatehandlerupdatehandleruridocidquery)
-	- [Database.invokeUpdateHandler(updateHandlerUri,docId,params)](#comcloudantclientapidatabaseinvokeupdatehandlerupdatehandleruridocidparams)
-- [Bulk Documents](#bulk-documents)
-	- [Insert/Update docs ](#insertupdate-docs )
-	- [Fetch All/multiple documents](#fetch-all/multiple-documents)
-- [Attachment Functions](#attachment-functions)
-	- [Inline attachment](#inline-attachment)
-	- [Standalone Attachments](#standalone-attachments)
-- [Design Document Functions](#design-document-functions)
-	- [retrieving the design doc from server](#retrieving-the-design-doc-from-server)
-  - [Creating a View (Map-Reduce Index)](#creating-a-view-map-reduce-index)
-- [Query a View](#query-a-view)
-- [Cloudant Query](#cloudant-query)
-- [Cloudant Search](#cloudant-search)
-- [Cookie Authentication](#cookie-authentication)
-- [Advanced Configuration](#advanced-configuration)
-- [tests](#tests)
-
-### Initialization
-
-When using the managed service at cloudant.com, initialize your Cloudant connection by constructing a `CloudantClient` supplying the `account` to connect to, `api key` ( if using an API key, otherwise pass in the account for this parameter also) and `password`  (And see the [security note](#security-note) about placing your password into your source code.
-
-~~~ java
-String password = System.getProperty("cloudant_password");
-CloudantClient client = new CloudantClient("mdb","mdb",password);
-
-System.out.println("Connected to Cloudant");
-
-  /*
-   * The rest of my code goes here.
-   */
-})
-~~~
-
-When using Cloudant Local, initialize your Cloudant connection by constructing a `CloudantClient` supplying the URL of the Cloudant Local along with `userName or Apikey` and  `password` (And see the [security note](#security-note) about placing your password into your source code.
-
-~~~ java
-String password = System.getProperty("cloudant_password");
-CloudantClient client = new CloudantClient("https://9.123.45.64","mdb",password);
-
-System.out.println("Connected to Cloudant");
-
-  /*
-   * The rest of my code goes here.
-   */
-})
-~~~
-
-## Authorization
-
-This feature interfaces with the Cloudant authorization API
-
-Use the authorization feature to generate new API keys to access your data. An API key is basically a username/password pair for granting others access to your data, without giving them the keys to the castle.
-
-Generate an API key.
-
-~~~ java
-ApiKey key = client.generateApiKey();
-System.out.println(key);
-
+// Get an ExampleDocument out of the database and deserialize the JSON into a Java type
+ExampleDocument doc = db.find(ExampleDocument.class,"example_id");
+System.out.println(doc);
 ~~~
 
 Output:
-
-    key: isdaingialkyciffestontsk password: XQiDHmwnkUu4tknHIjjs2P64
-
-Next, set access roles for this API key:
-
-~~~ java
-// Set read-only access for this key.
-Database db = client.database("alice", false);
-db.setPermissions(key.getKey(), EnumSet.<Permissions>of(Permissions._reader));
-System.out.println(key.getKey() + " now has read-only access to alice")
-
-~~~
-
-## Server Functions
-
-Once CloudantClient is initialized without errors, the returned object is representing your connection to the server. To work with databases, use these database functions. (To work with data *inside* the databases, see below.)
-
-### com.cloudant.client.api.CloudantClient.createDB(name)
-
-Create a Cloudant database with the given `name`.
-
-~~~ java
-client.createDB("alice");
-
-~~~
-
-### com.cloudant.client.api.CloudantClient.database(name,create)
-
-Get a Database reference
-
-~~~ java
-Database db = client.database("alice", false);
-System.out.println("Database Name:" + db.info().getDbName() );
-
-~~~
-
-### com.cloudant.client.api.CloudantClient.deleteDB(name)
-
-Destroy database named `name`.
-
-~~~ java
-client.deleteDB("alice");
-
-~~~
-
-### com.cloudant.client.api.CloudantClient.getAllDbs()
-
-List all the databases in Cloudant server.
-
-~~~ java
-List<String> databases = client.getAllDbs();
-System.out.println("All my databases : ");
-for ( String db : databases ) {
-	System.out.println(db);
+```
+Server version = 1.0.2
+All my databases: example_db, stuff, scores
+You have inserted the document.
+{ id: example_id,
+  rev: 1-6e4cb465d49c0368ac3946506d26335d,
+  isExample: true
 }
-
-~~~
-
-### com.cloudant.client.api.CloudantClient.getMembership()
-`getMembership()` returns the list of nodes in a cluster
-
-~~~ java
-	Membership membership = client.getMembership();
-~~~
-
-### com.cloudant.client.api.CloudantClient.getActiveTasks()
-`getActiveTasks()` returns all active tasks
-
-~~~ java
-	List<Task> tasks = client.getActiveTasks();
-~~~
-
-### com.cloudant.client.api.CloudantClient.replicator()
-
-`replicator()` provides access to Cloudant `com.cloudant.client.api.Replicator` APIs
-
-~~~ java
-Replicator replicator = client.replicator()
-~~~
-
-### com.cloudant.client.api.CloudantClient.replication()
-
-Replicates `source` to `target`. `target`
-must exist, add `createTarget(true)` to create it prior to
-replication.
-
-~~~ java
-ReplicationResult result = client.replication()
-					.createTarget(true)
-					.source(db1.getDBUri().toString())
-					.target(db2.getDBUri().toString())
-					.trigger();
-List<ReplicationHistory> histories = result.getHistories();
-
-~~~
-
-### com.cloudant.client.api.CloudantClient.executeRequest()
-
-This API enables extending Cloudant internal API by allowing a user-defined raw HTTP request to execute against a cloudant client.
-~~~ java
-
-HttpConnection head = com.cloudant.http.Http.HEAD(new URL(db.getDBUri() + "doc-id"));
-HttpConnection response = client.executeRequest(head);
-String revision = response.getConnection().getHeaderField("ETAG");
-~~~
-
-### com.cloudant.client.api.CloudantClient.uuids()
-`uuids()` request cloudant to send a list of UUIDs.
-
-~~~ java
-	List<String> uuids = client.uuids(count);
-~~~
-
-### com.cloudant.client.api.CloudantClient.getServerVersion()
-`getServerVersion()` returns Cloudant Server version.
-
-~~~ java
-	String serverVersion = client.serverVersion();
-~~~
-
-## Database Functions
-
-### com.cloudant.client.api.Database.changes()
-
-`com.cloudant.client.api.Database.changes().getChanges()` asks for the changes feed on the specified database. `includeDocs(true)` and `limit(1)` sets additional properties to the query string.
-
-~~~ java
-ChangesResult changes = db.changes()
-				.includeDocs(true)
-				.limit(1)
-				.getChanges();
-
-List<ChangesResult.Row> rows = changes.getResults();
-
-for (Row row : rows) {
-	List<ChangesResult.Row.Rev> revs = row.getChanges();
-	String docId = row.getId();
-	JsonObject doc = row.getDoc();
-}
-
-~~~
-
-`com.cloudant.client.api.Database.changes().continuousChanges()` asks for the continuous changes feed on the specified database. `since(since)`, `includeDocs(true)` and `limit(1)` sets additional properties to the query string.
-
-~~~ java
-CouchDbInfo dbInfo = db.info();
-String since = dbInfo.getUpdateSeq();
-Changes changes = db.changes()
-				.includeDocs(true)
-				.since(since)
-				.heartBeat(30000)
-				.continuousChanges();
-
-while (changes.hasNext()) {
-	ChangesResult.Row feed = changes.next();
-	final JsonObject feedObject = feed.getDoc();
-	final String docId = feed.getId();
-	changes.stop();
-}
-~~~
-
-### com.cloudant.client.api.Database.getShard(documentId)
-`getShard(documentId)` gets info about the shard this document belongs to .
-
-~~~ java
-	Shard s = db.getShard("snipe");
-~~~
-
-`getShards()`get info about the shards in the database.
-
-~~~ java
-	List<Shard> shards = db.getShards();
-~~~
-
-### com.cloudant.client.api.Database.Database.info()
-
-`.info()` returns the DB info for this db.
-
-~~~ java
-	DbInfo dbInfo = db.info();
-~~~
-
-### com.cloudant.client.api.Database.setPermissions()
-
-`.setPermissions()` sets the permissions for a user/apiKey on the DB.
-~~~ java
-ApiKey key = client.generateApiKey();
-EnumSet<Permissions> p = EnumSet.<Permissions>of( Permissions._writer, Permissions._reader);
-db.setPermissions(key.getKey(), p);
-~~~
-
-### com.cloudant.client.api.Database.ensureFullCommit()
-Requests the database commits any recent changes to disk
-
-~~~ java
-db.ensureFullCommit();
-~~~
-
-## Document Functions
-
-Once you run `com.cloudant.client.api.CloudantClient.database(name,create)`, use the returned object to work with documents in the database.
-
-### com.cloudant.client.api.Database.save(object)
-Saves an object in the database, using HTTP PUT request.If the object doesn't have an `_id` value, we will assign a `UUID` as the document id.
-
-~~~ java
-Database db = dbClient.database("alice", true);
-JsonObject json = new JsonObject();
-json.addProperty("_id", "test-doc-id-2");
-json.add("json-array", new JsonArray());
-Response response =db.save(json);
-
-~~~
-
-Insert `pojo` in the database. The parameter `object` can be a pojo.
-
-~~~ java
-Database db = dbClient.database("alice", true);
-Foo foo = new Foo();
-Response response = db.save(foo);
-
-~~~
-
-Insert `map` in the database. The parameter `object`  can be a `map` having key value presentation of a document.
-
-~~~ java
-Database db = dbClient.database("alice", true);
-Map<String, Object> map = new HashMap<>();
-map.put("_id", "test-doc-id-1");
-map.put("title", "test-doc");
-Response response =db.save(map);
-
-~~~
-
-
-### com.cloudant.client.api.Database.save(object,writeQuorum)
-Saves an object in the database, using HTTP PUT request, with specified write quorum .If the object doesn't have an `_id` value, we will assign a `UUID` as the document id.
-~~~ java
-Database db = dbClient.database("alice", true);
-Response response = db.save(new Animal("human"), 2);
-
-~~~
-
-### com.cloudant.client.api.Database.post(object)
-Saves an object in the database using HTTP POST request.The database will be responsible for generating the document id.
-
-~~~ java
-Database db = dbClient.database("alice", true);
-Response response = db.post(new Foo());
-
-~~~
-
-### com.cloudant.client.api.Database.post(object,writeQuorum)
-Saves an object in the database using HTTP POST request with specificied write quorum.The database will be responsible for generating the document id.
-
-~~~ java
-Database db = dbClient.database("alice", true);
-db.post(new Animal("test"), 2);
-Animal h = db.find(Animal.class, "test",
-				new com.cloudant.client.api.model.Params().readQuorum(3));
-~~~
-
-### com.cloudant.client.api.Database.saveAttachment(inputStream,name,contentType)
- Saves an attachment to a new document with a generated UUID as the document id.
-
-~~~ java
-byte[] bytesToDB = "binary data".getBytes();
-ByteArrayInputStream bytesIn = new ByteArrayInputStream(bytesToDB);
-Response response = db.saveAttachment(bytesIn, "foo.txt", "text/plain");
-~~~
-
-
-### com.cloudant.client.api.Database.saveAttachment(inputStream,name,contentType,docId,docRev)
-Saves an attachment to an existing document given both a document id and revision, or save to a new document given only the id, and rev as null.
-
-~~~ java
-byte[] bytesToDB = "binary data".getBytes();
-ByteArrayInputStream bytesIn = new ByteArrayInputStream(bytesToDB);
-Response response = db.saveAttachment(bytesIn, "foo.txt", "text/plain","abcd12345",null);
-~~~
-
-### com.cloudant.client.api.Database.batch(object)
-Saves a document with batch. You can write documents to the database at a higher rate by using the batch option. This collects document writes together in memory (on a user-by-user basis) before they are committed to disk. This increases the risk of the documents not being stored in the event of a failure, since the documents are not written to disk immediately.
-
-~~~ java
-Database db = dbClient.database("alice", true);
-db.batch(new Foo());
-
-~~~
-
-### com.cloudant.client.api.Database.find(doc-id)
-Finds a document based on the provided `doc-id` and return the result as `InputStream`. Make sure you close the stream when done, else you could lock up the client easily
-
-~~~ java
-Database db = dbClient.database("alice", true);
-Response response = db.save(new Foo());
-InputStream inputStream = db.find(response.getId());
-
-// do stuff and finally dont forget to close the stream
-inputStream.close();
-
-~~~
-
-### com.cloudant.client.api.Database.find(doc-id,rev)
-Finds a document based on the provided `doc-id` and `rev`,return the result as `InputStream`. Make sure you close the stream when done, else you could lock up the client easily
-
-~~~ java
-Database db = dbClient.database("alice", true);
-Response response = db.save(new Foo());
-InputStream inputStream = db.find(response.getId(),response.getRev());
-
-// do stuff and finally dont forget to close the stream
-inputStream.close();
-~~~
-### com.cloudant.client.api.Database.find(class,doc-id)
-
-Retrieve the pojo from database by providing `doc_id`  .
-
-~~~ java
-Database db = dbClient.database("alice", true);
-Foo foo = db.find(Foo.class, "doc-id");
-
-~~~
-
-### com.cloudant.client.api.Database.find(class,doc-id,rev-id)
-Retrieve the pojo from database by providing `doc_id`and `rev-id`  .
-
-~~~ java
-Database db = dbClient.database("alice", true);
-Foo foo = db.find(Foo.class, "doc-id", "rev-id");
-
-~~~
-
-### com.cloudant.client.api.Database.find(class,doc-id,params)
-Finds an Object of the specified type by providing `doc_id`.Extra query parameters can be specified via `params` argument
-
-~~~ java
-Database db = dbClient.database("alice", true);
-Response response = db.save(new Foo());
-Foo foo = db.find(Foo.class, response.getId(), new Params().revsInfo());
-
-~~~
-
-### com.cloudant.client.api.Database.findAny(class,uri)
-This method finds any document given a URI.The URI must be URI-encoded.
-
-~~~ java
-Database db = dbClient.database("alice", true);
-Foo foo = db.findAny(Foo.class,
-				"https://mdb.cloudant.com/alice/03c6a4619b9e42d68db0e592757747fe");
-~~~
-
-### com.cloudant.client.api.Database.contains(doc-id)
-returns true if the document exists with given `doc-id`
-
-~~~ java
-
-Database db = dbClient.database("alice", true);
-boolean found = db.contains("doc-id");
-~~~
-
-### com.cloudant.client.api.Database.update(object)
-Updates an object in the database, the object must have the correct `_id` and `_rev` values.
-
-~~~ java
-Database db = dbClient.database("alice", true);
-String idWithSlash = "a/" + generateUUID();
-Response response = db.save(new Bar(idWithSlash));
-
-Bar bar = db.find(Bar.class, response.getId());
-Response responseUpdate = db.update(bar);
-~~~
-
-### com.cloudant.client.api.Database.update(object,writeQuorum)
-Updates an object in the database, the object must have the correct `_id` and `_rev` values. The second argument is the write quorum for the update.
-
-~~~ java
-db.save(new Animal("human"), 2);
-Animal h = db.find(Animal.class, "human",
-				new com.cloudant.client.api.model.Params().readQuorum(2));
-db.update(h.setClass("inhuman"), 2);
-
-~~~
-
-
-### com.cloudant.client.api.Database.remove(object)
-
-The API removes the `object` from database. The object should contain `_id` and `_rev` .
-
-~~~ java
-
-Database db = dbClient.database("alice", true);
-Response response = db.remove(foo);
-~~~
-
-### com.cloudant.client.api.Database.remove(doc-id,rev-id)
-~~~ java
-
-Database db = dbClient.database("alice", true);
-Response response = db.remove("doc-id", "doc-rev");
-~~~
-
-### com.cloudant.client.api.Database.invokeUpdateHandler(updateHandlerUri,docId,query)
-Invokes an Update Handler.Use this method in particular when the docId contain special characters such as slashes (/). The `updateHandlerUri` should be in the format: `designDoc/update1`.
-~~~ java
-final String oldValue = "foo";
-final String newValue = "foo bar";
-Response response = db.save(new Foo(null, oldValue));
-String query = "field=title&value=" + newValue;
-String output = db.invokeUpdateHandler("example/example_update", response.getId(), query);
-~~~
-
-### com.cloudant.client.api.Database.invokeUpdateHandler(updateHandlerUri,docId,params)
-This method can be used if the query is generated using `Params` API.
-
-~~~ java
-final String oldValue = "foo";
-final String newValue = "foo bar";
-Response response = db.save(new Foo(null, oldValue));
-Params params = new Params()
-				.addParam("field", "title")
-				.addParam("value", newValue);
-String output = db.invokeUpdateHandler("example/example_update", response.getId(), params);
-~~~
-
-## Bulk Documents
-
-Bulk documents API performs two operations: Modify & Fetch for bulk documents.
-
-### Insert/Update docs
-
-~~~ java
-
-List<Object> newDocs = new ArrayList<Object>();
-newDocs.add(new Foo());
-newDocs.add(new JsonObject());
-List<Response> responses = db.bulk(newDocs);
-~~~
-
-### Fetch all/multiple documents
-
-List all the doc IDs in the database.
-
-~~~ java
-
-List<String> allDocIds = db.getAllDocsRequestBuilder().build()
-                          .getRepsonse().getDocIds();
-
-~~~
-
-Fetch all the docs in the database.
-
-~~~ java
-
-List<Foo> allFoos = db.getAllDocsRequestBuilder().includeDocs(true).build()
-                          .getRepsonse().getDocsAs(Foo.class);
-
-~~~
-
-Fetch multiple documents specified by docID's in the database .
-~~~ java
-
-String[] docIds = new String[]{"doc-id-1", "doc-id-2"};
-List<Foo> foosWithIds = db.getAllDocsRequestBuilder().keys(docIds).includeDocs(true)
-                          .build().getRepsonse().getDocsAs(Foo.class);
-
-~~~
-
-
-## Attachment Functions
-
-### Inline attachment
- com.cloudant.client.api.model.Attachment represents an inline attachment enclosed in a document.
-
-The base64 data of an attachment may be encoded utilizing the included dependency on Apache Codec Base64.encodeBase64String(bytes).
-
-Model classes that extend com.cloudant.client.api.model.Document inherit the support for inline attachments.
-~~~ java
-
-Attachment attachment = new Attachment();
-attachment.setData(Base64.encodeBase64String("attachment test string".getBytes()));
-attachment.setContentType("text/plain");
-Foo foo = new Foo(); // Foo extends Document
-foo.addAttachment("attachment.txt", attachment);
-db.save(foo);
-~~~
-
-To retrieve the base64 data of an attachment, include a parameter to the find()
-
-~~~ java
-
-Foo foo = db.find(Foo.class, "doc-id", new Params().attachments());
-String attachmentData = foo.getAttachments().get("attachment.txt").getData();
-~~~
-
-### Standalone Attachments
-Standalone attachments could be saved to an existing, or to a new document. The attachment data is provided as `InputStream`
-
-~~~ java
-
-byte[] bytesToDB = "binary attachment data".getBytes();
-ByteArrayInputStream bytesIn = new ByteArrayInputStream(bytesToDB);
-Response response = db.saveAttachment(bytesIn, "foo.txt", "text/plain");
-InputStream in = db.find( "doc_id/foo.txt");
-~~~
-
-## Design Document Functions
-
-These functions are for working with views and design documents, including querying the database using map-reduce views, [Cloudant Search](#cloudant-search), and [Cloudant Query](#cloudant-query).
-
-### retrieving the design doc from server
-call getFromDb(design-doc) to retrieve the server copy .
-~~~ java
-
-DesignDocument designDoc = db.getDesignDocumentManager().getFromDb("_design/example");
-~~~
-
-### Creating a View (Map-Reduce Index)
-
-To create a view, upload a design document containing the index:
-
-```java
-// Uploads the design document with view index:
-// {
-//   "_id": "_design/name",
-//   "views": {
-//     "view1": {
-//       "map":"function(doc){emit(doc.field, 1)}",
-//       "reduce": "function(key, value, rereduce){return sum(values)}"
-//     }
-//   }
-// }
-
-Map<String, Object> view1 = new HashMap<>();
-view1.put("map", "function(doc){emit(doc.field, 1)}");
-view1.put("reduce", "function(key, value, rereduce){return sum(values)}");
-
-Map<String, Object> views = new HashMap<>();
-views.put("view1", view1);
-
-Map<String, Object> view_ddoc = new HashMap<>();
-view_ddoc.put("_id", "_design/name");
-view_ddoc.put("views", views);
-
-db.save(view_ddoc);
 ```
 
-Take a look at the [Cloudant Design Documents documentation](https://docs.cloudant.com/design_documents.html) for possible parameters and more information on show functions.
+## Related documentation
+* [Cloudant docs](http://docs.cloudant.com/)
+* [Cloudant for developers](https://cloudant.com/for-developers/)
 
-## Query a View
+## Development
 
-Refer to the [javadoc for the com.cloudant.client.api.views package](http://www.javadoc.io/doc/com.cloudant/cloudant-client/) for information about and examples of querying a view.
+For information about contributing, building, and running tests see the [CONTRIBUTING.md](CONTRIBUTING.md).
 
-## Cloudant Query
+### Using in Other Projects
 
-This feature interfaces with Cloudant's query functionality. See the [Cloudant Query documentation][query] for details.
+The preferred approach for using java-cloudant in other projects is to use the Gradle or Maven dependency as described above.
 
-when working with a database (as opposed to the root server), call the `.database()` method.
-
-~~~ java
-
-Database db = dbClient.database("movies-demo", false);
-~~~
-
-To see all the indexes in a database, call the database `.listIndices()` method .
-
-~~~ java
-
-List<Index> indices = db.listIndices();
-~~~
-
-To create an index, use  `.createIndex()` method
-
-~~~ java
-
-db.createIndex("Person_name", "Person_name", null,
-				new IndexField[]{
-					new IndexField("Person_name",SortOrder.asc),
-					new IndexField("Movie_year",SortOrder.asc)});
-db.createIndex("Movie_year", "Movie_year", null,
-				new IndexField[]{
-				       new IndexField("Movie_year",SortOrder.asc)});
-~~~
-
-
-
-To query using the index, use the `.findByIndex()` method.
-
-~~~ java
-
-List<Movie> movies = db.findByIndex("\"selector\": {
-                     \"Movie_year\": {\"$gt\": 1960}, \"Person_name\": \"Alec Guinness\"
-                     }",
-					Movie.class,
-					new FindByIndexOptions()
-						.sort(new IndexField("Movie_year", SortOrder.desc))
-						.fields("Movie_name").fields("Movie_year"));
-~~~
-
-
-## Cloudant Search
-
-This feature interfaces with Cloudant's search functionality. See the [Cloudant Search documentation][search] for details.
-
-First, when working with a database (as opposed to the root server), call the `.database()` method.
-
-~~~ java
-
-Database db = dbClient.database("movies-demo", false);
-~~~
-
-## Creating a search index
-
-To create a search index, upload a design document containing the index:
-
-```java
-// Uploads the search index:
-// {
-//   "_id": "_design/views101",
-//   "indexes": {
-//     "animals": {
-//       "index": "function(doc){ index(\"default\", doc._id); }"
-//     }
-//   }
-// }
-
-Map<String, Object> animals = new HashMap<>();
-animals.put("index", "function(doc){ index(\"default\", doc._id); }");
-
-Map<String, Object> indexes = new HashMap<>();
-indexes.put("animals", animals);
-
-Map<String, Object> ddoc = new HashMap<>();
-ddoc.put("_id", "_design/searchindex");
-ddoc.put("indexes", indexes);
-
-db.save(ddoc);
-```
-
-To query this index, create instance of `com.cloudant.client.api.Search`  by calling the database `.search()` method. The argument of `.search()` method is the design document name. The other criterion can be set by calling different methods on `search` object.
-
-~~~ java
-
-Search search = db.search("views101/animals");
-SearchResult<Animal> rslt= search.limit(10)
-				                       .includeDocs(true)
-                                 			.counts(new String[] {"class","diet"})
-				                        .querySearchResult("l*", Animal.class);
-~~~
-
-## Cookie Authentication
-
-Cloudant supports making requests using Cloudant's [cookie authentication](http://guide.couchdb.org/editions/1/en/security.html#cookies) functionality. there's a [step-by-step guide here](http://codetwizzle.com/articles/couchdb-cookie-authentication-nodejs-couchdb/), but essentially you just:
-
-~~~ java
-
- CloudantClient client = new CloudantClient("cloudant.account",
-							 "cloudant.username",
-							 "cloudant.password"));
-String cookie = client.getCookie() ;
-  ~~~
-
-To reuse a cookie:
-
-~~~ java
-
-// Make a new connection with the cookie.
-CloudantClient cookieBasedClient = new
-                          CloudantClient("cloudant.account", cookie);
-
-~~~
-
-
-### Advanced Configuration
-
-#### ConnectOptions
-Besides the account and password options, you can add an optional `com.cloudant.client.api.model.ConnectOptions` value to specify some advanced configuration options.
-
-~~~ java
-ConnectOptions connectOptions = new ConnectOptions()
-                                        .setSocketTimeout(50)
-                                        .setConnectionTimeout(50)
-                                        .setMaxConnections(100)
-                                        .setProxyHost("http://localhost")
-                                        .setProxyPort(8080)
-                                        .setSSLAuthenticationDisabled(true);
- CloudantClient client = new CloudantClient("cloudant.com","test","password",
-                                                  connectOptions );
-
-~~~
-
-#### Custom GSON serialization
-java-cloudant internally uses the Gson library to serialize/deserialize JSON to/from Java objects. You can register your custom de-serializers by providing the CloudantClient instance by with your own GsonBuilder instance
-
-~~~java
-GsonBuilder builder = new GsonBuilder();
-builder.setDateFormat("yyyy-MM-dd'T'HH:mm:ss");
-
-CloudantClient account = new CloudantClient(cloudantaccount,userName,password);
-account.setGsonBuilder(builder);
-~~~
-
-#### Resource sharing
-
-Client objects are thread-safe with the exception of the `setGsonBuilder` method. All methods aside from `setGsonBuilder` can be called from any thread, meaning `Client` objects can -- and should -- be shared across threads. The `Database` object is thread-safe and a single `Database` object may be shared across threads.
-
-Connection pools are managed per CloudantClient instance. The default size of the connection pool is 6. Use ConnectOptions#setMaxConnections(int) to configure the maximum connections in the pool. Idle connections within the pool may be terminated by the server, so will not remain open indefinitely meaning that this will not completely remove the overhead of creating new connections.
-
-#### J2EE
-
-This library can be used in J2EE environments, but currently does not implement any J2EE standards or provide wrappers for them. As such there is no built-in support for JCA connection management or JNDI lookups of `CloudantClient` instances.
-
-To get JNDI support would require a `javax.naming.spi.ObjectFactory` implementation and configuration of your JNDI provider to register this factory and reference this library.
-
-## Tests
-
-The test suite needs access to cloudant account(s) to run.
-To run the test suite first edit the cloudant properties.
-Copy the files `src/test/resources/cloudant-sample.properties` and
-`src/test/resources/cloudant-2-sample.properties` to
-`src/test/resources/cloudant.properties` and
-`src/test/resources/cloudant-2.properties`, and then provide values for the following properties:
-
-~~~ java
-cloudant.account=myCloudantAccount
-cloudant.username=testuser
-cloudant.password=testpassword
-~~~
-
-Once all the required properties are provided in the properties file
-run the `com.cloudant.test.main.CloudantTestSuite` test class.
-
-## License
+### License
 
 Copyright 2014-2015 Cloudant, an IBM company.
 
@@ -1015,9 +164,8 @@ Licensed under the apache license, version 2.0 (the "license"); you may not use 
 
 Unless required by applicable law or agreed to in writing, software distributed under the license is distributed on an "as is" basis, without warranties or conditions of any kind, either express or implied. See the license for the specific language governing permissions and limitations under the license.
 
-[query]: http://docs.cloudant.com/api/cloudant-query.html
-[search]: http://docs.cloudant.com/api/search.html
-[auth]: http://docs.cloudant.com/api/authz.html
-[issues]: https://github.com/cloudant/java-cloudant /issues
-[follow]: https://github.com/iriscouch/follow
-[request]:  https://github.com/mikeal/request
+### Issues
+
+If you are a Cloudant customer please contact Cloudant support for help with any issues.
+
+It is also possible to open issues [here in github](../../issues)

--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,12 @@ dependencies {
 
 //include variable debug info in the compiled classes
 compileJava.options.debugOptions.debugLevel = "source,lines,vars"
+//fail on javac warnings
+compileJava.options.compilerArgs << "-Werror"
+//suppress the bootstrap class path warning which will always apply if we build on a JVM newer
+// than the -source setting and do not set the
+// "-bootclasspath pathToJREMatchingSourceLevel/jre/lib/rt.jar"
+compileJava.options.compilerArgs << "-Xlint:-options"
 
 tasks.withType(Test) {
     // pick up properties named test.* from command line, gradle.properties first

--- a/build.gradle
+++ b/build.gradle
@@ -152,6 +152,22 @@ javadoc {
             "**/lightcouch/NoDocumentException.java",
             "**/lightcouch/CouchDbException.java",
             "**")
+    //add a logging listener to check for javadoc warnings and fail the build if there are any
+    boolean hasJavaDocWarnings = false;
+    doFirst {
+        getLogging().addStandardErrorListener(new StandardOutputListener() {
+            void onOutput(CharSequence output) {
+                if (output =~ "warning:") {
+                    hasJavaDocWarnings = true
+                }
+            }
+        })
+    }
+    doLast {
+        if (hasJavaDocWarnings) {
+            throw new GradleException("Build failed due to javadoc warnings.");
+        }
+    }
 }
 
 task javadocJar(type: Jar, dependsOn: javadoc) {

--- a/build.gradle
+++ b/build.gradle
@@ -133,16 +133,19 @@ task sourcesJar(type: Jar, dependsOn: classes) {
 
 javadoc {
     options.setMemberLevel JavadocMemberLevel.PUBLIC
+    options.overview = "overview.html"
     exclude("**/com/cloudant/tests/**",
             "**/com/cloudant/test/**",
             "**/resources/**",
             "**/internal/**",
-            "**/lightcouch/**")
+            "**/lightcouch/**",
+            "**internal/**",
+            "**/http/interceptors/**")
     include("**/lightcouch/PreconditionFailedException.java",
             "**/lightcouch/DocumentConflictException.java",
             "**/lightcouch/NoDocumentException.java",
             "**/lightcouch/CouchDbException.java",
-            "**/client/**")
+            "**")
 }
 
 task javadocJar(type: Jar, dependsOn: javadoc) {

--- a/overview.html
+++ b/overview.html
@@ -1,0 +1,473 @@
+<html>
+<!--
+This overview.html provides Javadoc overview for the application.
+The content from the body section is added to the Javadoc overview page.
+There is no need to add a head/title as that is provided by Javadoc.
+-->
+<body>
+
+<P>
+    This is the <a href="https://github.com/cloudant/java-cloudant" target="_blank">official
+    Cloudant library for java.</a>
+</P>
+
+<h1>Contents</h1>
+<OL>
+    <LI><a href="#Compatibility">Compatibility</a></LI>
+    <LI><a href="#Initialization">Initialization</a>
+        <OL>
+            <LI><a href="#Cloudant service example">Cloudant service example</a></LI>
+            <LI><a href="#Cloudant Local example">Cloudant Local example</a></LI>
+        </OL>
+    </LI>
+    <LI><a href="#Authentication">Authentication</a>
+        <OL>
+            <LI><a href="#Cookie authentication">Cookie authentication</a></LI>
+            <LI><a href="#Custom authentication">Custom authentication</a></LI>
+        </OL>
+    </LI>
+    <LI><a href="#Capabilities">Capabilities</a>
+        <OL>
+            <LI><a href="#Server Operations">Server Operations</a></LI>
+            <LI><a href="#Database Operations">Database Operations</a></LI>
+            <LI><a href="#Document Operations">Document Operations</a>
+                <OL>
+                    <LI><a href="#Single document CRUD">Single document CRUD</a></LI>
+                    <LI><a href="#Bulk document CRU">Bulk document CRU</a></LI>
+                </OL>
+            </LI>
+            <LI><a href="#Attachments">Attachments</a>
+                <OL>
+                    <LI><a href="#Standalone Attachments">Standalone Attachments</a></LI>
+                    <LI><a href="#Inline Attachments">Inline Attachments</a></LI>
+                </OL>
+            </LI>
+            <LI><a href="#Design Documents">Design Documents</a></LI>
+            <LI><a href="#Using Views">Using Views</a></LI>
+            <LI><a href="#Cloudant Query">Cloudant Query</a></LI>
+            <LI><a href="#Cloudant Search">Cloudant Search</a></LI>
+        </OL>
+    </LI>
+    <LI><a href="#Advanced Configuration">Advanced Configuration</a>
+        <OL>
+            <LI><a href="#Connection options">Connection options</a></LI>
+            <LI><a href="#Resource sharing">Resource sharing</a>
+                <OL>
+                    <LI><a href="#Thread safety">Thread safety</a></LI>
+                    <LI><a href="#Connection pooling">Connection pooling</a>
+                        <OL>
+                            <LI><a href="#Default pooling">Default pooling</a></LI>
+                            <LI><a href="#With OkHttp">With OkHttp</a></LI>
+                        </OL>
+                    </LI>
+                </OL>
+            </LI>
+            <LI><a href="#J2EE">J2EE</a></LI>
+        </OL>
+    <LI><a href="#Project">Project</a></LI>
+</OL>
+
+<h1 id="Compatibility">Compatibility</h1>
+
+<P>
+    This library can be used with the following databases
+</P>
+<UL>
+    <LI><a href="https://cloudant.com" target="_blank">IBM&reg; Cloudant&reg;
+        Database-as-a-Service</a></LI>
+    <LI><a href="http://www.ibm.com/software/products/cloudant-data-layer-local-edition"
+           target="_blank">IBM&reg; Cloudant&reg; Data Layer Local Edition</a> (Cloudant Local)
+    </LI>
+    <LI><a href="http://couchdb.apache.org/" target="_blank">Apache CouchDB&trade;</a></LI>
+</UL>
+<P>
+    Note that some features are Cloudant specific.
+</P>
+
+<P>
+    The library is compiled with Java 1.6 compatibility, but it is recommended to run with the
+    latest available Java version.
+</P>
+
+<h1 id="Initialization">Initialization</h1>
+
+<P>
+    Use the {@link com.cloudant.client.api.ClientBuilder} class to build a CloudantClient
+    instance.
+    The {@link com.cloudant.client.api.CloudantClient} class is the starting point for
+    interacting
+    with Cloudant from Java.
+</P>
+
+<h2 id="Cloudant service example">Cloudant service example</h2>
+
+<P>
+    When using the managed service at cloudant.com, initialize your Cloudant connection by using
+    {@link com.cloudant.client.api.ClientBuilder#account(String)} supplying the account to
+    connect
+    to. Set additional options for the API key or username and passphrase.
+</P>
+
+<pre>
+    {@code
+    CloudantClient client = ClientBuilder.account("yourCloudantAccount")
+            .setUsername("yourAPIKey")
+            .setPassword("yourAPIKeyPassphrase")
+            .build();
+    }
+</pre>
+
+<h2 id="Cloudant Local example">Cloudant Local example</h2>
+
+<P>
+    When using Cloudant Local, initialize your Cloudant connection by using
+    {@link com.cloudant.client.api.ClientBuilder#url(URL)} supplying the URL of the Cloudant
+    Local.
+    Again set additional options for the user name or API key and passphase.
+</P>
+
+
+<pre>
+    {@code
+    CloudantClient client = ClientBuilder.url(new URL("https://192.0.2.0"))
+            .username("yourAPIKey")
+            .password("yourAPIKeyPassphrase")
+            .build();
+    }
+</pre>
+
+<h1 id="Authentication">Authentication</h1>
+
+<h2 id="Cookie authentication">Cookie authentication</h2>
+
+<P>
+    Using the {@link com.cloudant.client.api.ClientBuilder#username(String)} and
+    {@link com.cloudant.client.api.ClientBuilder#password(String)}
+    options uses
+    <a href="https://docs.cloudant.com/authentication.html#cookie-authentication" target="_blank">
+        cookie authentication</a> for the CloudantClient connection. The supplied credentials are
+    used to request a session with the server and the session is renewed automatically if the cookie
+    expires. If the credentials become invalid then a new instance of a CloudantClient needs to be
+    created.
+</P>
+
+<h2 id="Custom authentication">Custom authentication</h2>
+
+<P>
+    If cookie authentication is not desired then it is possible to build the CloudantClient
+    without
+    credentials and use a {@link HttpConnectionInterceptor} to customize the HTTP request with
+    the
+    desired authentication mechanism.
+</P>
+
+<P>
+    An example using Basic Authentication is shown in the javadoc for
+    {@link com.cloudant.client.api.ClientBuilder#interceptors(HttpConnectionInterceptor[])}.
+</P>
+
+<h1 id="Capabilities">Capabilities</h1>
+
+<h2 id="Server Operations">Server Operations</h2>
+
+<P>
+    {@link com.cloudant.client.api.CloudantClient} encapsulates the connection to the server and
+    provides access to server operations.
+</P>
+
+<h2 id="Database Operations">Database Operations</h2>
+
+<P>
+    {@link com.cloudant.client.api.CloudantClient#database(String, boolean)} returns a
+    {@link com.cloudant.client.api.Database} object that provides access to database operations.
+</P>
+
+<h2 id="Document Operations">Document Operations</h2>
+
+<h3 id="Single document CRUD">Single document CRUD</h3>
+
+<P>
+    CRUD operations for documents in a database are achieved via the
+    {@link com.cloudant.client.api.Database} object.
+</P>
+<UL>
+    <LI>Create - {@link com.cloudant.client.api.Database#save(Object)} or {@link
+        com.cloudant.client.api.Database#post(Object)}
+    </LI>
+    <LI>Read - {@link com.cloudant.client.api.Database#find(Class, String)}</LI>
+    <LI>Update - {@link com.cloudant.client.api.Database#save(Object)} or {@link
+        com.cloudant.client.api.Database#update(Object)}
+    </LI>
+    <LI>Delete - {@link com.cloudant.client.api.Database#remove(Object)}</LI>
+</UL>
+
+<h3 id="Bulk document CRU">Bulk document CRU</h3>
+
+<P>
+    {@link com.cloudant.client.api.Database} also provides a bulk documents API for fetching or
+    modifying multiple documents in a single request.
+</P>
+<UL>
+    <LI>Create/Update - {@link com.cloudant.client.api.Database#bulk(List)}</LI>
+    <LI>Read - {@link com.cloudant.client.api.views.AllDocsRequestBuilder} via {@link
+        com.cloudant.client.api.Database#getAllDocsRequestBuilder()}
+    </LI>
+</UL>
+
+<h2 id="Attachments">Attachments</h2>
+
+See the <a href="https://docs.cloudant.com/attachments.html" target="_blank">Cloudant documentation
+</a> for more information about attachments.
+
+<h3 id="Standalone Attachments">Standalone Attachments</h3>
+
+<P>
+    Standalone attachment data is provided as an {@link java.io.InputStream}. The attachment can
+    be
+    created and either referenced from an existing document or a new document.
+</P>
+<UL>
+    <LI>Add or update an attachment on an existing document -
+        {@link com.cloudant.client.api.Database#saveAttachment(java.io.InputStream,
+        java.lang.String, java.lang.String, java.lang.String, java.lang.String)}
+    </LI>
+    <LI>Create a new document with an attachment -
+        {@link com.cloudant.client.api.Database#saveAttachment(java.io.InputStream,
+        java.lang.String, java.lang.String)}
+    </LI>
+</UL>
+
+<h3 id="Inline Attachments">Inline Attachments</h3>
+
+<P>
+    <a href="https://docs.cloudant.com/attachments.html#inline" target="_blank">Inline attachments
+    </a> enclose the attachment data, Base64 encoded, within the document body. The
+    {@link com.cloudant.client.api.model.Attachment} class represents an inline attachment.
+    Classes that extend {@link com.cloudant.client.api.model.Document} automatically inherit
+    support for inline attachments.
+</P>
+
+<P>Example usage of inline attachment, using Apache Commons Codec for Base64 encoding:</P>
+<pre>
+    {@code
+        Attachment attachment = new Attachment();
+        attachment.setData(Base64.encodeBase64String("attachment test string".getBytes()));
+        attachment.setContentType("text/plain");
+        Foo foo = new Foo(); // Foo extends Document
+        foo.addAttachment("attachment.txt", attachment);
+        db.save(foo);
+    }
+</pre>
+<P>Note that attachment data is <strong>not</strong> included by default when reading documents.
+    To retrieve inline attachment data use
+    {@link com.cloudant.client.api.model.Params#attachments()}.
+    See {@link com.cloudant.client.api.Database#find(java.lang.Class, java.lang.String,
+    com.cloudant.client.api.model.Params)} for an example.
+</P>
+
+<h2 id="Design Documents">Design Documents</h2>
+
+<P>
+    Design documents are used to define server side operations, including querying the database
+    using map-reduce views, <a href="#Cloudant Search">Cloudant Search</a>, and
+    <a href="#Cloudant Query">Cloudant Query</a>. The results can be retrieved by the client. It is
+    recommend to read the <a href="https://docs.cloudant.com/design_documents.html" target="_blank">
+    Cloudant design document documentation</a> before working with design documents to gain an
+    understanding of the available parameters and functions.
+</P>
+
+<P>
+    The {@link com.cloudant.client.api.model.DesignDocument} class encapsulates a design document in
+    a Java object.
+</P>
+
+<P>See {@link com.cloudant.client.api.DbDesign#getFromDb(java.lang.String)} for an example of
+    retrieving a design document from the sever.</P>
+
+<P>Example of creating a view (map-reduce index) using {@link java.util.Map} to generate
+    the JSON for the design document </P>
+<pre>
+    {@code
+    // Uploads the design document with view index:
+    // {
+    //   "_id": "_design/name",
+    //   "views": {
+    //     "view1": {
+    //       "map":"function(doc){emit(doc.field, 1)}",
+    //       "reduce": "function(key, value, rereduce){return sum(values)}"
+    //     }
+    //   }
+    // }
+
+    Map<String, Object> view1 = new HashMap<>();
+    view1.put("map", "function(doc){emit(doc.field, 1)}");
+    view1.put("reduce", "function(key, value, rereduce){return sum(values)}");
+
+    Map<String, Object> views = new HashMap<>();
+    views.put("view1", view1);
+
+    Map<String, Object> view_ddoc = new HashMap<>();
+    view_ddoc.put("_id", "_design/name");
+    view_ddoc.put("views", views);
+
+    db.save(view_ddoc);
+    }
+</pre>
+
+<h2 id="Using Views">Using Views</h2>
+
+For background information about views please refer to the
+<a href="https://docs.cloudant.com/creating_views.html" target="_blank">Cloudant views documentation
+</a>. Refer to the <a href="{@docroot}com/cloudant/client/api/views/package-summary.html">
+    com.cloudant.client.api.views package</a> for information about and examples of using this
+library to query a view.
+
+<h2 id="Cloudant Query">Cloudant Query</h2>
+
+<P>
+    This feature interfaces with Cloudant's query functionality. See the
+    <a href="https://docs.cloudant.com/cloudant_query.html" target="_blank">Cloudant Query
+        documentation</a> for details.
+</P>
+<UL>
+    <LI>To see all the indexes in a database use: {@link
+        com.cloudant.client.api.Database#listIndices}
+    </LI>
+    <LI>To create an index use: {@link
+        com.cloudant.client.api.Database#createIndex(java.lang.String)} or {@link
+        com.cloudant.client.api.Database#createIndex(java.lang.String, java.lang.String,
+        java.lang.String, com.cloudant.client.api.model.IndexField[])}
+    </LI>
+    <LI>To query an index use: {@link com.cloudant.client.api.Database#findByIndex(java.lang.String,
+        java.lang.Class)} or {@link com.cloudant.client.api.Database#findByIndex(java.lang.String,
+        java.lang.Class, com.cloudant.client.api.model.FindByIndexOptions)}
+    </LI>
+</UL>
+
+<h2 id="Cloudant Search">Cloudant Search</h2>
+
+<P>
+    This feature interfaces with Cloudant's full text search functionality. See the
+    <a href="https://docs.cloudant.com/search.html" target="_blank">Cloudant Search documentation
+    </a> for details. Searches are based on index functions in design documents.
+</P>
+
+<P>
+    To create a search index, upload a design document containing the index:
+</P>
+<pre>
+    {@code
+    // Uploads the search index:
+    // {
+    //   "_id": "_design/views101",
+    //   "indexes": {
+    //     "animals": {
+    //       "index": "function(doc){ index(\"default\", doc._id); }"
+    //     }
+    //   }
+    // }
+
+    Map<String, Object> animals = new HashMap<>();
+    animals.put("index", "function(doc){ index(\"default\", doc._id); }");
+
+    Map<String, Object> indexes = new HashMap<>();
+    indexes.put("animals", animals);
+
+    Map<String, Object> ddoc = new HashMap<>();
+    ddoc.put("_id", "_design/searchindex");
+    ddoc.put("indexes", indexes);
+
+    db.save(ddoc);
+    }
+</pre>
+<P>
+    To query this index, use an instance of {@link com.cloudant.client.api.Search} by calling {@link
+    com.cloudant.client.api.Database#search}.
+</P>
+
+<h1 id="Advanced Configuration">Advanced Configuration</h1>
+
+<h2 id="Connection options">Connection options</h2>
+
+<P>
+    The {@link ClientBuilder} provide access to additional advanced configuration options for the
+    server connection. For example customized SSL, proxies and timeouts.
+</P>
+
+<h2 id="Custom GSON serialization">Custom GSON serialization</h2>
+
+<P>
+    Internally the Gson library is used to serialize/deserialize JSON to/from Java objects. You can
+    supply your own GsonBuilder instance to customize configuration, for example registering custom
+    de-serializers.
+</P>
+
+<P>Example setting the date/time format Gson uses:</P>
+<pre>
+    {@code
+    GsonBuilder builder = new GsonBuilder();
+    builder.setDateFormat("yyyy-MM-dd'T'HH:mm:ss");
+
+    CloudantClient client = ClientBuilder.account("example").username("user").password("password)
+            .gsonBuilder(builder).build();
+    }
+</pre>
+
+<h2 id="Resource sharing">Resource sharing</h2>
+
+<h3 id="Thread safety">Thread safety</h3>
+
+<P>
+    CloudantClient objects are thread-safe. All methods can be called from any thread, meaning
+    CloudantClient objects can <em>and should</em> be shared across threads. The Database object is
+    thread-safe and a single Database object may be shared across threads.
+</P>
+
+<h3 id="Connection pooling">Connection pooling</h3>
+
+<P>
+    Connection pooling behaviour differs depending on whether the optional OkHttp dependency is
+    included. Note that idle connections within the pool may be terminated by the server, so will
+    not remain open indefinitely meaning that this will not completely remove the overhead of
+    creating new connections.
+</P>
+
+<h4 id="Default pooling">Default pooling</h4>
+
+<P>
+    By default the underlying {@link HttpUrlConnection} will use the JVM wide connection pool
+    configuration (via the {@code http.maxConnections} property). Under these circumstances the pool
+    is shared between all applications in the VM and between all CloudantClient instances.
+</P>
+
+<h4 id="With OkHttp">With OkHttp</h4>
+
+<P>
+    When the OkHttp dependency is included then connection pools are managed per CloudantClient
+    instance. The default size of the connection pool is 6. Use {@link
+    ClientBuilder#maxConnections(int)} to configure the maximum connections in the pool.
+</P>
+
+<h2 id="J2EE">J2EE</h2>
+
+<P>
+    This library can be used in J2EE environments, but currently does not implement any J2EE
+    standards or provide wrappers for them. As such there is no built-in support for JCA connection
+    management or JNDI lookups of CloudantClient instances.
+</P>
+
+<P>
+    To get JNDI support would require a {@link javax.naming.spi.ObjectFactory} implementation and
+    configuration of your JNDI provider to register this factory and reference this library.
+</P>
+
+
+<h1 id="Project">Project</h1>
+
+<P>
+    Please visit the <a href="https://github.com/cloudant/java-cloudant" target="_blank">
+    java-cloudant project page</a> for more information.
+</P>
+
+</body>
+</html>

--- a/overview.html
+++ b/overview.html
@@ -281,7 +281,7 @@ See the <a href="https://docs.cloudant.com/attachments.html" target="_blank">Clo
     a Java object.
 </P>
 
-<P>See {@link com.cloudant.client.api.DbDesign#getFromDb(java.lang.String)} for an example of
+<P>See {@link com.cloudant.client.api.DesignDocumentManager#get(java.lang.String, java.lang.String)} for an example of
     retrieving a design document from the sever.</P>
 
 <P>Example of creating a view (map-reduce index) using {@link java.util.Map} to generate

--- a/src/main/java/com/cloudant/client/api/Changes.java
+++ b/src/main/java/com/cloudant/client/api/Changes.java
@@ -21,8 +21,9 @@ import com.cloudant.client.api.model.ChangesResult.Row;
 /**
  * <p>Contains the Change Notifications API, supports <i>normal</i> and <i>continuous</i> feed
  * Changes.
- * <h3>Usage Example:</h3>
+ * <p>Usage example for normal feed limiting to 10 results, with a filter:</p>
  * <pre>
+ * {@code
  * // feed type normal
  * String since = db.info().getUpdateSeq(); // latest update seq
  * ChangesResult changeResult = db.changes()
@@ -31,11 +32,16 @@ import com.cloudant.client.api.model.ChangesResult.Row;
  * 	.filter("example/filter")
  * 	.getChanges();
  *
+ * //process the ChangesResult
  * for (ChangesResult.Row row : changeResult.getResults()) {
  *   String docId = row.getId()
  *   JsonObject doc = row.getDoc();
  * }
- *
+ * }
+ * </pre>
+ * <P>Usage example for continuous feed, including document content:</P>
+ * <pre>
+ * {@code
  * // feed type continuous
  * Changes changes = db.changes()
  * 	.includeDocs(true)
@@ -46,13 +52,18 @@ import com.cloudant.client.api.model.ChangesResult.Row;
  * 	ChangesResult.Row feed = changes.next();
  *  String docId = feed.getId();
  *  JsonObject doc = feed.getDoc();
- * 	// changes.stop(); // stop continuous feed
+ * }
+ *
+ * //while loop blocks; stop from another thread
+ * changes.stop(); // stop continuous feed
  * }
  * </pre>
  *
  * @author Ganesh K Choudhary
  * @see ChangesResult
  * @since 0.0.1
+ * @see <a href="https://docs.cloudant.com/database.html#get-changes">Databases - get
+ * changes</a>
  */
 public class Changes {
     private com.cloudant.client.org.lightcouch.Changes changes;
@@ -63,7 +74,8 @@ public class Changes {
 
     /**
      * Requests Change notifications of feed type continuous.
-     * <p>Feed notifications are accessed in an <i>iterator</i> style.
+     * <p>Feed notifications are accessed in an <i>iterator</i> style.</p>
+     * @return this Changes object configured for continuous feed.
      */
     public Changes continuousChanges() {
         changes = changes.continuousChanges();
@@ -73,6 +85,8 @@ public class Changes {
     /**
      * Checks whether a feed is available in the continuous stream, blocking
      * until a feed is received.
+     *
+     * @return true if there is a change
      */
     public boolean hasNext() {
         return changes.hasNext();
@@ -96,6 +110,7 @@ public class Changes {
 
     /**
      * Requests Change notifications of feed type normal.
+     * @return {@link ChangesResult} encapsulating the normal feed changes
      */
     public ChangesResult getChanges() {
         com.cloudant.client.org.lightcouch.ChangesResult couchDbChangesResult = changes.getChanges();

--- a/src/main/java/com/cloudant/client/api/Changes.java
+++ b/src/main/java/com/cloudant/client/api/Changes.java
@@ -61,9 +61,9 @@ import com.cloudant.client.api.model.ChangesResult.Row;
  *
  * @author Ganesh K Choudhary
  * @see ChangesResult
+ * @see <a target="_blank" href="https://docs.cloudant.com/database.html#get-changes">Databases -
+ * get changes</a>
  * @since 0.0.1
- * @see <a href="https://docs.cloudant.com/database.html#get-changes">Databases - get
- * changes</a>
  */
 public class Changes {
     private com.cloudant.client.org.lightcouch.Changes changes;
@@ -75,6 +75,7 @@ public class Changes {
     /**
      * Requests Change notifications of feed type continuous.
      * <p>Feed notifications are accessed in an <i>iterator</i> style.</p>
+     *
      * @return this Changes object configured for continuous feed.
      */
     public Changes continuousChanges() {
@@ -110,10 +111,12 @@ public class Changes {
 
     /**
      * Requests Change notifications of feed type normal.
+     *
      * @return {@link ChangesResult} encapsulating the normal feed changes
      */
     public ChangesResult getChanges() {
-        com.cloudant.client.org.lightcouch.ChangesResult couchDbChangesResult = changes.getChanges();
+        com.cloudant.client.org.lightcouch.ChangesResult couchDbChangesResult = changes
+                .getChanges();
         ChangesResult changeResult = new ChangesResult(couchDbChangesResult);
         return changeResult;
     }

--- a/src/main/java/com/cloudant/client/api/ClientBuilder.java
+++ b/src/main/java/com/cloudant/client/api/ClientBuilder.java
@@ -81,8 +81,8 @@ import javax.net.ssl.SSLSocketFactory;
  * CloudantClient client = ClientBuilder.account("yourCloudantAccount")
  *                          .username("yourUsername")
  *                          .password("yourPassword")
- *                          .connectionTimeout(ClientBuilder.TimeoutOption.minutes(1))
- *                          .readTimeout(ClientBuilder.TimeoutOption.minutes(1))
+ *                          .connectTimeout(1, TimeUnit.MINUTES)
+ *                          .readTimeout(1, TimeUnit.MINUTES)
  *                          .build();
  * }
  * </pre>
@@ -98,13 +98,11 @@ public class ClientBuilder {
     /**
      * Connection timeout defaults to 5 minutes
      **/
-    public static final TimeoutOption DEFAULT_CONNECTION_TIMEOUT
-            = TimeoutOption.minutes(5);
+    public static final long DEFAULT_CONNECTION_TIMEOUT = 5l;
     /**
      * Read timeout defaults to 5 minutes
      **/
-    public static final TimeoutOption DEFAULT_READ_TIMEOUT
-            = TimeoutOption.minutes(5);
+    public static final long DEFAULT_READ_TIMEOUT = 5l;
 
     private List<HttpConnectionRequestInterceptor> requestInterceptors = new ArrayList
             <HttpConnectionRequestInterceptor>();
@@ -123,8 +121,12 @@ public class ClientBuilder {
     private String proxyPassword;
     private boolean isSSLAuthenticationDisabled;
     private SSLSocketFactory authenticatedModeSSLSocketFactory;
-    private TimeoutOption connectionTimeout = DEFAULT_CONNECTION_TIMEOUT;
-    private TimeoutOption readTimeout = DEFAULT_READ_TIMEOUT;
+    private long connectTimeout = DEFAULT_CONNECTION_TIMEOUT;
+    private TimeUnit connectTimeoutUnit = TimeUnit.MINUTES;
+    ;
+    private long readTimeout = DEFAULT_READ_TIMEOUT;
+    private TimeUnit readTimeoutUnit = TimeUnit.MINUTES;
+    ;
 
     /**
      * Constructs a new ClientBuilder for building a CloudantClient instance to connect to the
@@ -216,8 +218,8 @@ public class ClientBuilder {
 
 
         //If setter methods for read and connection timeout are not called, default values are used.
-        props.addRequestInterceptors(new TimeoutCustomizationInterceptor(connectionTimeout,
-                readTimeout));
+        props.addRequestInterceptors(new TimeoutCustomizationInterceptor(connectTimeout,
+                connectTimeoutUnit, readTimeout, readTimeoutUnit));
 
         //Set connect options
         props.setMaxConnections(maxConnections);
@@ -366,11 +368,11 @@ public class ClientBuilder {
      *
      * @return this ClientBuilder object for setting additional options
      * @throws IllegalStateException if {@link #customSSLSocketFactory(SSLSocketFactory)}
-     * has been called on this ClientBuilder
+     *                               has been called on this ClientBuilder
      * @see #customSSLSocketFactory(SSLSocketFactory)
      */
     public ClientBuilder disableSSLAuthentication() {
-        if(authenticatedModeSSLSocketFactory == null) {
+        if (authenticatedModeSSLSocketFactory == null) {
             this.isSSLAuthenticationDisabled = true;
         } else {
             throw new IllegalStateException("Cannot disable SSL authentication when a " +
@@ -378,7 +380,7 @@ public class ClientBuilder {
         }
         return this;
     }
-    
+
 
     /**
      * Specifies the custom SSLSocketFactory to use when connecting to Cloudant over a
@@ -388,11 +390,11 @@ public class ClientBuilder {
      *                default SSLSocketFactory of the JRE.
      * @return this ClientBuilder object for setting additional options
      * @throws IllegalStateException if {@link #disableSSLAuthentication()}
-     * has been called on this ClientBuilder
+     *                               has been called on this ClientBuilder
      * @see #disableSSLAuthentication()
      */
     public ClientBuilder customSSLSocketFactory(SSLSocketFactory factory) {
-        if(!isSSLAuthenticationDisabled) {
+        if (!isSSLAuthenticationDisabled) {
             this.authenticatedModeSSLSocketFactory = factory;
         } else {
             throw new IllegalStateException("Cannot use a custom SSLSocketFactory when " +
@@ -447,19 +449,20 @@ public class ClientBuilder {
      * CloudantClient client = ClientBuilder.account("yourCloudantAccount")
      *      .username("yourUsername")
      *      .password("yourPassword")
-     *      .connectionTimeout(ClientBuilder.TimeoutOption.seconds(2))
+     *      .connectTimeout(2, TimeUnit.SECONDS)
      *      .build();
      * }
      * </pre>
-     * Defaults to {@link #DEFAULT_CONNECTION_TIMEOUT}
+     * Defaults to {@link #DEFAULT_CONNECTION_TIMEOUT} with {@link TimeUnit#MINUTES}.
      *
-     * @param connectionTimeout TimeoutOption of the required duration
+     * @param connectTimeout     duration of the read timeout
+     * @param connectTimeoutUnit unit of measurement of the read timeout parameter
      * @return this ClientBuilder object for setting additional options
-     * @see com.cloudant.client.api.ClientBuilder.TimeoutOption
      * @see java.net.HttpURLConnection#setConnectTimeout(int)
      **/
-    public ClientBuilder connectionTimeout(TimeoutOption connectionTimeout) {
-        this.connectionTimeout = connectionTimeout;
+    public ClientBuilder connectTimeout(long connectTimeout, TimeUnit connectTimeoutUnit) {
+        this.connectTimeout = connectTimeout;
+        this.connectTimeoutUnit = connectTimeoutUnit;
         return this;
     }
 
@@ -475,78 +478,21 @@ public class ClientBuilder {
      * CloudantClient client = ClientBuilder.account("yourCloudantAccount")
      *      .username("yourUsername")
      *      .password("yourPassword")
-     *      .readTimeout(ClientBuilder.TimeoutOption.seconds(2))
+     *      .readTimeout(2, TimeUnit.SECONDS)
      *      .build();
      * }
      * </pre>
-     * Defaults to {@link #DEFAULT_READ_TIMEOUT}
+     * Defaults to {@link #DEFAULT_READ_TIMEOUT} with {@link TimeUnit#MINUTES}.
      *
-     * @param readTimeout TimeoutOption of the required duration
+     * @param readTimeout     duration of the read timeout
+     * @param readTimeoutUnit unit of measurement of the read timeout parameter
      * @return this ClientBuilder object for setting additional options
-     * @see com.cloudant.client.api.ClientBuilder.TimeoutOption
      * @see java.net.HttpURLConnection#setReadTimeout(int)
      **/
-    public ClientBuilder readTimeout(TimeoutOption readTimeout) {
+    public ClientBuilder readTimeout(long readTimeout, TimeUnit readTimeoutUnit) {
         this.readTimeout = readTimeout;
+        this.readTimeoutUnit = readTimeoutUnit;
         return this;
     }
 
-    /**
-     * Class that encapsulates the value of a timeout, bound by the range 0 to {@link Integer#MAX_VALUE}
-     * milliseconds. If the specified timeout exceeds the range maximum it will be set to the
-     * maximum value and likewise if the value is less than 0 then it will be set at 0.
-     * <P>
-     * Conveniently creates timeout values in minutes, seconds or using another {@link TimeUnit}.
-     * </P>
-     *
-     * @see ClientBuilder#readTimeout(TimeoutOption)
-     * @see ClientBuilder#connectionTimeout(TimeoutOption)
-     */
-    public final static class TimeoutOption {
-
-        private int timeoutMillis;
-
-        /**
-         * Constructs a new TimeoutOption instance with the specified timeout duration.
-         *
-         * @param timeout     value of the duration of the timeout in the specified unit
-         * @param timeoutUnit the {@link TimeUnit} of the timeout duration value
-         */
-        public TimeoutOption(long timeout, TimeUnit timeoutUnit) {
-            Long to = timeoutUnit.toMillis(timeout);
-            if (timeout < 0) {
-                timeoutMillis = 0;
-            } else if (timeout > Integer.MAX_VALUE) {
-                timeoutMillis = Integer.MAX_VALUE;
-            } else {
-                timeoutMillis = to.intValue();
-            }
-        }
-
-        /**
-         * Constructs a new TimeoutOption instance with the specified duration in minutes.
-         *
-         * @param minutes duration of the timeout in minutes
-         * @return a new TimeoutOption for the duration specified in minutes
-         */
-        public static TimeoutOption minutes(int minutes) {
-            return new TimeoutOption(minutes, TimeUnit.MINUTES);
-        }
-
-        /**
-         * Constructs a new TimeoutOption instance with the specified duration in seconds.
-         * @param seconds duration of the timeout in seconds
-         * @return a new TimeoutOption for the duration specified in seconds
-         */
-        public static TimeoutOption seconds(int seconds) {
-            return new TimeoutOption(seconds, TimeUnit.SECONDS);
-        }
-
-        /**
-         * @return the value of the timeout in milliseconds
-         */
-        public int asIntMillis() {
-            return timeoutMillis;
-        }
-    }
 }

--- a/src/main/java/com/cloudant/client/api/ClientBuilder.java
+++ b/src/main/java/com/cloudant/client/api/ClientBuilder.java
@@ -291,7 +291,7 @@ public class ClientBuilder {
     }
 
     /**
-     * Set a custom GsonBuilder to use when serializing and de-serializing requests and
+     * Set a custom GsonBuilder to use when serializing and de-serializing JSON in requests and
      * responses between the CloudantClient and the server.
      * <P>
      * Note: the supplied GsonBuilder will be augmented with some internal TypeAdapters.
@@ -407,8 +407,9 @@ public class ClientBuilder {
      * CloudantClient and the server.
      * <P>
      * An example interceptor use might be to apply a custom authorization mechanism. For
-     * instance to use BasicAuth instead of CookieAuth it is possible to add a
-     * {@link com.cloudant.http.interceptors.BasicAuthInterceptor}:
+     * instance to use BasicAuth instead of CookieAuth it is possible to use a
+     * {@link com.cloudant.http.interceptors.BasicAuthInterceptor} that adds the BasicAuth
+     * {@code Authorization} header to the request:
      * </P>
      * <pre>
      * {@code
@@ -491,7 +492,7 @@ public class ClientBuilder {
     }
 
     /**
-     * Class that holds the value of a timeout, bound by the range 0 to {@link Integer#MAX_VALUE}
+     * Class that encapsulates the value of a timeout, bound by the range 0 to {@link Integer#MAX_VALUE}
      * milliseconds. If the specified timeout exceeds the range maximum it will be set to the
      * maximum value and likewise if the value is less than 0 then it will be set at 0.
      * <P>

--- a/src/main/java/com/cloudant/client/api/CloudantClient.java
+++ b/src/main/java/com/cloudant/client/api/CloudantClient.java
@@ -37,6 +37,7 @@ import com.google.gson.reflect.TypeToken;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
+import java.util.EnumSet;
 import java.util.List;
 
 /**
@@ -171,7 +172,7 @@ public class CloudantClient {
      * Get the list of active tasks from the server.
      *
      * @return List of tasks
-     * @see <a href="https://docs.cloudant.com/active_tasks.html">Active tasks</a>
+     * @see <a target="_blank" href="https://docs.cloudant.com/active_tasks.html">Active tasks</a>
      */
     public List<Task> getActiveTasks() {
         InputStream response = null;
@@ -189,7 +190,8 @@ public class CloudantClient {
      * Get the list of all nodes and the list of active nodes in the cluster.
      *
      * @return Membership object encapsulating lists of all nodes and the cluster nodes
-     * @see <a href="https://docs.cloudant.com/advanced.html#get-/_membership">_membership</a>
+     * @see <a target="_blank"
+     * href="https://docs.cloudant.com/advanced.html#get-/_membership">_membership</a>
      */
     public Membership getMembership() {
         Membership membership = couchDbClient.get(buildUri(getBaseUri()).path("_membership")
@@ -206,7 +208,8 @@ public class CloudantClient {
      * @return Database object
      * @throws com.cloudant.client.org.lightcouch.NoDocumentException if the database does not
      *                                                                exist and create was false
-     * @see <a href="https://docs.cloudant.com/database.html#read">Databases - read</a>
+     * @see <a target="_blank" href="https://docs.cloudant.com/database.html#read">Databases -
+     * read</a>
      */
     public Database database(String name, boolean create) {
         return new Database(this, couchDbClient.database(name, create));
@@ -216,7 +219,8 @@ public class CloudantClient {
      * Request to delete the database with the specified name.
      *
      * @param dbName the database name
-     * @see <a href="https://docs.cloudant.com/database.html#deleting-a-database">Databases - delete
+     * @see <a target="_blank"
+     * href="https://docs.cloudant.com/database.html#deleting-a-database">Databases - delete
      * </a>
      */
     public void deleteDB(String dbName) {
@@ -230,7 +234,8 @@ public class CloudantClient {
      * @throws com.cloudant.client.org.lightcouch.PreconditionFailedException if a database with
      *                                                                        the same name
      *                                                                        already exists
-     * @see <a href="https://docs.cloudant.com/database.html#create">Databases - create</a>
+     * @see <a target="_blank" href="https://docs.cloudant.com/database.html#create">Databases -
+     * create</a>
      */
     public void createDB(String dbName) {
         couchDbClient.createDB(dbName);
@@ -247,7 +252,7 @@ public class CloudantClient {
      * List all the databases on the server for the Cloudant account.
      *
      * @return List of the names of all the databases
-     * @see <a href="https://docs.cloudant.com/database.html#get-databases">
+     * @see <a target="_blank" href="https://docs.cloudant.com/database.html#get-databases">
      * Databases - get databases</a>
      */
     public List<String> getAllDbs() {
@@ -258,7 +263,8 @@ public class CloudantClient {
      * Get the reported server version from the welcome message metadata.
      *
      * @return Cloudant server version.
-     * @see <a href="https://docs.cloudant.com/advanced.html#get-/">Welcome message</a>
+     * @see <a target="_blank" href="https://docs.cloudant.com/advanced.html#get-/">Welcome
+     * message</a>
      */
     public String serverVersion() {
         return couchDbClient.serverVersion();
@@ -269,7 +275,8 @@ public class CloudantClient {
      *
      * @return Replication object for configuration and triggering
      * @see com.cloudant.client.api.Replication
-     * @see <a href="https://docs.cloudant.com/replication.html#the-/_replicate-endpoint">
+     * @see <a target="_blank"
+     * href="https://docs.cloudant.com/replication.html#the-/_replicate-endpoint">
      * Replication - _replicate
      * </a>
      */
@@ -285,7 +292,8 @@ public class CloudantClient {
      *
      * @return Replicator object for interacting with the _replicator DB
      * @see com.cloudant.client.api.Replicator
-     * @see <a href="https://docs.cloudant.com/replication.html#the-/_replicator-database">
+     * @see <a target="_blank"
+     * href="https://docs.cloudant.com/replication.html#the-/_replicator-database">
      * Replication - _replicator
      * </a>
      */
@@ -333,7 +341,7 @@ public class CloudantClient {
      *
      * @param count the number of UUIDs
      * @return a List of UUID Strings
-     * @see <a href="https://docs.cloudant.com/advanced.html#get-/_uuids">_uuids</a>
+     * @see <a target="_blank" href="https://docs.cloudant.com/advanced.html#get-/_uuids">_uuids</a>
      */
     public List<String> uuids(long count) {
         return couchDbClient.uuids(count);

--- a/src/main/java/com/cloudant/client/api/Database.java
+++ b/src/main/java/com/cloudant/client/api/Database.java
@@ -38,7 +38,6 @@ import com.cloudant.client.internal.views.ViewQueryParameters;
 import com.cloudant.client.org.lightcouch.Changes;
 import com.cloudant.client.org.lightcouch.CouchDatabase;
 import com.cloudant.client.org.lightcouch.CouchDbException;
-import com.cloudant.client.org.lightcouch.CouchDbInfo;
 import com.cloudant.client.org.lightcouch.DocumentConflictException;
 import com.cloudant.client.org.lightcouch.NoDocumentException;
 import com.cloudant.client.org.lightcouch.Response;
@@ -108,11 +107,25 @@ public class Database {
      * </a> such as Cloudant DBaaS. For unsupported databases consider using the /db/_security
      * endpoint.
      * </p>
+     * <p>Example usage to set read-only access for a new key on the "example" database:</p>
+     * <pre>
+     * {@code
+     * // generate an API key
+     * ApiKey key = client.generateApiKey();
      *
-     * @param userNameorApikey
+     * // get the "example" database
+     * Database db = client.database("example", false);
+     *
+     * // set read-only permissions
+     * db.setPermissions(key.getKey(), EnumSet.<Permissions>of(Permissions._reader));
+     * }
+     * </pre>
+     *
+     * @param userNameorApikey the user or key to apply permissions to
      * @param permissions      permissions to grant
      * @throws UnsupportedOperationException if called on a database that does not provide the
      *                                       Cloudant authorization API
+     * @see CloudantClient#generateApiKey()
      * @see <a href="http://docs.cloudant.com/authorization.html#roles">Roles</a>
      * @see <a href="http://docs.cloudant.com/authorization.html#modifying-permissions">Modifying
      * permissions</a>
@@ -198,9 +211,10 @@ public class Database {
     }
 
     /**
-     * Get info about the shards in the database
+     * Get info about the shards in the database.
      *
      * @return List of shards
+     * @see <a href="https://docs.cloudant.com/advanced.html#get-/$db/_shards">_shards</a>
      */
     public List<Shard> getShards() {
         InputStream response = null;
@@ -215,10 +229,11 @@ public class Database {
     }
 
     /**
-     * Get info about the shard a document belongs to
+     * Get info about the shard a document belongs to.
      *
      * @param docId document ID
      * @return Shard info
+     * @see <a href="https://docs.cloudant.com/advanced.html#get-/$db/_shards">_shards</a>
      */
     public Shard getShard(String docId) {
         assertNotEmpty(docId, "docId");
@@ -227,6 +242,25 @@ public class Database {
 
     /**
      * Create a new index
+     * <P>
+     * Example usage creating an index that sorts ascending on name, then by year.
+     * </P>
+     * <pre>
+     * {@code
+     * db.createIndex("Person_name", "Person_name", null, new IndexField[]{
+     *       new IndexField("Person_name",SortOrder.asc),
+     *       new IndexField("Movie_year",SortOrder.asc)});
+     * }
+     * </pre>
+     * <P>
+     * Example usage creating an index that sorts ascending by year.
+     * </P>
+     * <pre>
+     * {@code
+     * db.createIndex("Movie_year", "Movie_year", null, new IndexField[]{
+     *      new IndexField("Movie_year",SortOrder.asc)});
+     * }
+     * </pre>
      *
      * @param indexName     optional name of the index (if not provided one will be generated)
      * @param designDocName optional name of the design doc in which the index will be created
@@ -240,9 +274,10 @@ public class Database {
     }
 
     /**
-     * create a new Index
+     * Create a new index from a JSON string
      *
-     * @param indexDefinition
+     * @param indexDefinition String representation of the index definition JSON
+     * @see #createIndex(String, String, String, IndexField[])
      * @see <a href="http://docs.cloudant.com/api/cloudant-query.html#creating-a-new-index">
      * index definition</a>
      */
@@ -267,10 +302,12 @@ public class Database {
     /**
      * Find documents using an index
      *
-     * @param selectorJson JSON object describing criteria used to select documents.
-     *                     Is of the form <code>"selector": {&lt;your data here&gt;} </code>
+     * @param selectorJson String representation of a JSON object describing criteria used to
+     *                     select documents. For example {@code "\"selector\": {<your data here>}"}.
      * @param classOfT     The class of Java objects to be returned
+     * @param <T>          the type of the Java object to be returned
      * @return List of classOfT objects
+     * @see #findByIndex(String, Class, FindByIndexOptions)
      * @see <a href="http://docs.cloudant.com/api/cloudant-query.html#cloudant-query-selectors">
      * selector syntax</a>
      */
@@ -280,11 +317,27 @@ public class Database {
 
     /**
      * Find documents using an index
+     * <P>
+     * Example usage to return the name and year of movies starring
+     * Alec Guinness since 1960 with the results sorted by year descending:
+     * </P>
+     * <pre>
+     * {@code
+     * List <Movie> movies = db.findByIndex("\"selector\": {
+     * \"Movie_year\": {\"$gt\": 1960}, \"Person_name\": \"Alec Guinness\"
+     * }",
+     * Movie.class,
+     * new FindByIndexOptions()
+     * .sort(new IndexField("Movie_year", SortOrder.desc))
+     * .fields("Movie_name").fields("Movie_year"));
+     * }
+     * </pre>
      *
-     * @param selectorJson JSON object describing criteria used to select documents.
-     *                     Is of the form <code>"selector": {&lt;your data here&gt;} </code>
+     * @param selectorJson String representation of a JSON object describing criteria used to
+     *                     select documents. For example {@code "\"selector\": {<your data here>}"}.
      * @param options      {@link FindByIndexOptions query Index options}
      * @param classOfT     The class of Java objects to be returned
+     * @param <T>          the type of the Java object to be returned
      * @return List of classOfT objects
      * @see <a href="http://docs.cloudant.com/api/cloudant-query.html#cloudant-query-selectors">
      * selector syntax</a>
@@ -321,8 +374,14 @@ public class Database {
 
     /**
      * List all indices
+     * <P>Example usage:</P>
+     * <pre>
+     * {@code
+     * List <Index> indices = db.listIndices();
+     * }
+     * </pre>
      *
-     * @return List of Index
+     * @return List of Index objects
      */
     public List<Index> listIndices() {
         InputStream response = null;
@@ -360,15 +419,18 @@ public class Database {
     /**
      * Provides access to Cloudant <tt>Search</tt> APIs.
      *
-     * @see Search
+     * @param searchIndexId the name of the index to search
+     * @return Search object for searching the index
+     * @see <a href="https://docs.cloudant.com/search.html">Search</a>
      */
     public Search search(String searchIndexId) {
         return new Search(client, this, searchIndexId);
     }
 
     /**
-     * Provides access to CouchDB Design Documents.
-     *
+     * Get a manager that has convenience methods for managing design documents.
+     * 
+     * @return a {@link DesignDocumentManager} for this database
      * @see DesignDocumentManager
      */
     public DesignDocumentManager getDesignDocumentManager() {
@@ -380,6 +442,7 @@ public class Database {
      * @param viewName  the view name
      * @return a builder to build view requests for the specified design document and view of
      * this database
+     * @see <a href="https://docs.cloudant.com/creating_views.html#using-views">Using views</a>
      */
     public ViewRequestBuilder getViewRequestBuilder(String designDoc, String viewName) {
         return new ViewRequestBuilder(client, this, designDoc, viewName);
@@ -409,9 +472,15 @@ public class Database {
     }
 
     /**
-     * Provides access to <tt>Change Notifications</tt> API.
+     * Provides access for interacting with the changes feed.
+     * <P>
+     * See the {@link com.cloudant.client.api.Changes} API for examples.
+     * </P>
      *
-     * @see Changes
+     * @return a Changes object for using the changes feed
+     * @see com.cloudant.client.api.Changes
+     * @see <a href="https://docs.cloudant.com/database.html#get-changes">Databases - get
+     * changes</a>
      */
     public com.cloudant.client.api.Changes changes() {
         Changes couchDbChanges = db.changes();
@@ -421,27 +490,41 @@ public class Database {
     }
 
     /**
-     * Finds an Object of the specified type.
+     * Retrieve the document with the specified ID from the database and deserialize to an
+     * instance of the POJO of type T.
      *
-     * @param <T>       Object type.
-     * @param classType The class of type T.
-     * @param id        The document id.
-     * @return An object of type T.
-     * @throws NoDocumentException If the document is not found in the database.
+     * @param <T>       object type
+     * @param classType the class of type T
+     * @param id        the document id
+     * @return an object of type T
+     * @throws NoDocumentException if the document is not found in the database
+     * @see #find(Class, String, String)
+     * @see <a href="https://docs.cloudant.com/document.html#read">Documents - read</a>
      */
     public <T> T find(Class<T> classType, String id) {
         return db.find(classType, id);
     }
 
     /**
-     * Finds an Object of the specified type.
+     * Retrieve the document with the specified ID from the database and deserialize to an
+     * instance of the POJO of type T. Uses the additional parameters specified when making the
+     * {@code GET} request.
+     * <P>Example usage to get inline attachments:</P>
+     * <pre>
+     * {@code
+     * Foo foo = db.find(Foo.class, "exampleId", new Params().attachments());
+     * String attachmentData = foo.getAttachments().get("attachment.txt").getData();
+     * }
+     * </pre>
      *
-     * @param <T>       Object type.
-     * @param classType The class of type T.
-     * @param id        The document id.
-     * @param params    Extra parameters to append.
-     * @return An object of type T.
-     * @throws NoDocumentException If the document is not found in the database.
+     * @param <T>       object type
+     * @param classType the class of type T
+     * @param id        the document id
+     * @param params    extra parameters to append
+     * @return An object of type T
+     * @throws NoDocumentException if the document is not found in the database.
+     * @see Params
+     * @see <a href="https://docs.cloudant.com/document.html#read">Documents - read</a>
      */
     public <T> T find(Class<T> classType, String id, Params params) {
         assertNotEmpty(params, "params");
@@ -449,14 +532,22 @@ public class Database {
     }
 
     /**
-     * Finds an Object of the specified type.
+     * Retrieve the document with the specified ID at the specified revision from the database
+     * and deserialize to an instance of the POJO of type T.
+     * <P>Example usage:</P>
+     * <pre>
+     * {@code
+     *     Foo foo = db.find(Foo.class, "exampleId", "1-12345exampleRev");
+     * }
+     * </pre>
      *
-     * @param <T>       Object type.
-     * @param classType The class of type T.
-     * @param id        The document _id field.
-     * @param rev       The document _rev field.
-     * @return An object of type T.
-     * @throws NoDocumentException If the document is not found in the database.
+     * @param <T>       object type
+     * @param classType the class of type T
+     * @param id        the document _id field
+     * @param rev       the document _rev field
+     * @return an object of type T
+     * @throws NoDocumentException if the document is not found in the database.
+     * @see <a href="https://docs.cloudant.com/document.html#read">Documents - read</a>
      */
     public <T> T find(Class<T> classType, String id, String rev) {
         return db.find(classType, id, rev);
@@ -464,22 +555,32 @@ public class Database {
 
     /**
      * This method finds any document given a URI.
-     * <p>The URI must be URI-encoded.
+     * <p>The URI must be URI-encoded.</p>
+     * <P>
+     * Example usage retrieving the Foo POJO with document ID "exampleId" from the database
+     * "exampleDb" in the "example" Cloudant account.
+     * </P>
+     * <pre>
+     * {@code
+     * Foo foo = db.findAny(Foo.class, "https://example.cloudant.com/exampleDb/exampleId");
+     * }
+     * </pre>
      *
-     * @param classType The class of type T.
-     * @param uri       The URI as string.
-     * @return An object of type T.
+     * @param classType the class of type T
+     * @param uri       the URI as string
+     * @param <T>       the type of Java object to return
+     * @return an object of type T
      */
     public <T> T findAny(Class<T> classType, String uri) {
         return db.findAny(classType, uri);
     }
 
     /**
-     * Finds a document and return the result as {@link InputStream}.
-     * <p><b>Note</b>: The stream must be closed after use to release the connection.
+     * Finds the document with the specified document ID and returns it as an {@link InputStream}.
+     * <p><b>Note</b>: The stream must be closed after use to release the connection.</p>
      *
-     * @param id The document _id field.
-     * @return The result as {@link InputStream}
+     * @param id the document _id field
+     * @return the result as {@link InputStream}
      * @throws NoDocumentException If the document is not found in the database.
      * @see #find(String, String)
      */
@@ -488,34 +589,82 @@ public class Database {
     }
 
     /**
-     * Finds a document given id and revision and returns the result as {@link InputStream}.
-     * <p><b>Note</b>: The stream must be closed after use to release the connection.
+     * Finds the document with the specified document ID and revision and returns it as {@link
+     * InputStream}.
+     * <p><b>Note</b>: The stream must be closed after use to release the connection.</p>
+     * <P>Example usage:</P>
+     * <pre>
+     * {@code
+     * InputStream inputStream = null;
+     * try{
+     *     inputStream = db.find("exampleId", "1-12345exampleRev");
+     *     //do stuff with the stream
+     * } finally {
+     *     //close the input stream
+     *     inputStream.close();
+     * }
+     * }
+     * </pre>
      *
-     * @param id  The document _id field.
-     * @param rev The document _rev field.
-     * @return The result as {@link InputStream}
-     * @throws NoDocumentException If the document is not found in the database.
+     * @param id  the document _id field
+     * @param rev the document _rev field
+     * @return the result as {@link InputStream}
+     * @throws NoDocumentException if the document is not found in the database at the specified
+     *                             revision
+     * @see <a href="https://docs.cloudant.com/document.html#read">Documents - read</a>
      */
     public InputStream find(String id, String rev) {
         return db.find(id, rev);
     }
 
     /**
-     * Checks if a document exist in the database.
+     * Checks if a document exists in the database.
      *
-     * @param id The document _id field.
-     * @return true If the document is found, false otherwise.
+     * @param id the document _id field
+     * @return {@code true} if the document is found, {@code false} otherwise
      */
     public boolean contains(String id) {
         return db.contains(id);
     }
 
     /**
-     * Saves an object in the database, using HTTP <tt>PUT</tt> request.
-     * <p>If the object doesn't have an <code>_id</code> value, the code will assign a
-     * <code>UUID</code> as the document id.
+     * Saves a document in the database.
+     * <p>If the serialized object's JSON does not contain an {@code _id} field, then a UUID will
+     * be generated for the document ID.
+     * </p>
+     * <P>
+     * Example of inserting a JsonObject into the database:
+     * </P>
+     * <pre>
+     * {@code
+     * JsonObject json = new JsonObject();
+     * json.addProperty("_id", "test-doc-id-2");
+     * json.add("json-array", new JsonArray());
+     * Response response = db.save(json);
+     * }
+     * </pre>
+     * <P>
+     * Example of inserting a POJO into the database:
+     * </P>
+     * <pre>
+     * {@code
+     * Foo foo = new Foo();
+     * Response response = db.save(foo);
+     * }
+     * </pre>
+     * <P>
+     * Example of inserting a Map into the database:
+     * </P>
+     * <pre>
+     * {@code
+     * Map<String, Object> map = new HashMap<>();
+     * map.put("_id", "test-doc-id-1");
+     * map.put("title", "test-doc");
+     * Response response = db.save(map);
+     * }
+     * </pre>
      *
-     * @param object The object to save
+     * @param object the object to save
      * @return {@link Response}
      * @throws DocumentConflictException If a conflict is detected during the save.
      */
@@ -527,14 +676,16 @@ public class Database {
     }
 
     /**
-     * Saves an object in the database, using HTTP <tt>PUT</tt> request.
-     * <p>If the object doesn't have an <code>_id</code> value, the code will assign a
-     * <code>UUID</code> as the document id.
+     * Saves a document in the database similarly to {@link Database#save(Object)} but using a
+     * specific write quorum.
      *
-     * @param object      The object to save
-     * @param writeQuorum the write Quorum
+     * @param object      the object to save
+     * @param writeQuorum the write quorum
      * @return {@link Response}
      * @throws DocumentConflictException If a conflict is detected during the save.
+     * @see Database#save(Object)
+     * @see <a href="https://docs.cloudant.com/document.html#quorum---writing-and-reading-data">
+     * Documents - quorum</a>
      */
     public com.cloudant.client.api.model.Response save(Object object, int writeQuorum) {
         Response couchDbResponse = client.couchDbClient.put(getDBUri(), object, true, writeQuorum);
@@ -544,11 +695,22 @@ public class Database {
     }
 
     /**
-     * Saves an object in the database using HTTP <tt>POST</tt> request.
-     * <p>The database will be responsible for generating the document id.
+     * Creates a document in the database using a HTTP {@code POST} request.
+     * <p>If the serialized object's JSON does not contain an {@code _id} field, then the server
+     * will generate a document ID.</p>
+     * <P>
+     * Example of creating a document in the database for a POJO:
+     * </P>
+     * <pre>
+     * {@code
+     * Foo foo = new Foo();
+     * Response response = db.post(foo);
+     * }
+     * </pre>
      *
      * @param object The object to save
      * @return {@link Response}
+     * @see <a href="https://docs.cloudant.com/document.html#documentCreate">Documents - create</a>
      */
     public com.cloudant.client.api.model.Response post(Object object) {
         Response couchDbResponse = db.post(object);
@@ -558,13 +720,15 @@ public class Database {
     }
 
     /**
-     * Saves an object in the database using HTTP <tt>POST</tt> request with specificied write
-     * quorum
-     * <p>The database will be responsible for generating the document id.
+     * Creates a document in the database similarly to {@link Database#post(Object)} but using a
+     * specific write quorum.
      *
      * @param object      The object to save
      * @param writeQuorum the write Quorum
      * @return {@link Response}
+     * @see Database#post(Object)
+     * @see <a href="https://docs.cloudant.com/document.html#quorum---writing-and-reading-data">
+     * Documents - quorum</a>
      */
     public com.cloudant.client.api.model.Response post(Object object, int writeQuorum) {
         assertNotEmpty(object, "object");
@@ -593,12 +757,24 @@ public class Database {
     }
 
     /**
-     * Updates an object in the database, the object must have the correct <code>_id</code> and
-     * <code>_rev</code> values.
+     * Updates an object in the database, the object must have the correct {@code _id} and
+     * {@code _rev} values.
+     * <P>Example usage:</P>
+     * <pre>
+     * {@code
+     * //get a Bar object from the database
+     * Bar bar = db.find(Bar.class, "exampleId");
+     * //change something about bar
+     * bar.setSomeProperty(true);
+     * //now update the remote Bar
+     * Response responseUpdate = db.update(bar);
+     * }
+     * </pre>
      *
-     * @param object The object to update
+     * @param object the object to update
      * @return {@link Response}
-     * @throws DocumentConflictException If a conflict is detected during the update.
+     * @throws DocumentConflictException if a conflict is detected during the update.
+     * @see <a href="https://docs.cloudant.com/document.html#update">Documents - update</a>
      */
     public com.cloudant.client.api.model.Response update(Object object) {
         Response couchDbResponse = db.update(object);
@@ -608,13 +784,16 @@ public class Database {
     }
 
     /**
-     * Updates an object in the database, the object must have the correct <code>_id</code> and
-     * <code>_rev</code> values.
+     * Updates an object in the database similarly to {@link #update(Object)}, but specifying the
+     * write quorum.
      *
-     * @param object      The object to update
-     * @param writeQuorum the write Quorum
+     * @param object      the object to update
+     * @param writeQuorum the write quorum
      * @return {@link Response}
-     * @throws DocumentConflictException If a conflict is detected during the update.
+     * @throws DocumentConflictException if a conflict is detected during the update.
+     * @see Database#update(Object)
+     * @see <a href="https://docs.cloudant.com/document.html#quorum---writing-and-reading-data">
+     * Documents - quorum</a>
      */
     public com.cloudant.client.api.model.Response update(Object object, int writeQuorum) {
         Response couchDbResponse = client.couchDbClient.put(getDBUri(), object, false, writeQuorum);
@@ -625,11 +804,21 @@ public class Database {
 
     /**
      * Removes a document from the database.
-     * <p>The object must have the correct <code>_id</code> and <code>_rev</code> values.
+     * <p>The object must have the correct {@code _id} and {@code _rev} values.</p>
+     * <P>Example usage:</P>
+     * <pre>
+     * {@code
+     * //get a Bar object from the database
+     * Bar bar = db.find(Bar.class, "exampleId");
+     * //now remove the remote Bar
+     * Response response = db.remove(bar);
+     * }
+     * </pre>
      *
-     * @param object The document to remove as object.
+     * @param object the document to remove as an object
      * @return {@link Response}
      * @throws NoDocumentException If the document is not found in the database.
+     * @see <a href="https://docs.cloudant.com/document.html#delete">Documents - delete</a>
      */
     public com.cloudant.client.api.model.Response remove(Object object) {
         Response couchDbResponse = db.remove(object);
@@ -639,13 +828,20 @@ public class Database {
     }
 
     /**
-     * Removes a document from the database given both a document <code>_id</code> and
-     * <code>_rev</code> values.
+     * Removes the document from the database with the specified {@code _id} and {@code _rev}
+     * values.
+     * <P>Example usage:</P>
+     * <pre>
+     * {@code
+     * Response response = db.remove("exampleId", "1-12345exampleRev");
+     * }
+     * </pre>
      *
-     * @param id  The document _id field.
-     * @param rev The document _rev field.
+     * @param id  the document _id field
+     * @param rev the document _rev field
      * @return {@link Response}
      * @throws NoDocumentException If the document is not found in the database.
+     * @see <a href="https://docs.cloudant.com/document.html#delete">Documents - delete</a>
      */
     public com.cloudant.client.api.model.Response remove(String id, String rev) {
         Response couchDbResponse = db.remove(id, rev);
@@ -655,10 +851,25 @@ public class Database {
     }
 
     /**
-     * Performs a Bulk Documents insert request.
+     * Uses the {@code _bulk_docs} endpoint to insert multiple documents into the database in a
+     * single HTTP request.
+     * <P>Example usage:</P>
+     * <pre>
+     * {@code
+     * //create a list
+     * List<Object> newDocs = new ArrayList<Object>();
+     * //add some objects to the list
+     * newDocs.add(new Foo());
+     * newDocs.add(new JsonObject());
+     * //use the bulk insert
+     * List<Response> responses = db.bulk(newDocs);
+     * }
+     * </pre>
      *
-     * @param objects The {@link List} of objects.
-     * @return {@code List<Response>} Containing the resulted entries.
+     * @param objects the {@link List} of objects
+     * @return {@code List<Response>} one per object
+     * @see <a href="https://docs.cloudant.com/document.html#bulk-operations">
+     * Documents - bulk operations</a>
      */
     public List<com.cloudant.client.api.model.Response> bulk(List<?> objects) {
         List<Response> couchDbResponseList = db.bulk(objects, false);
@@ -673,13 +884,23 @@ public class Database {
     }
 
     /**
-     * Saves an attachment to a new document with a generated <tt>UUID</tt> as the document id.
-     * <p>To retrieve an attachment, see {@link #find(String)}.
+     * Creates an attachment from the specified InputStream and a new document with a generated
+     * document ID.
+     * <P>Example usage:</P>
+     * <pre>
+     * {@code
+     * byte[] bytesToDB = "binary data".getBytes();
+     * ByteArrayInputStream bytesIn = new ByteArrayInputStream(bytesToDB);
+     * Response response = db.saveAttachment(bytesIn, "foo.txt", "text/plain");
+     * }
+     * </pre>
+     * <p>To retrieve an attachment, see {@link #find(Class, String, Params)}</p>
      *
-     * @param in          The {@link InputStream} holding the binary data.
+     * @param in          The {@link InputStream} providing the binary data.
      * @param name        The attachment name.
      * @param contentType The attachment "Content-Type".
      * @return {@link Response}
+     * @see <a href="https://docs.cloudant.com/attachments.html">Attachments</a>
      */
     public com.cloudant.client.api.model.Response saveAttachment(InputStream in, String name,
                                                                  String contentType) {
@@ -690,11 +911,25 @@ public class Database {
     }
 
     /**
+     * Creates or updates an attachment on the given document ID and revision.
+     * <P>
+     * If {@code docId} and {@code docRev} are {@code null} a new document will be created.
+     * </P>
+     * <P>
+     * Example usage:
+     * </P>
+     * <pre>
+     * {@code
+     * byte[] bytesToDB = "binary data".getBytes();
+     * ByteArrayInputStream bytesIn = new ByteArrayInputStream(bytesToDB);
+     * Response response = db.saveAttachment(bytesIn, "foo.txt", "text/plain","exampleId","3-rev");
+     * }
+     * </pre>
      * Saves an attachment to an existing document given both a document id
      * and revision, or save to a new document given only the id, and rev as {@code null}.
-     * <p>To retrieve an attachment, see {@link #find(String)}.
+     * <p>To retrieve an attachment, see {@link #find(Class, String, Params)}</p>
      *
-     * @param in          The {@link InputStream} holding the binary data.
+     * @param in          The {@link InputStream} providing the binary data.
      * @param name        The attachment name.
      * @param contentType The attachment "Content-Type".
      * @param docId       The document id to save the attachment under, or {@code null} to save
@@ -702,7 +937,8 @@ public class Database {
      * @param docRev      The document revision to save the attachment under, or {@code null}
      *                    when saving to a new document.
      * @return {@link Response}
-     * @throws DocumentConflictException
+     * @throws DocumentConflictException if the attachment cannot be saved because of a conflict
+     * @see <a href="https://docs.cloudant.com/attachments.html">Attachments</a>
      */
     public com.cloudant.client.api.model.Response saveAttachment(InputStream in, String name,
                                                                  String contentType, String
@@ -734,6 +970,17 @@ public class Database {
 
     /**
      * Invokes an Update Handler.
+     * <P>Example usage:</P>
+     * <pre>
+     * {@code
+     * final String newValue = "foo bar";
+     * Params params = new Params()
+     *         .addParam("field", "title")
+     *         .addParam("value", newValue);
+     * String output = db.invokeUpdateHandler("example/example_update", "exampleId", params);
+     *
+     * }
+     * </pre>
      * <pre>
      * Params params = new Params()
      * 	.addParam("field", "foo")
@@ -745,6 +992,8 @@ public class Database {
      * @param docId            The document id to update.
      * @param params           The query parameters as {@link Params}.
      * @return The output of the request.
+     * @see <a href="https://docs.cloudant.com/design_documents.html#update-handlers">
+     * Design documents - update handlers</a>
      */
     public String invokeUpdateHandler(String updateHandlerUri, String docId,
                                       Params params) {
@@ -760,7 +1009,10 @@ public class Database {
     }
 
     /**
-     * @return {@link CouchDbInfo} Containing the DB info.
+     * Get information about this database.
+     *
+     * @return DbInfo encapsulating the database info
+     * @see <a href="https://docs.cloudant.com/database.html#read">Databases - read</a>
      */
     public DbInfo info() {
         return client.couchDbClient.get(buildUri(getDBUri()).build(), DbInfo.class);
@@ -768,6 +1020,11 @@ public class Database {
 
     /**
      * Requests the database commits any recent changes to disk.
+     *
+     * @see <a
+     * href="http://docs.couchdb.org/en/1.6.1/api/database/compact.html#db-ensure-full-commit">
+     * CouchDB _ensure_full_commit
+     * </a>
      */
     public void ensureFullCommit() {
         db.ensureFullCommit();
@@ -816,11 +1073,6 @@ public class Database {
         return json + "] }}";
     }
 
-    /**
-     * @param selectorJson
-     * @param options
-     * @return
-     */
     private String getFindByIndexBody(String selectorJson,
                                       FindByIndexOptions options) {
 

--- a/src/main/java/com/cloudant/client/api/Database.java
+++ b/src/main/java/com/cloudant/client/api/Database.java
@@ -748,15 +748,6 @@ public class Database {
     }
 
     /**
-     * Saves a document with <tt>batch=ok</tt> query param.
-     *
-     * @param object The object to save.
-     */
-    public void batch(Object object) {
-        db.batch(object);
-    }
-
-    /**
      * Updates an object in the database, the object must have the correct {@code _id} and
      * {@code _rev} values.
      * <P>Example usage:</P>
@@ -947,25 +938,6 @@ public class Database {
         com.cloudant.client.api.model.Response response = new com.cloudant.client.api.model
                 .Response(couchDbResponse);
         return response;
-    }
-
-    /**
-     * Invokes an Update Handler.
-     * <code>String query = "field=foo&amp;value=bar";</code>
-     * <code>String output = dbClient.invokeUpdateHandler("designDoc/update1", "docId", query);
-     * </code>
-     *
-     * @param updateHandlerUri The Update Handler URI, in the format: <code>designDoc/update1</code>
-     * @param docId            The document id to update.
-     * @param query            The query string parameters, e.g,
-     *                         <code>field=field1&amp;value=value1</code>
-     * @return The output of the request.
-     * @deprecated use {@link #invokeUpdateHandler(String, String, Params)} instead.
-     */
-    @Deprecated
-    public String invokeUpdateHandler(String updateHandlerUri, String docId,
-                                      String query) {
-        return db.invokeUpdateHandler(updateHandlerUri, docId, query);
     }
 
     /**

--- a/src/main/java/com/cloudant/client/api/Database.java
+++ b/src/main/java/com/cloudant/client/api/Database.java
@@ -102,7 +102,7 @@ public class Database {
      * Set permissions for a user/apiKey on this database.
      * <p>
      * Note this method is only applicable to databases that support the
-     * <a href="http://docs.cloudant.com/authorization.html">
+     * <a target="_blank" href="http://docs.cloudant.com/authorization.html">
      * Cloudant authorization API
      * </a> such as Cloudant DBaaS. For unsupported databases consider using the /db/_security
      * endpoint.
@@ -126,8 +126,9 @@ public class Database {
      * @throws UnsupportedOperationException if called on a database that does not provide the
      *                                       Cloudant authorization API
      * @see CloudantClient#generateApiKey()
-     * @see <a href="http://docs.cloudant.com/authorization.html#roles">Roles</a>
-     * @see <a href="http://docs.cloudant.com/authorization.html#modifying-permissions">Modifying
+     * @see <a target="_blank" href="http://docs.cloudant.com/authorization.html#roles">Roles</a>
+     * @see <a target="_blank"
+     * href="http://docs.cloudant.com/authorization.html#modifying-permissions">Modifying
      * permissions</a>
      */
     public void setPermissions(String userNameorApikey, EnumSet<Permissions> permissions) {
@@ -191,7 +192,7 @@ public class Database {
      * Returns the Permissions of this database.
      * <p>
      * Note this method is only applicable to databases that support the
-     * <a href="http://docs.cloudant.com/authorization.html">
+     * <a target="_blank" href="http://docs.cloudant.com/authorization.html">
      * Cloudant authorization API
      * </a> such as Cloudant DBaaS. For unsupported databases consider using the /db/_security
      * endpoint.
@@ -200,8 +201,9 @@ public class Database {
      * @return the map of userNames to their Permissions
      * @throws UnsupportedOperationException if called on a database that does not provide the
      *                                       Cloudant authorization API
-     * @see <a href="http://docs.cloudant.com/authorization.html#roles">Roles</a>
-     * @see <a href="http://docs.cloudant.com/authorization.html#viewing-permissions">Viewing
+     * @see <a target="_blank" href="http://docs.cloudant.com/authorization.html#roles">Roles</a>
+     * @see <a target="_blank"
+     * href="http://docs.cloudant.com/authorization.html#viewing-permissions">Viewing
      * permissions</a>
      */
     public Map<String, EnumSet<Permissions>> getPermissions() {
@@ -214,7 +216,8 @@ public class Database {
      * Get info about the shards in the database.
      *
      * @return List of shards
-     * @see <a href="https://docs.cloudant.com/advanced.html#get-/$db/_shards">_shards</a>
+     * @see <a target="_blank"
+     * href="https://docs.cloudant.com/advanced.html#get-/$db/_shards">_shards</a>
      */
     public List<Shard> getShards() {
         InputStream response = null;
@@ -233,7 +236,8 @@ public class Database {
      *
      * @param docId document ID
      * @return Shard info
-     * @see <a href="https://docs.cloudant.com/advanced.html#get-/$db/_shards">_shards</a>
+     * @see <a target="_blank"
+     * href="https://docs.cloudant.com/advanced.html#get-/$db/_shards">_shards</a>
      */
     public Shard getShard(String docId) {
         assertNotEmpty(docId, "docId");
@@ -278,7 +282,8 @@ public class Database {
      *
      * @param indexDefinition String representation of the index definition JSON
      * @see #createIndex(String, String, String, IndexField[])
-     * @see <a href="http://docs.cloudant.com/api/cloudant-query.html#creating-a-new-index">
+     * @see <a target="_blank"
+     * href="http://docs.cloudant.com/api/cloudant-query.html#creating-a-new-index">
      * index definition</a>
      */
     public void createIndex(String indexDefinition) {
@@ -308,7 +313,8 @@ public class Database {
      * @param <T>          the type of the Java object to be returned
      * @return List of classOfT objects
      * @see #findByIndex(String, Class, FindByIndexOptions)
-     * @see <a href="http://docs.cloudant.com/api/cloudant-query.html#cloudant-query-selectors">
+     * @see <a target="_blank"
+     * href="http://docs.cloudant.com/api/cloudant-query.html#cloudant-query-selectors">
      * selector syntax</a>
      */
     public <T> List<T> findByIndex(String selectorJson, Class<T> classOfT) {
@@ -339,7 +345,8 @@ public class Database {
      * @param classOfT     The class of Java objects to be returned
      * @param <T>          the type of the Java object to be returned
      * @return List of classOfT objects
-     * @see <a href="http://docs.cloudant.com/api/cloudant-query.html#cloudant-query-selectors">
+     * @see <a target="_blank"
+     * href="http://docs.cloudant.com/api/cloudant-query.html#cloudant-query-selectors">
      * selector syntax</a>
      */
     public <T> List<T> findByIndex(String selectorJson, Class<T> classOfT, FindByIndexOptions
@@ -421,7 +428,7 @@ public class Database {
      *
      * @param searchIndexId the name of the index to search
      * @return Search object for searching the index
-     * @see <a href="https://docs.cloudant.com/search.html">Search</a>
+     * @see <a target="_blank" href="https://docs.cloudant.com/search.html">Search</a>
      */
     public Search search(String searchIndexId) {
         return new Search(client, this, searchIndexId);
@@ -442,7 +449,8 @@ public class Database {
      * @param viewName  the view name
      * @return a builder to build view requests for the specified design document and view of
      * this database
-     * @see <a href="https://docs.cloudant.com/creating_views.html#using-views">Using views</a>
+     * @see <a target="_blank"
+     * href="https://docs.cloudant.com/creating_views.html#using-views">Using views</a>
      */
     public ViewRequestBuilder getViewRequestBuilder(String designDoc, String viewName) {
         return new ViewRequestBuilder(client, this, designDoc, viewName);
@@ -479,7 +487,8 @@ public class Database {
      *
      * @return a Changes object for using the changes feed
      * @see com.cloudant.client.api.Changes
-     * @see <a href="https://docs.cloudant.com/database.html#get-changes">Databases - get
+     * @see <a target="_blank"
+     * href="https://docs.cloudant.com/database.html#get-changes">Databases - get
      * changes</a>
      */
     public com.cloudant.client.api.Changes changes() {
@@ -499,7 +508,8 @@ public class Database {
      * @return an object of type T
      * @throws NoDocumentException if the document is not found in the database
      * @see #find(Class, String, String)
-     * @see <a href="https://docs.cloudant.com/document.html#read">Documents - read</a>
+     * @see <a target="_blank" href="https://docs.cloudant.com/document.html#read">Documents -
+     * read</a>
      */
     public <T> T find(Class<T> classType, String id) {
         return db.find(classType, id);
@@ -524,7 +534,8 @@ public class Database {
      * @return An object of type T
      * @throws NoDocumentException if the document is not found in the database.
      * @see Params
-     * @see <a href="https://docs.cloudant.com/document.html#read">Documents - read</a>
+     * @see <a target="_blank" href="https://docs.cloudant.com/document.html#read">Documents -
+     * read</a>
      */
     public <T> T find(Class<T> classType, String id, Params params) {
         assertNotEmpty(params, "params");
@@ -547,7 +558,8 @@ public class Database {
      * @param rev       the document _rev field
      * @return an object of type T
      * @throws NoDocumentException if the document is not found in the database.
-     * @see <a href="https://docs.cloudant.com/document.html#read">Documents - read</a>
+     * @see <a target="_blank" href="https://docs.cloudant.com/document.html#read">Documents -
+     * read</a>
      */
     public <T> T find(Class<T> classType, String id, String rev) {
         return db.find(classType, id, rev);
@@ -611,7 +623,8 @@ public class Database {
      * @return the result as {@link InputStream}
      * @throws NoDocumentException if the document is not found in the database at the specified
      *                             revision
-     * @see <a href="https://docs.cloudant.com/document.html#read">Documents - read</a>
+     * @see <a target="_blank" href="https://docs.cloudant.com/document.html#read">Documents -
+     * read</a>
      */
     public InputStream find(String id, String rev) {
         return db.find(id, rev);
@@ -684,7 +697,8 @@ public class Database {
      * @return {@link Response}
      * @throws DocumentConflictException If a conflict is detected during the save.
      * @see Database#save(Object)
-     * @see <a href="https://docs.cloudant.com/document.html#quorum---writing-and-reading-data">
+     * @see <a target="_blank"
+     * href="https://docs.cloudant.com/document.html#quorum---writing-and-reading-data">
      * Documents - quorum</a>
      */
     public com.cloudant.client.api.model.Response save(Object object, int writeQuorum) {
@@ -710,7 +724,8 @@ public class Database {
      *
      * @param object The object to save
      * @return {@link Response}
-     * @see <a href="https://docs.cloudant.com/document.html#documentCreate">Documents - create</a>
+     * @see <a target="_blank"
+     * href="https://docs.cloudant.com/document.html#documentCreate">Documents - create</a>
      */
     public com.cloudant.client.api.model.Response post(Object object) {
         Response couchDbResponse = db.post(object);
@@ -727,7 +742,8 @@ public class Database {
      * @param writeQuorum the write Quorum
      * @return {@link Response}
      * @see Database#post(Object)
-     * @see <a href="https://docs.cloudant.com/document.html#quorum---writing-and-reading-data">
+     * @see <a target="_blank"
+     * href="https://docs.cloudant.com/document.html#quorum---writing-and-reading-data">
      * Documents - quorum</a>
      */
     public com.cloudant.client.api.model.Response post(Object object, int writeQuorum) {
@@ -765,7 +781,8 @@ public class Database {
      * @param object the object to update
      * @return {@link Response}
      * @throws DocumentConflictException if a conflict is detected during the update.
-     * @see <a href="https://docs.cloudant.com/document.html#update">Documents - update</a>
+     * @see <a target="_blank" href="https://docs.cloudant.com/document.html#update">Documents -
+     * update</a>
      */
     public com.cloudant.client.api.model.Response update(Object object) {
         Response couchDbResponse = db.update(object);
@@ -783,7 +800,8 @@ public class Database {
      * @return {@link Response}
      * @throws DocumentConflictException if a conflict is detected during the update.
      * @see Database#update(Object)
-     * @see <a href="https://docs.cloudant.com/document.html#quorum---writing-and-reading-data">
+     * @see <a target="_blank"
+     * href="https://docs.cloudant.com/document.html#quorum---writing-and-reading-data">
      * Documents - quorum</a>
      */
     public com.cloudant.client.api.model.Response update(Object object, int writeQuorum) {
@@ -809,7 +827,8 @@ public class Database {
      * @param object the document to remove as an object
      * @return {@link Response}
      * @throws NoDocumentException If the document is not found in the database.
-     * @see <a href="https://docs.cloudant.com/document.html#delete">Documents - delete</a>
+     * @see <a target="_blank" href="https://docs.cloudant.com/document.html#delete">Documents -
+     * delete</a>
      */
     public com.cloudant.client.api.model.Response remove(Object object) {
         Response couchDbResponse = db.remove(object);
@@ -832,7 +851,8 @@ public class Database {
      * @param rev the document _rev field
      * @return {@link Response}
      * @throws NoDocumentException If the document is not found in the database.
-     * @see <a href="https://docs.cloudant.com/document.html#delete">Documents - delete</a>
+     * @see <a target="_blank" href="https://docs.cloudant.com/document.html#delete">Documents -
+     * delete</a>
      */
     public com.cloudant.client.api.model.Response remove(String id, String rev) {
         Response couchDbResponse = db.remove(id, rev);
@@ -859,7 +879,7 @@ public class Database {
      *
      * @param objects the {@link List} of objects
      * @return {@code List<Response>} one per object
-     * @see <a href="https://docs.cloudant.com/document.html#bulk-operations">
+     * @see <a target="_blank" href="https://docs.cloudant.com/document.html#bulk-operations">
      * Documents - bulk operations</a>
      */
     public List<com.cloudant.client.api.model.Response> bulk(List<?> objects) {
@@ -891,7 +911,7 @@ public class Database {
      * @param name        The attachment name.
      * @param contentType The attachment "Content-Type".
      * @return {@link Response}
-     * @see <a href="https://docs.cloudant.com/attachments.html">Attachments</a>
+     * @see <a target="_blank" href="https://docs.cloudant.com/attachments.html">Attachments</a>
      */
     public com.cloudant.client.api.model.Response saveAttachment(InputStream in, String name,
                                                                  String contentType) {
@@ -929,7 +949,7 @@ public class Database {
      *                    when saving to a new document.
      * @return {@link Response}
      * @throws DocumentConflictException if the attachment cannot be saved because of a conflict
-     * @see <a href="https://docs.cloudant.com/attachments.html">Attachments</a>
+     * @see <a target="_blank" href="https://docs.cloudant.com/attachments.html">Attachments</a>
      */
     public com.cloudant.client.api.model.Response saveAttachment(InputStream in, String name,
                                                                  String contentType, String
@@ -964,7 +984,8 @@ public class Database {
      * @param docId            The document id to update.
      * @param params           The query parameters as {@link Params}.
      * @return The output of the request.
-     * @see <a href="https://docs.cloudant.com/design_documents.html#update-handlers">
+     * @see <a target="_blank"
+     * href="https://docs.cloudant.com/design_documents.html#update-handlers">
      * Design documents - update handlers</a>
      */
     public String invokeUpdateHandler(String updateHandlerUri, String docId,
@@ -984,7 +1005,8 @@ public class Database {
      * Get information about this database.
      *
      * @return DbInfo encapsulating the database info
-     * @see <a href="https://docs.cloudant.com/database.html#read">Databases - read</a>
+     * @see <a target="_blank" href="https://docs.cloudant.com/database.html#read">Databases -
+     * read</a>
      */
     public DbInfo info() {
         return client.couchDbClient.get(buildUri(getDBUri()).build(), DbInfo.class);

--- a/src/main/java/com/cloudant/client/api/DesignDocumentManager.java
+++ b/src/main/java/com/cloudant/client/api/DesignDocumentManager.java
@@ -27,7 +27,6 @@ import org.apache.commons.io.FileUtils;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
-import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -63,17 +62,16 @@ import java.util.List;
  * }
  * </pre>
  *
- * @see {@link Database#getDesignDocumentManager()} to access the API.
+ * See {@link Database#getDesignDocumentManager()} to access the API.
+ *
  * @see DesignDocument
  * @since 2.0.0
  */
 public class DesignDocumentManager {
 
-    private URI dbUri;
     private Database db;
 
     DesignDocumentManager(Database db) {
-        this.dbUri = db.getDBUri();
         this.db = db;
     }
 
@@ -86,12 +84,13 @@ public class DesignDocumentManager {
      * using {@code equals()}. If both documents are not equal, then the given document will be
      * saved to the database and updates the existing document.
      *
-     * @param document The design document to synchronize
+     * @param document the design document to synchronize (optionally prefixed with "_design/")
      * @return {@link Response} as a result of a document save or update, or returns {@code null}
-     * if no action was taken and the document in the database is up-to-date with the given document.
+     * if no action was taken and the document in the database is up-to-date with the given
+     * document.
      */
     public Response put(DesignDocument document) {
-        CouchDbUtil.assertNotEmpty(document, "Document");
+        CouchDbUtil.assertNotEmpty(document, "DesignDocument");
         DesignDocument documentFromDb;
         try {
             documentFromDb = get(document.getId());
@@ -106,6 +105,12 @@ public class DesignDocumentManager {
         return null;
     }
 
+    /**
+     * Synchronize multiple design documents with the database.
+     *
+     * @param designDocs DesignDocument objects to put in the database
+     * @see #put(DesignDocument)
+     */
     public void put(DesignDocument... designDocs) {
         for (DesignDocument designDocument : designDocs) {
             put(designDocument);
@@ -115,7 +120,7 @@ public class DesignDocumentManager {
     /**
      * Gets a design document from the database.
      *
-     * @param id The document id
+     * @param id the design document id (optionally prefixed with "_design/")
      * @return {@link DesignDocument}
      */
     public DesignDocument get(String id) {
@@ -125,10 +130,10 @@ public class DesignDocumentManager {
     }
 
     /**
-     * Gets a design document using the id and rev from the database.
+     * Gets a design document using the id and revision from the database.
      *
-     * @param id  The document id
-     * @param rev The document revision
+     * @param id  the document id (optionally prefixed with "_design/")
+     * @param rev the document revision
      * @return {@link DesignDocument}
      */
     public DesignDocument get(String id, String rev) {
@@ -141,7 +146,7 @@ public class DesignDocumentManager {
     /**
      * Removes a design document from the database.
      *
-     * @param id The document id
+     * @param id the document id (optionally prefixed with "_design/")
      * @return {@link DesignDocument}
      */
     public Response remove(String id) {
@@ -154,8 +159,8 @@ public class DesignDocumentManager {
     /**
      * Removes a design document using the id and rev from the database.
      *
-     * @param id  The document id
-     * @param rev The document revision
+     * @param id  the document id
+     * @param rev the document revision
      * @return {@link DesignDocument}
      */
     public Response remove(String id, String rev) {
@@ -178,10 +183,11 @@ public class DesignDocumentManager {
     }
 
     /**
-     * Deserialize a directory of javascript design documents to a DesignDocument object.
+     * Deserialize a directory of javascript design documents to a List of DesignDocument objects.
      *
      * @param directory the directory containing javascript files
      * @return {@link DesignDocument}
+     * @throws FileNotFoundException if the file does not exist or cannot be read
      */
     public static List<DesignDocument> fromDirectory(File directory) throws FileNotFoundException {
         List<DesignDocument> designDocuments = new ArrayList<DesignDocument>();
@@ -197,10 +203,11 @@ public class DesignDocumentManager {
     }
 
     /**
-     * Deserialize a javascript design document to a DesignDocument object.
+     * Deserialize a javascript design document file to a DesignDocument object.
      *
      * @param file the design document javascript file
      * @return {@link DesignDocument}
+     * @throws FileNotFoundException if the file does not exist or cannot be read
      */
     public static DesignDocument fromFile(File file) throws FileNotFoundException {
         assertNotEmpty(file, "Design js file");

--- a/src/main/java/com/cloudant/client/api/Replication.java
+++ b/src/main/java/com/cloudant/client/api/Replication.java
@@ -52,7 +52,8 @@ public class Replication {
     }
 
     /**
-     * Triggers a replication request.
+     * Triggers a replication request, blocks while the replication is in progress.
+     * @return ReplicationResult encapsulating the result
      */
     public com.cloudant.client.api.model.ReplicationResult trigger() {
         ReplicationResult couchDbReplicationResult = replication.trigger();
@@ -61,93 +62,57 @@ public class Replication {
         return replicationResult;
     }
 
-    /**
-     * @param source
-     * @return
-     */
     public Replication source(String source) {
         this.replication = replication.source(source);
         return this;
     }
 
-    /**
-     * @param target
-     * @return
-     */
     public Replication target(String target) {
         this.replication = replication.target(target);
         return this;
     }
 
-    /**
-     * @param continuous
-     * @return
-     */
     public Replication continuous(Boolean continuous) {
         this.replication = replication.continuous(continuous);
         return this;
     }
 
-    /**
-     * @param filter
-     * @return
-     */
     public Replication filter(String filter) {
         this.replication = replication.filter(filter);
         return this;
     }
 
-    /**
-     * @param queryParams
-     * @return
-     */
     public Replication queryParams(String queryParams) {
         this.replication = replication.queryParams(queryParams);
         return this;
     }
 
-    /**
-     * @param queryParams
-     * @return
-     */
-    public Replication queryParams(
-            Map<String, Object> queryParams) {
+    public Replication queryParams(Map<String, Object> queryParams) {
         this.replication = replication.queryParams(queryParams);
         return this;
     }
 
     /**
-     * @param docIds
-     * @return
-     * @see com.cloudant.client.org.lightcouch.Replication#docIds(java.lang.String[])
+     * Limit the replication to the specified document IDs.
+     *
+     * @param docIds one or more document IDs to include in the replication
+     * @return this to set more options or trigger the replication
      */
     public Replication docIds(String... docIds) {
         this.replication = replication.docIds(docIds);
         return this;
     }
 
-    /**
-     * @param proxy
-     * @return
-     */
     public Replication proxy(String proxy) {
         this.replication = replication.proxy(proxy);
         return this;
     }
 
-    /**
-     * @param cancel
-     * @return
-     */
     public Replication cancel(Boolean cancel) {
         this.replication = replication.cancel(cancel);
         return this;
     }
 
-    /**
-     * @param createTarget
-     * @return
-     */
     public Replication createTarget(Boolean createTarget) {
         this.replication = replication.createTarget(createTarget);
         return this;
@@ -156,6 +121,9 @@ public class Replication {
 
     /**
      * Starts a replication since an update sequence.
+     *
+     * @param sinceSeq sequence number
+     * @return this to set more options or trigger the replication
      */
     public Replication sinceSeq(Integer sinceSeq) {
         this.replication = replication.sinceSeq(sinceSeq);
@@ -163,11 +131,13 @@ public class Replication {
     }
 
     /**
-     * @param consumerSecret
-     * @param consumerKey
-     * @param tokenSecret
-     * @param token
-     * @return
+     * Set OAuth 1 authentication credentials for the replication target
+     *
+     * @param consumerSecret client secret
+     * @param consumerKey client identifier
+     * @param tokenSecret OAuth server token secret
+     * @param token OAuth server issued token
+     * @return this to set more options or trigger the replication
      */
     public Replication targetOauth(String consumerSecret,
                                    String consumerKey, String tokenSecret, String token) {

--- a/src/main/java/com/cloudant/client/api/Replicator.java
+++ b/src/main/java/com/cloudant/client/api/Replicator.java
@@ -92,6 +92,8 @@ public class Replicator {
 
     /**
      * Finds all documents in the replicator database.
+     *
+     * @return the list of ReplicatorDocuments
      */
     public List<com.cloudant.client.api.model.ReplicatorDocument> findAll() {
         List<ReplicatorDocument> couchDbReplicatorDocList = replicator.findAll();
@@ -117,181 +119,101 @@ public class Replicator {
         return response;
     }
 
-    /**
-     * @param source
-     * @return
-     */
     public Replicator source(String source) {
         this.replicator = replicator.source(source);
         return this;
     }
 
-    /**
-     * @param target
-     * @return
-     */
     public Replicator target(String target) {
         this.replicator = replicator.target(target);
         return this;
     }
 
-    /**
-     * @param continuous
-     * @return
-     */
     public Replicator continuous(boolean continuous) {
         this.replicator = replicator.continuous(continuous);
         return this;
     }
 
-    /**
-     * @param filter
-     * @return
-     */
     public Replicator filter(String filter) {
         this.replicator = replicator.filter(filter);
         return this;
     }
 
-    /**
-     * @param queryParams
-     * @return
-     */
     public Replicator queryParams(String queryParams) {
         this.replicator = replicator.queryParams(queryParams);
         return this;
     }
 
-    /**
-     * @param queryParams
-     * @return
-     */
     public Replicator queryParams(Map<String, Object> queryParams) {
         this.replicator = replicator.queryParams(queryParams);
         return this;
     }
 
-    /**
-     * @param docIds
-     * @return
-     */
     public Replicator docIds(String... docIds) {
         this.replicator = replicator.docIds(docIds);
         return this;
     }
 
-    /**
-     * @param proxy
-     * @return
-     */
     public Replicator proxy(String proxy) {
         this.replicator = replicator.proxy(proxy);
         return this;
     }
 
-    /**
-     * @param createTarget
-     * @return
-     */
     public Replicator createTarget(Boolean createTarget) {
         this.replicator = replicator.createTarget(createTarget);
         return this;
     }
 
-    /**
-     * @param workerProcesses
-     * @return
-     */
     public Replicator workerProcesses(int workerProcesses) {
         this.replicator = replicator.workerProcesses(workerProcesses);
         return this;
     }
 
-    /**
-     * @param connectionTimeout
-     * @return
-     */
     public Replicator connectionTimeout(long connectionTimeout) {
         this.replicator = replicator.connectionTimeout(connectionTimeout);
         return this;
     }
 
-    /**
-     * @param replicatorDB
-     * @return
-     */
     public Replicator replicatorDB(String replicatorDB) {
         this.replicator = replicator.replicatorDB(replicatorDB);
         return this;
     }
 
-    /**
-     * @param replicatorDocId
-     * @return
-     */
     public Replicator replicatorDocId(String replicatorDocId) {
         this.replicator = replicator.replicatorDocId(replicatorDocId);
         return this;
     }
 
-    /**
-     * @param replicatorDocRev
-     * @return
-     */
     public Replicator replicatorDocRev(String replicatorDocRev) {
         this.replicator = replicator.replicatorDocRev(replicatorDocRev);
         return this;
     }
 
-    /**
-     * @param workerBatchSize
-     * @return
-     */
     public Replicator workerBatchSize(int workerBatchSize) {
         this.replicator = replicator.workerBatchSize(workerBatchSize);
         return this;
     }
 
-    /**
-     * @param httpConnections
-     * @return
-     */
     public Replicator httpConnections(int httpConnections) {
         this.replicator = replicator.httpConnections(httpConnections);
         return this;
     }
 
-    /**
-     * @param retriesPerRequest
-     * @return
-     */
     public Replicator retriesPerRequest(int retriesPerRequest) {
         this.replicator = replicator.retriesPerRequest(retriesPerRequest);
         return this;
     }
 
-    /**
-     * @param userCtxRoles
-     * @return
-     */
     public Replicator userCtxRoles(String... userCtxRoles) {
         this.replicator = replicator.userCtxRoles(userCtxRoles);
         return this;
     }
 
-    /**
-     * @param sinceSeq
-     * @return
-     */
     public Replicator sinceSeq(Integer sinceSeq) {
         this.replicator = replicator.sinceSeq(sinceSeq);
         return this;
     }
 
-    /**
-     * @param userCtxName
-     * @return
-     */
     public Replicator userCtxName(String userCtxName) {
         this.replicator = replicator.userCtxName(userCtxName);
         return this;

--- a/src/main/java/com/cloudant/client/api/Search.java
+++ b/src/main/java/com/cloudant/client/api/Search.java
@@ -275,8 +275,8 @@ public class Search {
      *
      * @param sortJson JSON string specifying the sort order
      * @return this for additional parameter setting or to query
-     * @see <a href="http://docs.cloudant.com/api/search.html">sort query parameter format</a>
-     *
+     * @see <a target="_blank" href="http://docs.cloudant.com/api/search.html">sort query
+     * parameter format</a>
      */
     public Search sort(String sortJson) {
         assertNotEmpty(sortJson, "sort");
@@ -318,7 +318,8 @@ public class Search {
      *
      * @param groupsortJson JSON string specifying the group sort
      * @return this for additional parameter setting or to query
-     * @see <a href="http://docs.cloudant.com/api/search.html">sort query parameter format</a>
+     * @see <a target="_blank" href="http://docs.cloudant.com/api/search.html">sort query
+     * parameter format</a>
      */
     public Search groupSort(String groupsortJson) {
         assertNotEmpty(groupsortJson, "groupsortJson");
@@ -331,7 +332,8 @@ public class Search {
      *
      * @param rangesJson JSON string specifying the ranges
      * @return this for additional parameter setting or to query
-     * @see <a href="http://docs.cloudant.com/api/search.html">ranges query argument format</a>
+     * @see <a target="_blank" href="http://docs.cloudant.com/api/search.html">ranges query
+     * argument format</a>
      */
     public Search ranges(String rangesJson) {
         assertNotEmpty(rangesJson, "rangesJson");
@@ -358,10 +360,11 @@ public class Search {
     }
 
     /**
-     * @param fieldName the name of the field
+     * @param fieldName  the name of the field
      * @param fieldValue the value of the field
      * @return this for additional parameter setting or to query
-     * @see <a href="https://docs.cloudant.com/search.html#faceting">drilldown query parameter</a>
+     * @see <a target="_blank" href="https://docs.cloudant.com/search.html#faceting">drilldown
+     * query parameter</a>
      */
     public Search drillDown(String fieldName, String fieldValue) {
         assertNotEmpty(fieldName, "fieldName");
@@ -404,7 +407,8 @@ public class Search {
             String field = fld.getKey();
             Map<String, Long> ovalues = new HashMap<String, Long>();
             if (fld.getValue().isJsonObject()) {
-                Set<Map.Entry<String, JsonElement>> values = fld.getValue().getAsJsonObject().entrySet();
+                Set<Map.Entry<String, JsonElement>> values = fld.getValue().getAsJsonObject()
+                        .entrySet();
                 for (Entry<String, JsonElement> value : values) {
                     ovalues.put(value.getKey(), value.getValue().getAsLong());
                 }
@@ -417,7 +421,8 @@ public class Search {
     private <T> List<SearchResult<T>.SearchResultRow> getRows(
             JsonArray jsonrows, SearchResult<T> sr, Class<T> classOfT) {
 
-        List<SearchResult<T>.SearchResultRow> ret = new ArrayList<SearchResult<T>.SearchResultRow>();
+        List<SearchResult<T>.SearchResultRow> ret = new ArrayList<SearchResult<T>
+                .SearchResultRow>();
         for (JsonElement e : jsonrows) {
             SearchResult<T>.SearchResultRow row = sr.new SearchResultRow();
             JsonObject oe = e.getAsJsonObject();

--- a/src/main/java/com/cloudant/client/api/Search.java
+++ b/src/main/java/com/cloudant/client/api/Search.java
@@ -414,12 +414,12 @@ public class Search {
         return map;
     }
 
-    private <T> List<SearchResult<T>.SearchResultRows> getRows(
+    private <T> List<SearchResult<T>.SearchResultRow> getRows(
             JsonArray jsonrows, SearchResult<T> sr, Class<T> classOfT) {
 
-        List<SearchResult<T>.SearchResultRows> ret = new ArrayList<SearchResult<T>.SearchResultRows>();
+        List<SearchResult<T>.SearchResultRow> ret = new ArrayList<SearchResult<T>.SearchResultRow>();
         for (JsonElement e : jsonrows) {
-            SearchResult<T>.SearchResultRows row = sr.new SearchResultRows();
+            SearchResult<T>.SearchResultRow row = sr.new SearchResultRow();
             JsonObject oe = e.getAsJsonObject();
             row.setId(oe.get("id").getAsString());
             row.setOrder(JsonToObject(db.getGson(), e, "order", Object[].class));
@@ -434,7 +434,7 @@ public class Search {
 
     private <T> void setGroups(JsonArray jsongroups, SearchResult<T> sr, Class<T> classOfT) {
         for (JsonElement e : jsongroups) {
-            SearchResult<T>.SearchResultGroups group = sr.new SearchResultGroups();
+            SearchResult<T>.SearchResultGroup group = sr.new SearchResultGroup();
             JsonObject oe = e.getAsJsonObject();
             group.setBy(oe.get("by").getAsString());
             group.setTotalRows(oe.get("total_rows").getAsLong());

--- a/src/main/java/com/cloudant/client/api/Search.java
+++ b/src/main/java/com/cloudant/client/api/Search.java
@@ -45,7 +45,7 @@ import java.util.logging.Logger;
 
 /**
  * This class provides access to the Cloudant <tt>Search</tt> APIs.
- * <h3>Usage Example:</h3>
+ * <p>Usage Example:</p>
  * <pre>
  * {@code
  *  List<Bird> birds = db.search("views101/animals")
@@ -247,6 +247,7 @@ public class Search {
 
     /**
      * @param limit limit the number of documents in the result
+     * @return this for additional parameter setting or to query
      */
     public Search limit(Integer limit) {
         this.limit = limit;
@@ -261,7 +262,7 @@ public class Search {
      * in the response
      *
      * @param bookmark see the next page of results after this bookmark result
-     * @return
+     * @return this for additional parameter setting or to query
      */
     public Search bookmark(String bookmark) {
         this.bookmark = bookmark;
@@ -272,9 +273,10 @@ public class Search {
     /**
      * Specify the sort order for the result.
      *
-     * @param sortJson @see <a href="http://docs.cloudant.com/api/search.html"> sort</a>
-     *                 query argument for format
-     * @return
+     * @param sortJson JSON string specifying the sort order
+     * @return this for additional parameter setting or to query
+     * @see <a href="http://docs.cloudant.com/api/search.html">sort query parameter format</a>
+     *
      */
     public Search sort(String sortJson) {
         assertNotEmpty(sortJson, "sort");
@@ -284,11 +286,11 @@ public class Search {
 
 
     /**
-     * field by which to group results.
+     * Group results by the specified field.
      *
-     * @param fieldName
+     * @param fieldName by which to group results
      * @param isNumber  whether field isNumeric.
-     * @return
+     * @return this for additional parameter setting or to query
      */
     public Search groupField(String fieldName, boolean isNumber) {
         assertNotEmpty(fieldName, "fieldName");
@@ -303,8 +305,8 @@ public class Search {
     /**
      * Maximum group count when groupField is set
      *
-     * @param limit
-     * @return
+     * @param limit the maximum group count
+     * @return this for additional parameter setting or to query
      */
     public Search groupLimit(int limit) {
         uriBuilder.query("group_limit", limit);
@@ -314,9 +316,9 @@ public class Search {
     /**
      * the sort order of the groups when groupField is set
      *
-     * @param groupsortJson @see <a href="http://docs.cloudant.com/api/search.html"> sort</a>
-     *                      query argument here for format
-     * @return
+     * @param groupsortJson JSON string specifying the group sort
+     * @return this for additional parameter setting or to query
+     * @see <a href="http://docs.cloudant.com/api/search.html">sort query parameter format</a>
      */
     public Search groupSort(String groupsortJson) {
         assertNotEmpty(groupsortJson, "groupsortJson");
@@ -325,12 +327,11 @@ public class Search {
     }
 
     /**
-     * Ranges for faceted searches.  @see <a href="http://docs.cloudant.com/api/search.html">
-     *     ranges</a>
-     * query argument here for format
+     * Ranges for faceted searches
      *
-     * @param rangesJson
-     * @return
+     * @param rangesJson JSON string specifying the ranges
+     * @return this for additional parameter setting or to query
+     * @see <a href="http://docs.cloudant.com/api/search.html">ranges query argument format</a>
      */
     public Search ranges(String rangesJson) {
         assertNotEmpty(rangesJson, "rangesJson");
@@ -341,8 +342,8 @@ public class Search {
     /**
      * Array of fieldNames for which counts should be produced
      *
-     * @param countsfields
-     * @return
+     * @param countsfields array of the field names
+     * @return this for additional parameter setting or to query
      */
     public Search counts(String[] countsfields) {
         assert (countsfields.length > 0);
@@ -357,11 +358,10 @@ public class Search {
     }
 
     /**
-     * @param fieldName
-     * @param fieldValue
-     * @return
-     * @see <a href="http://docs.cloudant.com/api/search.html"> drilldown</a>
-     * query argument
+     * @param fieldName the name of the field
+     * @param fieldValue the value of the field
+     * @return this for additional parameter setting or to query
+     * @see <a href="https://docs.cloudant.com/search.html#faceting">drilldown query parameter</a>
      */
     public Search drillDown(String fieldName, String fieldValue) {
         assertNotEmpty(fieldName, "fieldName");
@@ -373,6 +373,7 @@ public class Search {
 
     /**
      * @param stale Accept values: ok
+     * @return this for additional parameter setting or to query
      */
     public Search stale(boolean stale) {
         if (stale) {
@@ -383,6 +384,7 @@ public class Search {
 
     /**
      * @param includeDocs whether to include the document in the result
+     * @return this for additional parameter setting or to query
      */
     public Search includeDocs(Boolean includeDocs) {
         this.includeDocs = includeDocs;

--- a/src/main/java/com/cloudant/client/api/model/ApiKey.java
+++ b/src/main/java/com/cloudant/client/api/model/ApiKey.java
@@ -15,7 +15,7 @@
 package com.cloudant.client.api.model;
 
 /**
- * Encapsulates a ApiKey response from Cloudant
+ * Encapsulates an ApiKey response from Cloudant
  *
  * @author Mario Briggs
  * @since 0.0.1

--- a/src/main/java/com/cloudant/client/api/model/Attachment.java
+++ b/src/main/java/com/cloudant/client/api/model/Attachment.java
@@ -16,7 +16,7 @@ package com.cloudant.client.api.model;
 
 
 /**
- * Represents an in-line document attachment.
+ * Encapsulates an in-line document attachment.
  *
  * @see com.cloudant.client.api.model.Document#addAttachment(String, Attachment)
  */
@@ -46,43 +46,28 @@ public class Attachment {
         return attachement.getData();
     }
 
-    /**
-     * @return
-     */
     public String getContentType() {
         return attachement.getContentType();
     }
 
-    /**
-     * @return
-     */
     public int getRevpos() {
         return attachement.getRevpos();
     }
 
-    /**
-     * @return
-     */
     public String getDigest() {
         return attachement.getDigest();
     }
 
-    /**
-     * @return
-     */
     public long getLength() {
         return attachement.getLength();
     }
 
-    /**
-     * @return
-     */
     public boolean isStub() {
         return attachement.isStub();
     }
 
     /**
-     * @param contentType
+     * @param contentType the media type of the attachment
      */
     public void setContentType(String contentType) {
         attachement.setContentType(contentType);

--- a/src/main/java/com/cloudant/client/api/model/ChangesResult.java
+++ b/src/main/java/com/cloudant/client/api/model/ChangesResult.java
@@ -22,7 +22,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Represents Changes feed result of type <i>normal</i>.
+ * Encapsulates a Changes feed result of type <i>normal</i>.
  *
  * @author Ganesh K Choudhary
  * @see Changes
@@ -56,7 +56,7 @@ public class ChangesResult {
 
 
     /**
-     * Represent a row in Changes result.
+     * Encapsulates a Changes feed result row.
      */
     public static class Row {
         private com.cloudant.client.org.lightcouch.ChangesResult.Row row;
@@ -95,7 +95,7 @@ public class ChangesResult {
         }
 
         /**
-         * Represent a Change rev.
+         * Encapsulates the revision of a change result row.
          */
         public static class Rev {
             private com.cloudant.client.org.lightcouch.ChangesResult.Row.Rev rev;

--- a/src/main/java/com/cloudant/client/api/model/DbInfo.java
+++ b/src/main/java/com/cloudant/client/api/model/DbInfo.java
@@ -18,7 +18,7 @@ package com.cloudant.client.api.model;
 import com.google.gson.annotations.SerializedName;
 
 /**
- * Holds information about a CouchDB database instance.
+ * Encapsulates information about a database instance.
  *
  * @author Ganesh K Choudhary
  */

--- a/src/main/java/com/cloudant/client/api/model/DesignDocument.java
+++ b/src/main/java/com/cloudant/client/api/model/DesignDocument.java
@@ -15,7 +15,6 @@
 
 package com.cloudant.client.api.model;
 
-import com.cloudant.client.org.lightcouch.*;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.gson.annotations.SerializedName;
@@ -26,7 +25,6 @@ import java.util.Map;
  * Encapsulates a design document.
  *
  * @author Ahmed Yehia
- * @see CouchDbDesign
  * @since 0.0.2
  */
 public class DesignDocument extends com.cloudant.client.org.lightcouch.Document {
@@ -251,7 +249,8 @@ public class DesignDocument extends com.cloudant.client.org.lightcouch.Document 
          * Set the name of a database to copy the reduced view results into.
          * <P>
          * For more information, including an explanation of the potential performance impact of
-         * this option see the <a href="https://docs.cloudant.com/creating_views.html#dbcopy">
+         * this option see the <a target="_blank"
+         * href="https://docs.cloudant.com/creating_views.html#dbcopy">
          * Cloudant dbcopy documentation
          * </a>.
          * </P>
@@ -263,7 +262,6 @@ public class DesignDocument extends com.cloudant.client.org.lightcouch.Document 
         }
 
         /**
-         *
          * @return the database name where reduced view results will be stored, or null if unset
          */
         public String getDbCopy() {

--- a/src/main/java/com/cloudant/client/api/model/DesignDocument.java
+++ b/src/main/java/com/cloudant/client/api/model/DesignDocument.java
@@ -23,7 +23,7 @@ import com.google.gson.annotations.SerializedName;
 import java.util.Map;
 
 /**
- * Represents a design document.
+ * Encapsulates a design document.
  *
  * @author Ahmed Yehia
  * @see CouchDbDesign
@@ -222,7 +222,7 @@ public class DesignDocument extends com.cloudant.client.org.lightcouch.Document 
     }
 
     /**
-     * Holds Map Reduce functions in a view.
+     * Encapsulates a Map-Reduce function in a view.
      *
      * @author Ahmed Yehia
      */

--- a/src/main/java/com/cloudant/client/api/model/FindByIndexOptions.java
+++ b/src/main/java/com/cloudant/client/api/model/FindByIndexOptions.java
@@ -24,7 +24,7 @@ import java.util.List;
  * <p>Example:
  * <pre>
  * database.findByIndex(
- * 	   " "selector": { "Movie_year": {"$gt": 1960}, "Person_name": "Alec Guinness" }"
+ * 	   " \"selector\": { \"Movie_year\": {\"$gt\": 1960}, \"Person_name\": \"Alec Guinness\" }"
  * 		Movie.class,
  * 		new FindByIndexOptions()
  * .sort(new IndexField("Movie_year", SortOrder.desc))
@@ -50,6 +50,7 @@ public class FindByIndexOptions {
 
     /**
      * @param limit limit the number of results return
+     * @return this to set additional options
      */
     public FindByIndexOptions limit(Integer limit) {
         this.limit = limit;
@@ -58,6 +59,7 @@ public class FindByIndexOptions {
 
     /**
      * @param skip Skips <i>n</i> number of results.
+     * @return this to set additional options
      */
     public FindByIndexOptions skip(Integer skip) {
         this.skip = skip;
@@ -66,6 +68,7 @@ public class FindByIndexOptions {
 
     /**
      * @param readQuorum set the readQuorum
+     * @return this to set additional options
      */
     public FindByIndexOptions readQuorum(Integer readQuorum) {
         this.readQuorum = readQuorum;
@@ -76,6 +79,7 @@ public class FindByIndexOptions {
      * Can be called multiple times to set the sort syntax
      *
      * @param sort add a sort syntax field
+     * @return this to set additional options
      */
     public FindByIndexOptions sort(IndexField sort) {
         this.sort.add(sort);
@@ -87,6 +91,7 @@ public class FindByIndexOptions {
      * Can be called multiple times to set the list of return fields
      *
      * @param field set the return fields
+     * @return this to set additional options
      */
     public FindByIndexOptions fields(String field) {
         this.fields.add(field);
@@ -97,6 +102,7 @@ public class FindByIndexOptions {
      * Specify a specific index to run the query against
      *
      * @param designDocument set the design document to use
+     * @return this to set additional options
      */
     public FindByIndexOptions useIndex(String designDocument) {
         this.useIndex = "\"" + designDocument + "\"";
@@ -108,6 +114,7 @@ public class FindByIndexOptions {
      *
      * @param designDocument set the design document to use
      * @param indexName set the index name to use
+     * @return this to set additional options
      */
     public FindByIndexOptions useIndex(String designDocument, String indexName) {
         this.useIndex = "[\"" + designDocument + "\",\"" + indexName + "\"]";

--- a/src/main/java/com/cloudant/client/api/model/IndexField.java
+++ b/src/main/java/com/cloudant/client/api/model/IndexField.java
@@ -22,8 +22,17 @@ package com.cloudant.client.api.model;
  */
 public class IndexField {
 
+    /**
+     * Ascending or descending sort order
+     */
     public enum SortOrder {
+        /**
+         * ascending
+         */
         asc,
+        /**
+         * descending
+         */
         desc
     }
 
@@ -47,7 +56,7 @@ public class IndexField {
 
 
     /**
-     * Represents a Cloudant Sort Syntax for a json field. Used to specify
+     * Encapsulates a Cloudant Sort Syntax for a json field. Used to specify
      * an element of the 'index.fields' array (POST db/_index) and 'sort' array (db/_find) @see <a
      * href = "http://docs.cloudant.com/api/cloudant-query.html#cloudant-query-sort-syntax"> sort
      * Syntax</a>

--- a/src/main/java/com/cloudant/client/api/model/ReplicationResult.java
+++ b/src/main/java/com/cloudant/client/api/model/ReplicationResult.java
@@ -20,7 +20,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Holds the result of a replication request, along with previous sessions history.
+ * Encapsulates the result of a replication request, along with previous session's history.
  *
  * @author Ganesh K Choudhary
  * @see Replication
@@ -38,35 +38,35 @@ public class ReplicationResult {
     }
 
     /**
-     * @return
+     * @return true if the replication completed successfully
      */
     public boolean isOk() {
         return replicationResult.isOk();
     }
 
     /**
-     * @return
+     * @return the session ID
      */
     public String getSessionId() {
         return replicationResult.getSessionId();
     }
 
     /**
-     * @return
+     * @return the last sequence number of the replication source
      */
     public String getSourceLastSeq() {
         return replicationResult.getSourceLastSeq();
     }
 
     /**
-     * @return
+     * @return the local ID
      */
     public String getLocalId() {
         return replicationResult.getLocalId();
     }
 
     /**
-     * @return
+     * @return list of previous replication results
      */
     public List<ReplicationHistory> getHistories() {
         List<com.cloudant.client.org.lightcouch.ReplicationResult.ReplicationHistory> couchDbreplicationHistories =
@@ -84,7 +84,7 @@ public class ReplicationResult {
 
 
     /**
-     * Represents a replication session history.
+     * Encapsulates the history of a replication session.
      *
      * @author Ganesh K Choudhary
      */
@@ -100,79 +100,46 @@ public class ReplicationResult {
             this.replicationHistory = replicationHistory;
         }
 
-        /**
-         * @return
-         */
         public String getSessionId() {
             return replicationHistory.getSessionId();
         }
 
-        /**
-         * @return
-         */
         public String getStartTime() {
             return replicationHistory.getStartTime();
         }
 
-        /**
-         * @return
-         */
         public String getEndTime() {
             return replicationHistory.getEndTime();
         }
 
-        /**
-         * @return
-         */
         public String getStartLastSeq() {
             return replicationHistory.getStartLastSeq();
         }
 
-        /**
-         * @return
-         */
         public String getEndLastSeq() {
             return replicationHistory.getEndLastSeq();
         }
 
-        /**
-         * @return
-         */
         public String getRecordedSeq() {
             return replicationHistory.getRecordedSeq();
         }
 
-        /**
-         * @return
-         */
         public long getMissingChecked() {
             return replicationHistory.getMissingChecked();
         }
 
-        /**
-         * @return
-         */
         public long getMissingFound() {
             return replicationHistory.getMissingFound();
         }
 
-        /**
-         * @return
-         */
         public long getDocsRead() {
             return replicationHistory.getDocsRead();
         }
 
-        /**
-         * @return
-         */
         public long getDocsWritten() {
             return replicationHistory.getDocsWritten();
         }
 
-        /**
-         * @return
-         */
         public long getDocWriteFailures() {
             return replicationHistory.getDocWriteFailures();
         }

--- a/src/main/java/com/cloudant/client/api/model/ReplicatorDocument.java
+++ b/src/main/java/com/cloudant/client/api/model/ReplicatorDocument.java
@@ -24,7 +24,7 @@ import java.util.Iterator;
 import java.util.Map;
 
 /**
- * Represents a replication document in the <tt>_replicator</tt> database.
+ * Encapsulates a <tt>_replicator</tt> database replication document.
  *
  * @author Ganesh K Choudhary
  * @see Replicator
@@ -42,24 +42,14 @@ public class ReplicatorDocument {
         this.replicatorDocument = replicatorDocument;
     }
 
-
-    /**
-     * @return
-     */
     public String getId() {
         return replicatorDocument.getId();
     }
 
-    /**
-     * @return
-     */
     public String getRevision() {
         return replicatorDocument.getRevision();
     }
 
-    /**
-     * @return
-     */
     public Map<String, com.cloudant.client.api.model.Attachment> getAttachments() {
         Map<String, Attachment> couchDbAttachments = replicatorDocument.getAttachments();
         Map<String, com.cloudant.client.api.model.Attachment> attachments = new HashMap<String,
@@ -76,23 +66,14 @@ public class ReplicatorDocument {
         return attachments;
     }
 
-    /**
-     * @param id
-     */
     public void setId(String id) {
         replicatorDocument.setId(id);
     }
 
-    /**
-     * @param revision
-     */
     public void setRevision(String revision) {
         replicatorDocument.setRevision(revision);
     }
 
-    /**
-     * @param attachments
-     */
     public void setAttachments(Map<String, com.cloudant.client.api.model.Attachment> attachments) {
         Map<String, Attachment> lightCouchAttachments = new HashMap<String, Attachment>();
         Iterator<String> iterator = attachments.keySet().iterator();
@@ -105,264 +86,152 @@ public class ReplicatorDocument {
         replicatorDocument.setAttachments(lightCouchAttachments);
     }
 
-    /**
-     * @param name
-     * @param attachment
-     */
     public void addAttachment(String name, com.cloudant.client.api.model.Attachment attachment) {
         replicatorDocument.addAttachment(name, attachment.getAttachement());
     }
 
-    /**
-     * @return
-     */
     public String getSource() {
         return replicatorDocument.getSource();
     }
 
-    /**
-     * @return
-     */
     public String getTarget() {
         return replicatorDocument.getTarget();
     }
 
-    /**
-     * @return
-     */
     public Boolean getContinuous() {
         return replicatorDocument.getContinuous();
     }
 
-    /**
-     * @return
-     */
     public String getFilter() {
         return replicatorDocument.getFilter();
     }
 
-    /**
-     * @return
-     */
     public JsonObject getQueryParams() {
         return replicatorDocument.getQueryParams();
     }
 
-    /**
-     * @return
-     */
     public String[] getDocIds() {
         return replicatorDocument.getDocIds();
     }
 
-    /**
-     * @return
-     */
     public String getProxy() {
         return replicatorDocument.getProxy();
     }
 
-    /**
-     * @return
-     */
     public Boolean getCreateTarget() {
         return replicatorDocument.getCreateTarget();
     }
 
-    /**
-     * @return
-     */
     public String getReplicationId() {
         return replicatorDocument.getReplicationId();
     }
 
-    /**
-     * @return
-     */
     public String getReplicationState() {
         return replicatorDocument.getReplicationState();
     }
 
-    /**
-     * @return
-     */
     public String getReplicationStateTime() {
         return replicatorDocument.getReplicationStateTime();
     }
 
-    /**
-     * @return
-     */
     public UserCtx getUserCtx() {
         com.cloudant.client.org.lightcouch.ReplicatorDocument.UserCtx couchDbUserCtx = replicatorDocument.getUserCtx();
         UserCtx userCtx = new UserCtx(couchDbUserCtx);
         return userCtx;
     }
 
-    /**
-     * @return
-     */
     public Integer getWorkerProcesses() {
         return replicatorDocument.getWorkerProcesses();
     }
 
-    /**
-     * @return
-     */
     public Integer getWorkerBatchSize() {
         return replicatorDocument.getWorkerBatchSize();
     }
 
-    /**
-     * @return
-     */
     public Integer getHttpConnections() {
         return replicatorDocument.getHttpConnections();
     }
 
-    /**
-     * @return
-     */
     public Long getConnectionTimeout() {
         return replicatorDocument.getConnectionTimeout();
     }
 
-    /**
-     * @return
-     */
     public Integer getRetriesPerRequest() {
         return replicatorDocument.getRetriesPerRequest();
     }
 
-    /**
-     * @param source
-     */
     public void setSource(String source) {
         replicatorDocument.setSource(source);
     }
 
-    /**
-     * @param target
-     */
     public void setTarget(String target) {
         replicatorDocument.setTarget(target);
     }
 
-    /**
-     * @param continuous
-     */
     public void setContinuous(Boolean continuous) {
         replicatorDocument.setContinuous(continuous);
     }
 
-    /**
-     * @param filter
-     */
     public void setFilter(String filter) {
         replicatorDocument.setFilter(filter);
     }
 
-    /**
-     * @param queryParams
-     */
     public void setQueryParams(JsonObject queryParams) {
         replicatorDocument.setQueryParams(queryParams);
     }
 
-    /**
-     * @param docIds
-     */
     public void setDocIds(String[] docIds) {
         replicatorDocument.setDocIds(docIds);
     }
 
-    /**
-     * @param proxy
-     */
     public void setProxy(String proxy) {
         replicatorDocument.setProxy(proxy);
     }
 
-    /**
-     * @param createTarget
-     */
     public void setCreateTarget(Boolean createTarget) {
         replicatorDocument.setCreateTarget(createTarget);
     }
 
-    /**
-     * @param replicationId
-     */
     public void setReplicationId(String replicationId) {
         replicatorDocument.setReplicationId(replicationId);
     }
 
-    /**
-     * @param replicationState
-     */
     public void setReplicationState(String replicationState) {
         replicatorDocument.setReplicationState(replicationState);
     }
 
-    /**
-     * @param replicationStateTime
-     */
     public void setReplicationStateTime(String replicationStateTime) {
         replicatorDocument.setReplicationStateTime(replicationStateTime);
     }
 
-    /**
-     * @param userCtx
-     */
     public void setUserCtx(UserCtx userCtx) {
         replicatorDocument.setUserCtx(userCtx.getLightCouchUserCtx());
     }
 
-    /**
-     * @param workerProcesses
-     */
     public void setWorkerProcesses(Integer workerProcesses) {
         replicatorDocument.setWorkerProcesses(workerProcesses);
     }
 
-    /**
-     * @param workerBatchSize
-     */
     public void setWorkerBatchSize(Integer workerBatchSize) {
         replicatorDocument.setWorkerBatchSize(workerBatchSize);
     }
 
-    /**
-     * @param httpConnections
-     */
     public void setHttpConnections(Integer httpConnections) {
         replicatorDocument.setHttpConnections(httpConnections);
     }
 
-    /**
-     * @param connectionTimeout
-     */
     public void setConnectionTimeout(Long connectionTimeout) {
         replicatorDocument.setConnectionTimeout(connectionTimeout);
     }
 
-    /**
-     * @param retriesPerRequest
-     */
     public void setRetriesPerRequest(Integer retriesPerRequest) {
         replicatorDocument.setRetriesPerRequest(retriesPerRequest);
     }
 
-    /**
-     * @return
-     */
     public Integer getSinceSeq() {
         return replicatorDocument.getSinceSeq();
     }
 
-    /**
-     * @param sinceSeq
-     */
     public void setSinceSeq(Integer sinceSeq) {
         replicatorDocument.setSinceSeq(sinceSeq);
     }
@@ -386,30 +255,18 @@ public class ReplicatorDocument {
             return this;
         }
 
-        /**
-         * @return
-         */
         public String getName() {
             return userCtx.getName();
         }
 
-        /**
-         * @return
-         */
         public String[] getRoles() {
             return userCtx.getRoles();
         }
 
-        /**
-         * @param name
-         */
         public void setName(String name) {
             userCtx.setName(name);
         }
 
-        /**
-         * @param roles
-         */
         public void setRoles(String[] roles) {
             userCtx.setRoles(roles);
         }

--- a/src/main/java/com/cloudant/client/api/model/Response.java
+++ b/src/main/java/com/cloudant/client/api/model/Response.java
@@ -51,14 +51,14 @@ public class Response {
     }
 
     /**
-     * @return
+     * @return error string returned by the server or {@code null}
      */
     public String getError() {
         return response.getError();
     }
 
     /**
-     * @return
+     * @return reason phrase returned by the server or {@code null}
      */
     public String getReason() {
         return response.getReason();

--- a/src/main/java/com/cloudant/client/api/model/SearchResult.java
+++ b/src/main/java/com/cloudant/client/api/model/SearchResult.java
@@ -22,7 +22,7 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Holds a search result entries
+ * Encapsulates search result entries
  *
  * @param <T> Object type T, an instance into which the rows[].doc/group[].rows[].doc
  *            attribute of the Search result response should be deserialized into.
@@ -34,8 +34,8 @@ public class SearchResult<T> {
     @SerializedName("total_rows")
     private long totalRows;
     private String bookmark;
-    private List<SearchResultRows> rows = new ArrayList<SearchResultRows>();
-    private List<SearchResultGroups> groups = new ArrayList<SearchResultGroups>();
+    private List<SearchResultRow> rows = new ArrayList<SearchResultRow>();
+    private List<SearchResultGroup> groups = new ArrayList<SearchResultGroup>();
     private Map<String, Map<String, Long>> counts = new HashMap<String, Map<String, Long>>();
     private Map<String, Map<String, Long>> ranges;
 
@@ -102,14 +102,14 @@ public class SearchResult<T> {
     /**
      * @return the rows
      */
-    public List<SearchResultRows> getRows() {
+    public List<SearchResultRow> getRows() {
         return rows;
     }
 
     /**
      * @param rows the rows to set
      */
-    public void setRows(List<SearchResultRows> rows) {
+    public void setRows(List<SearchResultRow> rows) {
         this.rows = rows;
     }
 
@@ -117,15 +117,15 @@ public class SearchResult<T> {
     /**
      * @return the groups
      */
-    public List<SearchResultGroups> getGroups() {
+    public List<SearchResultGroup> getGroups() {
         return groups;
     }
 
 
     /**
-     * Inner class holding the SearchResult rows.
+     * Encapsulates a SearchResult row.
      */
-    public class SearchResultRows {
+    public class SearchResultRow {
         private String id;
         private Object[] order;
         private T fields;
@@ -191,13 +191,13 @@ public class SearchResult<T> {
     }
 
     /**
-     * Inner class holding the SearchResult Groups.
+     * Encapsulates a SearchResult group.
      */
-    public class SearchResultGroups {
+    public class SearchResultGroup {
         private String by;
         @SerializedName("total_rows")
         private Long totalRows;
-        private List<SearchResultRows> rows = new ArrayList<SearchResultRows>();
+        private List<SearchResultRow> rows = new ArrayList<SearchResultRow>();
 
 
         /**
@@ -231,14 +231,14 @@ public class SearchResult<T> {
         /**
          * @param rows the rows to set
          */
-        public void setRows(List<SearchResultRows> rows) {
+        public void setRows(List<SearchResultRow> rows) {
             this.rows = rows;
         }
 
         /**
          * @return the rows
          */
-        public List<SearchResultRows> getRows() {
+        public List<SearchResultRow> getRows() {
             return rows;
         }
 

--- a/src/main/java/com/cloudant/client/api/model/package-info.java
+++ b/src/main/java/com/cloudant/client/api/model/package-info.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2015 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+/**
+ * This package provides additional objects for interacting with Cloudant
+ */
+package com.cloudant.client.api.model;

--- a/src/main/java/com/cloudant/client/api/package-info.java
+++ b/src/main/java/com/cloudant/client/api/package-info.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2015 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+/**
+ * This package provides the objects for interacting with Cloudant
+ */
+package com.cloudant.client.api;

--- a/src/main/java/com/cloudant/client/api/views/AllDocsRequest.java
+++ b/src/main/java/com/cloudant/client/api/views/AllDocsRequest.java
@@ -35,7 +35,7 @@ public interface AllDocsRequest {
      * </pre>
      *
      * @return the response object
-     * @throws IOException
+     * @throws IOException if there is an error communicating with the server
      * @since 2.0.0
      */
     AllDocsResponse getResponse() throws IOException;

--- a/src/main/java/com/cloudant/client/api/views/AllDocsRequestBuilder.java
+++ b/src/main/java/com/cloudant/client/api/views/AllDocsRequestBuilder.java
@@ -33,6 +33,36 @@ package com.cloudant.client.api.views;
  *   .build();
  * }
  * </pre>
+ * <P>Example to list all the document IDs in a database:</P>
+ * <pre>
+ *  {@code
+ *  List<String> allDocIds = db.getAllDocsRequestBuilder().build().getResponse().getDocIds();
+ *  }
+ *  </pre>
+ * <P>
+ * Example to fetch all the documents in the database:
+ * </P>
+ * <pre>
+ *  {@code
+ *  List<Foo> allFoos = db.getAllDocsRequestBuilder().includeDocs(true).build()
+ *          .getRepsonse().getDocsAs(Foo.class);
+ *  }
+ *  </pre>
+ * <P>
+ * Example to fetch multiple documents, with the specified document IDs from the database:
+ * </P>
+ * <pre>
+ *  {@code
+ *   String[] docIds = new String[]{"doc-id-1", "doc-id-2"};
+ *   List<Foo> foosWithIds = db.getAllDocsRequestBuilder().keys(docIds).includeDocs(true).build()
+ *           .getRepsonse().getDocsAs(Foo.class);
+ *  }
+ *
+ *  </pre>
+ *
+ * @see AllDocsRequest
+ * @see AllDocsResponse
+ * @since 2.0.0
  */
 public interface AllDocsRequestBuilder extends RequestBuilder<AllDocsRequestBuilder>,
         SettableViewParameters.Unpaginated<String, AllDocsRequestBuilder> {

--- a/src/main/java/com/cloudant/client/api/views/Key.java
+++ b/src/main/java/com/cloudant/client/api/views/Key.java
@@ -78,7 +78,8 @@ public class Key {
         public static final Type<Boolean> BOOLEAN = new Type<Boolean>(Boolean.class);
         /**
          * Type constant for
-         * <a href="https://docs.cloudant.com/creating_views.html#map-function-examples">
+         * <a target="_blank"
+         * href="https://docs.cloudant.com/creating_views.html#map-function-examples">
          * complex keys.</a>
          *
          * @since 2.0.0

--- a/src/main/java/com/cloudant/client/api/views/SettableViewParameters.java
+++ b/src/main/java/com/cloudant/client/api/views/SettableViewParameters.java
@@ -18,7 +18,7 @@ package com.cloudant.client.api.views;
  * Describes the parameters that can be set when building view requests.
  *
  * <P>
- * <a href="https://docs.cloudant.com/creating_views.html#using-views">
+ * <a target="_blank" href="https://docs.cloudant.com/creating_views.html#using-views">
  * Cloudant API reference
  * </a>
  * </P>
@@ -87,7 +87,8 @@ public interface SettableViewParameters {
          * Include the full content of the documents in the response.
          * <P>
          * Note that using include_docs=true might have
-         * <a href="https://docs.cloudant.com/creating_views.html#multi-document-fetching">
+         * <a target="_blank"
+         * href="https://docs.cloudant.com/creating_views.html#multi-document-fetching">
          * performance implications.</a>
          * </P>
          *

--- a/src/main/java/com/cloudant/client/api/views/ViewMultipleRequest.java
+++ b/src/main/java/com/cloudant/client/api/views/ViewMultipleRequest.java
@@ -57,7 +57,8 @@ import java.util.List;
  *
  * }
  * </pre>
- * <a href="https://docs.cloudant.com/creating_views.html#sending-several-queries-to-a-view">
+ * <a target="_blank"
+ * href="https://docs.cloudant.com/creating_views.html#sending-several-queries-to-a-view">
  * Cloudant API reference
  * </a>
  *

--- a/src/main/java/com/cloudant/client/api/views/ViewMultipleRequest.java
+++ b/src/main/java/com/cloudant/client/api/views/ViewMultipleRequest.java
@@ -74,7 +74,7 @@ public interface ViewMultipleRequest<K, V> {
      * Perform a single POST request to get the responses for the queries built into this request.
      *
      * @return a list of the responses, one for each query
-     * @throws IOException
+     * @throws IOException if there is an error communicating with the server
      * @since 2.0.0
      */
     List<ViewResponse<K, V>> getViewResponses() throws IOException;

--- a/src/main/java/com/cloudant/client/api/views/ViewRequest.java
+++ b/src/main/java/com/cloudant/client/api/views/ViewRequest.java
@@ -40,7 +40,7 @@ public interface ViewRequest<K, V> {
      * </pre>
      *
      * @return the response object
-     * @throws IOException
+     * @throws IOException if there is an error communicating with the server
      * @since 2.0.0
      */
     ViewResponse<K, V> getResponse() throws IOException;
@@ -64,7 +64,7 @@ public interface ViewRequest<K, V> {
      * </pre>
      *
      * @return value from the first result row or {@code null} if there were no rows
-     * @throws IOException
+     * @throws IOException if there is an error communicating with the server
      * @since 2.0.0
      */
     V getSingleValue() throws IOException;

--- a/src/main/java/com/cloudant/client/api/views/ViewRequestBuilder.java
+++ b/src/main/java/com/cloudant/client/api/views/ViewRequestBuilder.java
@@ -49,7 +49,7 @@ public class ViewRequestBuilder {
      *
      * @param client    the cloudant client
      * @param database  the database
-     * @param designDoc the design doc holding the view (optionally prefixed with "_design/")
+     * @param designDoc the design doc containing the view (optionally prefixed with "_design/")
      * @param viewName  the view to build a query request for
      */
     public ViewRequestBuilder(CloudantClient client, Database database, String designDoc, String

--- a/src/main/java/com/cloudant/client/api/views/ViewResponse.java
+++ b/src/main/java/com/cloudant/client/api/views/ViewResponse.java
@@ -127,12 +127,14 @@ public interface ViewResponse<K, V> extends Iterable<ViewResponse<K, V>> {
 
     /**
      * @return the next page of results from this view query
+     * @throws IOException if there is an error communicating with the server
      * @since 2.0.0
      */
     ViewResponse<K, V> nextPage() throws IOException;
 
     /**
      * @return the previous page of results from this view query
+     * @throws IOException if there is an error communicating with the server
      * @since 2.0.0
      */
     ViewResponse<K, V> previousPage() throws IOException;

--- a/src/main/java/com/cloudant/client/api/views/package-info.java
+++ b/src/main/java/com/cloudant/client/api/views/package-info.java
@@ -14,7 +14,7 @@
 
 /**
  * This package provides access to the
- * <a href="https://docs.cloudant.com/creating_views.html">view API</a>.
+ * <a target="_blank" href="https://docs.cloudant.com/creating_views.html">view API</a>.
  *
  * <H1>Overview</H1>
  * <P>
@@ -61,17 +61,17 @@
  *
  * //build a new request and specify any parameters required
  * ViewRequest<String, Integer> request = viewBuilder.newRequest(Key.Type.STRING,Integer.class)
- *   .startKey("square") //return docs after "square"
- *   .build();
+ * .startKey("square") //return docs after "square"
+ * .build();
  *
  * //perform the request and get the response
  * ViewResponse<String, Integer> response = request.getResponse();
  *
  * //loop through the rows of the response
  * for (ViewResponse.Row<String, Integer> row : response.getRows()) {
- *   String key = row.getKey();
- *   Integer value = row.getValue();
- *   System.out.println("Shape " + key + " has " + value + " sides.");
+ * String key = row.getKey();
+ * Integer value = row.getValue();
+ * System.out.println("Shape " + key + " has " + value + " sides.");
  * }
  * }
  * </PRE>

--- a/src/main/java/com/cloudant/client/org/lightcouch/Changes.java
+++ b/src/main/java/com/cloudant/client/org/lightcouch/Changes.java
@@ -82,6 +82,7 @@ public class Changes {
     /**
      * Requests Change notifications of feed type continuous.
      * <p>Feed notifications are accessed in an <i>iterator</i> style.
+     *
      */
     public Changes continuousChanges() {
         final URI uri = uriBuilder.query("feed", "continuous").build();

--- a/src/main/java/com/cloudant/client/org/lightcouch/CouchDatabaseBase.java
+++ b/src/main/java/com/cloudant/client/org/lightcouch/CouchDatabaseBase.java
@@ -328,31 +328,6 @@ public abstract class CouchDatabaseBase {
     /**
      * Invokes an Update Handler.
      * <pre>
-     * String query = "field=foo&value=bar";
-     * String output = dbClient.invokeUpdateHandler("designDoc/update1", "docId", query);
-     * </pre>
-     *
-     * @param updateHandlerUri The Update Handler URI, in the format: <code>designDoc/update1</code>
-     * @param docId            The document id to update.
-     * @param query            The query string parameters, e.g,
-     *                         <code>field=field1&value=value1</code>
-     * @return The output of the request.
-     * @deprecated Use {@link #invokeUpdateHandler(String, String, Params)} instead.
-     */
-    @Deprecated
-    public String invokeUpdateHandler(String updateHandlerUri, String docId, String query) {
-        assertNotEmpty(updateHandlerUri, "uri");
-        assertNotEmpty(docId, "docId");
-        final String[] v = updateHandlerUri.split("/");
-        final String path = String.format("_design/%s/_update/%s/", v[0], v[1]);
-        final URI uri = buildUri(getDBUri()).path(path).path(docId).query(query).build();
-        final InputStream response = couchDbClient.put(uri);
-        return streamToString(response);
-    }
-
-    /**
-     * Invokes an Update Handler.
-     * <pre>
      * Params params = new Params()
      * 	.addParam("field", "foo")
      * 	.addParam("value", "bar");

--- a/src/main/java/com/cloudant/client/org/lightcouch/CouchDatabaseBase.java
+++ b/src/main/java/com/cloudant/client/org/lightcouch/CouchDatabaseBase.java
@@ -215,22 +215,6 @@ public abstract class CouchDatabaseBase {
     }
 
     /**
-     * Saves a document with <tt>batch=ok</tt> query param.
-     *
-     * @param object The object to save.
-     */
-    public void batch(Object object) {
-        assertNotEmpty(object, "object");
-        InputStream response = null;
-        try {
-            URI uri = buildUri(getDBUri()).query("batch", "ok").build();
-            response = couchDbClient.post(uri, getGson().toJson(object));
-        } finally {
-            close(response);
-        }
-    }
-
-    /**
      * Updates an object in the database, the object must have the correct <code>_id</code> and
      * <code>_rev</code> values.
      *

--- a/src/main/java/com/cloudant/client/org/lightcouch/CouchDbClient.java
+++ b/src/main/java/com/cloudant/client/org/lightcouch/CouchDbClient.java
@@ -23,11 +23,12 @@ import static com.cloudant.client.org.lightcouch.internal.CouchDbUtil.getRespons
 import static com.cloudant.client.org.lightcouch.internal.URIBuilder.buildUri;
 
 import com.cloudant.client.org.lightcouch.internal.GsonHelper;
+import com.cloudant.http.internal.DefaultHttpUrlConnectionFactory;
 import com.cloudant.http.Http;
 import com.cloudant.http.HttpConnection;
 import com.cloudant.http.HttpConnectionRequestInterceptor;
 import com.cloudant.http.HttpConnectionResponseInterceptor;
-import com.cloudant.http.ok.OkHttpClientHttpUrlConnectionFactory;
+import com.cloudant.http.internal.ok.OkHttpClientHttpUrlConnectionFactory;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonObject;
@@ -71,7 +72,7 @@ public class CouchDbClient {
     private HttpConnection.HttpUrlConnectionFactory factory =
             (OkHttpClientHttpUrlConnectionFactory.isOkUsable())
                     ? new OkHttpClientHttpUrlConnectionFactory()
-                    : new HttpConnection.DefaultHttpUrlConnectionFactory();
+                    : new DefaultHttpUrlConnectionFactory();
 
     CouchDbClient(CouchDbConfig config) {
         final CouchDbProperties props = config.getProperties();
@@ -92,7 +93,7 @@ public class CouchDbClient {
             factory.getOkHttpClient().setConnectionPool(pool);
             this.factory = factory;
         } else {
-            factory = new HttpConnection.DefaultHttpUrlConnectionFactory();
+            factory = new DefaultHttpUrlConnectionFactory();
         }
 
         //set the proxy if it has been configured

--- a/src/main/java/com/cloudant/client/org/lightcouch/PreconditionFailedException.java
+++ b/src/main/java/com/cloudant/client/org/lightcouch/PreconditionFailedException.java
@@ -20,7 +20,7 @@ package com.cloudant.client.org.lightcouch;
  * </P>
  * <P>
  * An example of when CouchDB will return a 412 status code is for a
- * <a href="http://docs.couchdb.org/en/1.6.1/api/database/common.html#put--db">
+ * <a target="_blank" href="http://docs.couchdb.org/en/1.6.1/api/database/common.html#put--db">
  * <code>PUT /{db}</code></a> when the DB already exists.
  * </P>
  */

--- a/src/main/java/com/cloudant/client/org/lightcouch/Replication.java
+++ b/src/main/java/com/cloudant/client/org/lightcouch/Replication.java
@@ -60,7 +60,8 @@ import java.util.logging.Logger;
  * @author Ahmed Yehia
  * @see ReplicationResult
  * @see com.cloudant.client.api.model.ReplicationResult.ReplicationHistory
- * @see <a href="https://docs.cloudant.com/replication.html#the-/_replicate-endpoint">
+ * @see <a target="_blank"
+ * href="https://docs.cloudant.com/replication.html#the-/_replicate-endpoint">
  * Replication - _replicate
  * </a>
  * @since 0.0.2

--- a/src/main/java/com/cloudant/client/org/lightcouch/Replication.java
+++ b/src/main/java/com/cloudant/client/org/lightcouch/Replication.java
@@ -19,7 +19,6 @@ import static com.cloudant.client.org.lightcouch.internal.CouchDbUtil.assertNotE
 import static com.cloudant.client.org.lightcouch.internal.CouchDbUtil.close;
 import static com.cloudant.client.org.lightcouch.internal.URIBuilder.buildUri;
 
-import com.cloudant.client.org.lightcouch.ReplicationResult.ReplicationHistory;
 import com.google.gson.JsonObject;
 
 import java.io.InputStream;
@@ -32,26 +31,38 @@ import java.util.logging.Logger;
 
 /**
  * This class provides access to the database replication API; a replication request
- * is sent via HTTP POST to <code>_replicate</code> URI.
- * <p/>
- * <h3>Usage Example:</h3>
+ * is sent via HTTP {@code POST} to the {@code _replicate} endpoint.
+ * <P>
+ * Replicates source to target, the target must exist prior to replication. Use {@link
+ * #createTarget(Boolean)} to have it created automatically.
+ * </P>
+ * <p>Usage Example:</p>
  * <pre>
+ * {@code
  * ReplicationResult replication = db.replication()
- * 	.source("source-db")
- * 	.target("target-db")
+ * 	.source("https://source.example/source-db")
+ * 	.target("https://target.example/target-db")
  * 	.createTarget(true)
  * 	.filter("example/filter1")
  * 	.trigger();
  *
- * {@code
+ * if (replication.isOk()) {
+ *     //good
+ * } else {
+ *     //error handling
+ * }
+ *
+ * //get replication history
  * List<ReplicationHistory> histories = replication.getHistories();
  * }
  * </pre>
  *
  * @author Ahmed Yehia
  * @see ReplicationResult
- * @see ReplicationHistory
- * @see Replicator
+ * @see com.cloudant.client.api.model.ReplicationResult.ReplicationHistory
+ * @see <a href="https://docs.cloudant.com/replication.html#the-/_replicate-endpoint">
+ * Replication - _replicate
+ * </a>
  * @since 0.0.2
  */
 public class Replication {

--- a/src/main/java/com/cloudant/client/org/lightcouch/Replicator.java
+++ b/src/main/java/com/cloudant/client/org/lightcouch/Replicator.java
@@ -42,36 +42,47 @@ import java.util.Map;
  * <p>A replication is triggered by persisting a document, and cancelled by removing the document
  * that triggered the replication.
  * <p/>
- * <h3>Usage Example:</h3>
+ * <P>
+ * Replicates source to target, the target must exist prior to replication. Use {@link
+ * #createTarget(Boolean)} to have it created automatically.
+ * </P>
+ * <P>Usage Example:</P>
  * <pre>
+ * {@code
  * Response response = db.replicator()
- * 	.source("source-db")
- * 	.target("target-db")
+ * 	.source("https://source.example/source-db")
+ * 	.target("https://target.example/target-db")
  * 	.continuous(true)
  * 	.createTarget(true)
  * 	.replicatorDB("replicator-db-name") // optional, defaults to _replicator
  * 	.replicatorDocId("doc-id")          // optional, defaults to UUID
- * 	.save(); // trigger replication
+ * 	.save(); // persist the document to the _replicator database
  *
+ * 	//the replication is controlled by the server and will start soon after the save
+ *
+ * //get a specific replicator document
  * ReplicatorDocument replicatorDoc = db.replicator()
  * 	.replicatorDocId("doc-id")
  * 	.replicatorDocRev("doc-rev") // optional
  * 	.find();
  *
- * {@code
+ * //get all the replicator documents
  * List<ReplicatorDocument> replicatorDocs = db.replicator().findAll();
- * }
  *
+ * //remove a replicator document to cancel replication
  * Response response = db.replicator()
  * 	.replicatorDocId("doc-id")
  * 	.replicatorDocRev("doc-rev")
  * 	.remove(); // cancels a replication
+ * 	}
  * </pre>
  *
  * @author Ahmed Yehia
- * @see CouchDatabaseBase#replicator()
- * @see Replication
  * @see ReplicatorDocument
+ * @see <a href="https://docs.cloudant.com/replication.html#the-/_replicator-database">
+ * Replication - _replicator
+ * </a>
+ *
  * @since 0.0.2
  */
 public class Replicator {

--- a/src/main/java/com/cloudant/client/org/lightcouch/Replicator.java
+++ b/src/main/java/com/cloudant/client/org/lightcouch/Replicator.java
@@ -79,10 +79,10 @@ import java.util.Map;
  *
  * @author Ahmed Yehia
  * @see ReplicatorDocument
- * @see <a href="https://docs.cloudant.com/replication.html#the-/_replicator-database">
+ * @see <a target="_blank"
+ * href="https://docs.cloudant.com/replication.html#the-/_replicator-database">
  * Replication - _replicator
  * </a>
- *
  * @since 0.0.2
  */
 public class Replicator {
@@ -147,7 +147,7 @@ public class Replicator {
             for (JsonElement jsonElem : jsonArray) {
                 JsonElement elem = jsonElem.getAsJsonObject().get("doc");
                 if (!getAsString(elem.getAsJsonObject(), "_id").startsWith("_design")) { // skip
-                // design docs
+                    // design docs
                     ReplicatorDocument rd = client.getGson().fromJson(elem, ReplicatorDocument
                             .class);
                     list.add(rd);

--- a/src/main/java/com/cloudant/http/Http.java
+++ b/src/main/java/com/cloudant/http/Http.java
@@ -22,6 +22,7 @@ import java.net.URL;
  * Factory methods for obtaining <code>HttpConnection</code>s.
  *
  * @see com.cloudant.http.HttpConnection
+ * @since 2.0.0
  */
 public class Http {
 

--- a/src/main/java/com/cloudant/http/HttpConnection.java
+++ b/src/main/java/com/cloudant/http/HttpConnection.java
@@ -11,6 +11,8 @@
 package com.cloudant.http;
 
 import com.cloudant.http.interceptors.BasicAuthInterceptor;
+import com.cloudant.http.internal.AgentHelper;
+import com.cloudant.http.internal.DefaultHttpUrlConnectionFactory;
 
 import org.apache.commons.io.IOUtils;
 
@@ -20,8 +22,6 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.HttpURLConnection;
-import java.net.InetSocketAddress;
-import java.net.Proxy;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -340,9 +340,9 @@ public class HttpConnection  {
         /**
          * Called by HttpConnection to open URLs, can be implemented to provide customization.
          *
-         * @param url
+         * @param url the address of the URL to open
          * @return HttpURLConnection for the specified URL
-         * @throws IOException
+         * @throws IOException if there is an issue communicating with the server
          */
         HttpURLConnection openConnection(URL url) throws IOException;
 
@@ -355,28 +355,4 @@ public class HttpConnection  {
         void setProxy(URL proxyUrl);
     }
 
-    public static class DefaultHttpUrlConnectionFactory implements HttpUrlConnectionFactory {
-
-        protected Proxy proxy = null;
-
-        @Override
-        public HttpURLConnection openConnection(URL url) throws IOException {
-            if (proxy != null) {
-                return (HttpURLConnection) url.openConnection(proxy);
-            } else {
-                return (HttpURLConnection) url.openConnection();
-            }
-        }
-
-        @Override
-        public void setProxy(URL proxyUrl) {
-            if ("http".equals(proxyUrl.getProtocol()) || "https".equals(proxyUrl.getProtocol
-                    ())) {
-                proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(proxyUrl.getHost(),
-                        proxyUrl.getPort()));
-            } else {
-                throw new IllegalArgumentException("Only HTTP type proxies are supported");
-            }
-        }
-    }
 }

--- a/src/main/java/com/cloudant/http/HttpConnectionInterceptor.java
+++ b/src/main/java/com/cloudant/http/HttpConnectionInterceptor.java
@@ -1,4 +1,7 @@
 package com.cloudant.http;
 
+/**
+ * A marker interface for all HttpConnectionInterceptors.
+ */
 public interface HttpConnectionInterceptor {
 }

--- a/src/main/java/com/cloudant/http/HttpConnectionInterceptorContext.java
+++ b/src/main/java/com/cloudant/http/HttpConnectionInterceptorContext.java
@@ -16,6 +16,12 @@ package com.cloudant.http;
 /**
  * Created by tomblench on 30/03/15.
  */
+
+/**
+ * Provides the context for a {@link HttpConnectionInterceptor}.
+ *
+ * @since 2.0.0
+ */
 public class HttpConnectionInterceptorContext {
 
     public boolean replayRequest;

--- a/src/main/java/com/cloudant/http/HttpConnectionRequestInterceptor.java
+++ b/src/main/java/com/cloudant/http/HttpConnectionRequestInterceptor.java
@@ -22,26 +22,25 @@ import com.cloudant.http.interceptors.CookieInterceptor;
 import java.net.HttpURLConnection;
 
 /**
-
- A Request Interceptor is run before the request is made to the server. It can use headers to add support
- for other authentication methods, for example cookie authentication. See
- {@link CookieInterceptor#interceptRequest(HttpConnectionInterceptorContext)} for an example.
-
-
- Interceptors are executed in a pipeline and modify the context in a serial fashion.
+ * A Request Interceptor is run before the request is made to the server. It can use headers to
+ * add support for other authentication methods, for example cookie authentication. See
+ * {@link CookieInterceptor#interceptRequest(HttpConnectionInterceptorContext)} for an example.
+ *
+ * Interceptors are executed in a pipeline and modify the context in a serial fashion.
+ *
+ * @since 2.0.0
  */
-
-
 public interface HttpConnectionRequestInterceptor extends HttpConnectionInterceptor {
 
     /**
      * Intercept the request.
      * This method <strong>must not</strong> do any of the following:
      * <ul>
-     *     <li>Return null</li>
-     *     <li>Call methods on the underlying {@link java.net.HttpURLConnection} which
-     *     initiate a request such as {@link HttpURLConnection#getResponseCode()}</li>
+     * <li>Return null</li>
+     * <li>Call methods on the underlying {@link java.net.HttpURLConnection} which
+     * initiate a request such as {@link HttpURLConnection#getResponseCode()}</li>
      * </ul>
+     *
      * @param context Input context
      * @return Output context
      */

--- a/src/main/java/com/cloudant/http/HttpConnectionResponseInterceptor.java
+++ b/src/main/java/com/cloudant/http/HttpConnectionResponseInterceptor.java
@@ -15,17 +15,19 @@
 package com.cloudant.http;
 
 /**
- A Response Interceptor is run after the response is obtained from the
- server but before the output stream is returned to the original client. The Response
- Interceptor enables two main behaviours:
-<ul>
-  <li>Modifying the response for every request</li>
-
- <li> Replaying a (potentially modified) request by reacting to the
- response.</li>
- </ul>
-
- Interceptors are executed in a pipeline and modify the context in a serial fashion.
+ * A Response Interceptor is run after the response is obtained from the
+ * server but before the output stream is returned to the original client. The Response
+ * Interceptor enables two main behaviours:
+ * <ul>
+ * <li>Modifying the response for every request</li>
+ *
+ * <li> Replaying a (potentially modified) request by reacting to the
+ * response.</li>
+ * </ul>
+ *
+ * Interceptors are executed in a pipeline and modify the context in a serial fashion.
+ *
+ * @since 2.0.0
  */
 public interface HttpConnectionResponseInterceptor extends HttpConnectionInterceptor {
 
@@ -34,9 +36,10 @@ public interface HttpConnectionResponseInterceptor extends HttpConnectionInterce
      *
      * This method <strong>must not</strong> do any of the following
      * <ul>
-     *     <li>Return null</li>
-     *     <li>Read the response stream</li>
+     * <li>Return null</li>
+     * <li>Read the response stream</li>
      * </ul>
+     *
      * @param context Input context
      * @return Output context
      */

--- a/src/main/java/com/cloudant/http/interceptors/BasicAuthInterceptor.java
+++ b/src/main/java/com/cloudant/http/interceptors/BasicAuthInterceptor.java
@@ -14,7 +14,7 @@
 
 package com.cloudant.http.interceptors;
 
-import com.cloudant.http.Base64OutputStreamFactory;
+import com.cloudant.http.internal.Base64OutputStreamFactory;
 import com.cloudant.http.HttpConnectionInterceptorContext;
 import com.cloudant.http.HttpConnectionRequestInterceptor;
 

--- a/src/main/java/com/cloudant/http/internal/AgentHelper.java
+++ b/src/main/java/com/cloudant/http/internal/AgentHelper.java
@@ -12,7 +12,7 @@
  * and limitations under the License.
  */
 
-package com.cloudant.http;
+package com.cloudant.http.internal;
 
 import com.cloudant.client.org.lightcouch.CouchDbClient;
 

--- a/src/main/java/com/cloudant/http/internal/Base64OutputStreamFactory.java
+++ b/src/main/java/com/cloudant/http/internal/Base64OutputStreamFactory.java
@@ -12,7 +12,7 @@
  * and limitations under the License.
  */
 
-package com.cloudant.http;
+package com.cloudant.http.internal;
 
 import java.io.OutputStream;
 import java.lang.reflect.Constructor;

--- a/src/main/java/com/cloudant/http/internal/DefaultHttpUrlConnectionFactory.java
+++ b/src/main/java/com/cloudant/http/internal/DefaultHttpUrlConnectionFactory.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2015 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.http.internal;
+
+import com.cloudant.http.HttpConnection;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.net.URL;
+
+public class DefaultHttpUrlConnectionFactory implements HttpConnection.HttpUrlConnectionFactory {
+
+    protected Proxy proxy = null;
+
+    @Override
+    public HttpURLConnection openConnection(URL url) throws IOException {
+        if (proxy != null) {
+            return (HttpURLConnection) url.openConnection(proxy);
+        } else {
+            return (HttpURLConnection) url.openConnection();
+        }
+    }
+
+    @Override
+    public void setProxy(URL proxyUrl) {
+        if ("http".equals(proxyUrl.getProtocol()) || "https".equals(proxyUrl.getProtocol
+                ())) {
+            proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(proxyUrl.getHost(),
+                    proxyUrl.getPort()));
+        } else {
+            throw new IllegalArgumentException("Only HTTP type proxies are supported");
+        }
+    }
+}

--- a/src/main/java/com/cloudant/http/internal/ok/OkHttpClientHttpUrlConnectionFactory.java
+++ b/src/main/java/com/cloudant/http/internal/ok/OkHttpClientHttpUrlConnectionFactory.java
@@ -12,9 +12,9 @@
  * and limitations under the License.
  */
 
-package com.cloudant.http.ok;
+package com.cloudant.http.internal.ok;
 
-import com.cloudant.http.HttpConnection;
+import com.cloudant.http.internal.DefaultHttpUrlConnectionFactory;
 import com.squareup.okhttp.OkHttpClient;
 import com.squareup.okhttp.OkUrlFactory;
 
@@ -25,8 +25,7 @@ import java.net.URL;
 /**
  * Provides HttpUrlConnections by using an OkHttpClient.
  */
-public class OkHttpClientHttpUrlConnectionFactory extends HttpConnection
-        .DefaultHttpUrlConnectionFactory {
+public class OkHttpClientHttpUrlConnectionFactory extends DefaultHttpUrlConnectionFactory {
 
     private final OkHttpClient client;
     private final OkUrlFactory factory;

--- a/src/main/java/com/cloudant/http/package-info.java
+++ b/src/main/java/com/cloudant/http/package-info.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2015 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+/**
+ * This package provides the classes for interacting with HTTP.
+ */
+package com.cloudant.http;

--- a/src/test/java/com/cloudant/tests/CloudantClientHelper.java
+++ b/src/test/java/com/cloudant/tests/CloudantClientHelper.java
@@ -20,6 +20,7 @@ import com.cloudant.tests.util.SimpleHttpServer;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Created by Rhys Short on 21/05/15.
@@ -70,7 +71,7 @@ public abstract class CloudantClientHelper {
             SERVER_URL = new URL(HTTP_PROTOCOL + "://"
                     + COUCH_HOST
                     + ((COUCH_PORT != null) ? ":" + COUCH_PORT : "")); //port if supplied
-            
+
             SERVER_URI_WITH_USER_INFO = HTTP_PROTOCOL + "://"
                     + ((COUCH_USERNAME != null) ? COUCH_USERNAME + ":" + COUCH_PASSWORD + "@" : "")
                     + COUCH_HOST
@@ -79,8 +80,8 @@ public abstract class CloudantClientHelper {
             throw new RuntimeException(t);
         }
         CLIENT_INSTANCE = getClientBuilder()
-                .connectionTimeout(ClientBuilder.TimeoutOption.minutes(1))
-                .readTimeout(ClientBuilder.TimeoutOption.minutes(3))
+                .connectTimeout(1, TimeUnit.MINUTES)
+                .readTimeout(3, TimeUnit.MINUTES)
                 .build();
     }
 
@@ -91,7 +92,7 @@ public abstract class CloudantClientHelper {
     private static ClientBuilder testAddressClient(boolean isHttpsProtocolClient)
             throws MalformedURLException {
         URL url = null;
-        if(isHttpsProtocolClient) {
+        if (isHttpsProtocolClient) {
             url = new URL("https://192.0.2.0");
         } else {
             url = new URL("http://192.0.2.0");

--- a/src/test/java/com/cloudant/tests/CloudantClientTests.java
+++ b/src/test/java/com/cloudant/tests/CloudantClientTests.java
@@ -28,7 +28,7 @@ import com.cloudant.client.api.model.Membership;
 import com.cloudant.client.api.model.Task;
 import com.cloudant.client.org.lightcouch.CouchDbException;
 import com.cloudant.client.org.lightcouch.NoDocumentException;
-import com.cloudant.http.AgentHelper;
+import com.cloudant.http.internal.AgentHelper;
 import com.cloudant.test.main.RequiresCloudant;
 import com.cloudant.test.main.RequiresCloudantService;
 import com.cloudant.test.main.RequiresDB;

--- a/src/test/java/com/cloudant/tests/CloudantClientTests.java
+++ b/src/test/java/com/cloudant/tests/CloudantClientTests.java
@@ -180,7 +180,7 @@ public class CloudantClientTests {
     }
 
     @Test
-    public void testDefaultPorts() throws Exception{
+    public void testDefaultPorts() throws Exception {
         CloudantClient c = null;
 
         c = CloudantClientHelper.newTestAddressClient().build();
@@ -222,9 +222,7 @@ public class CloudantClientTests {
         //now try to connect, but should timeout because there is no connection available
         try {
             CloudantClient c = CloudantClientHelper.newSimpleHttpServerClient(server)
-                    .connectionTimeout(new ClientBuilder.TimeoutOption(100,
-                            TimeUnit.MILLISECONDS))
-                    .build();
+                    .connectTimeout(100, TimeUnit.MILLISECONDS).build();
 
             c.createDB("test");
         } catch (CouchDbException e) {
@@ -270,9 +268,7 @@ public class CloudantClientTests {
 
             try {
                 CloudantClient c = CloudantClientHelper.newSimpleHttpServerClient(server)
-                        .readTimeout(new ClientBuilder.TimeoutOption(READ_TIMEOUT,
-                                TimeUnit.MILLISECONDS))
-                        .build();
+                        .readTimeout(READ_TIMEOUT, TimeUnit.MILLISECONDS).build();
 
                 //do a call that expects a response
                 c.getAllDbs();
@@ -306,7 +302,7 @@ public class CloudantClientTests {
      * null.
      */
     @Test(expected = CouchDbException.class)
-    public void nullPassword() throws Exception{
+    public void nullPassword() throws Exception {
         CloudantClientHelper.newTestAddressClient()
                 .username("user")
                 .build();

--- a/src/test/java/com/cloudant/tests/DocumentsCRUDTest.java
+++ b/src/test/java/com/cloudant/tests/DocumentsCRUDTest.java
@@ -194,11 +194,6 @@ public class DocumentsCRUDTest {
         db.save(new Foo(id));
     }
 
-    @Test
-    public void batch() {
-        db.batch(new Foo());
-    }
-
     // Update
 
     @Test

--- a/src/test/java/com/cloudant/tests/SearchTests.java
+++ b/src/test/java/com/cloudant/tests/SearchTests.java
@@ -23,7 +23,7 @@ import com.cloudant.client.api.DesignDocumentManager;
 import com.cloudant.client.api.Search;
 import com.cloudant.client.api.model.DesignDocument;
 import com.cloudant.client.api.model.SearchResult;
-import com.cloudant.client.api.model.SearchResult.SearchResultRows;
+import com.cloudant.client.api.model.SearchResult.SearchResultRow;
 import com.cloudant.client.org.lightcouch.internal.URIBuilder;
 import com.cloudant.test.main.RequiresCloudant;
 import com.cloudant.tests.util.CloudantClientResource;
@@ -94,7 +94,7 @@ public class SearchTests {
         assertNotNull(rslt.getBookmark());
         assertEquals(rslt.getGroups().size(), 0);
         assertEquals(rslt.getRows().size(), 2);
-        for (@SuppressWarnings("rawtypes") SearchResultRows r : rslt.getRows()) {
+        for (@SuppressWarnings("rawtypes") SearchResultRow r : rslt.getRows()) {
             assertNotNull(r.getDoc());
             assertNotNull(r.getFields());
             assertNotNull(r.getId());

--- a/src/test/java/com/cloudant/tests/SearchTests.java
+++ b/src/test/java/com/cloudant/tests/SearchTests.java
@@ -69,7 +69,7 @@ public class SearchTests {
         // sync the design doc for faceted search
         File designDocViews101 =
                 new File(String.format("%s/views101_design_doc.js", new File(System.getProperty(
-                        "user.dir") + "/src/test/resources/design-docs")));
+                        "user.dir") + "/src/test/resources/design-files")));
         DesignDocument designDoc = DesignDocumentManager.fromFile(designDocViews101);
         db.getDesignDocumentManager().put(designDoc);
     }


### PR DESCRIPTION
*What*
Refactor documentation for next milestone.
In addition to reviewing the code changes I think for review it would be valuable to run `./gradlew clean javadoc` and then look at the built javadoc starting from `build/docs/javadoc/index.html`.

*Why*
Currently the `README.md` contains an API reference. This is confusing because it relates to the master branch, not the latest released version. There is also the problem of needing to update code samples in both the `README` and the javadoc, which means that they can easily get out of sync. A number of documentation updates were also required for recent changes.
Fixes #122.

*How*
Updated `CHANGES.md` with information
Add an `overview.html` to provide the "getting started" context in javadoc.
Slim down `README.md` to include links to other content and one simple example.
Move all API reference examples into javadoc for classes or methods.
Fix all javadoc warnings and fail builds if any warnings are introduced.
Removed javadoc that provided no additional value over the method signature.
Fail builds if any compile warnings are introduced.
Add the new http package to javadoc and refactor some HTTP class packaging to not expose them as API in the javadoc.
Removed deprecated methods.
Removed `Database.batch()` method as use of the `batch=ok` parameter is not recommended.

*Testing*
This is mostly documentation changes, but the `DocumentsCRUDTest.batch()` was removed as the code it was testing is no longer present.
Existing tests continue to pass.

reviewer @tomblench 
reviewer @emlaver 