### PR TITLE
126 remove methods

### DIFF
--- a/src/main/java/com/cloudant/client/api/CloudantClient.java
+++ b/src/main/java/com/cloudant/client/api/CloudantClient.java
@@ -30,7 +30,6 @@ import com.cloudant.client.org.lightcouch.CouchDbException;
 import com.cloudant.client.org.lightcouch.CouchDbProperties;
 import com.cloudant.client.org.lightcouch.Replication;
 import com.cloudant.client.org.lightcouch.Replicator;
-import com.cloudant.client.org.lightcouch.Response;
 import com.cloudant.http.HttpConnection;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -314,32 +313,6 @@ public class CloudantClient {
      */
     public Gson getGson() {
         return couchDbClient.getGson();
-    }
-
-
-    // Helper methods
-
-    /**
-     * Performs a HTTP GET request.
-     *
-     * @return An object of type T
-     */
-    <T> T get(URI uri, Class<T> classType) {
-        return couchDbClient.get(uri, classType);
-    }
-
-    /**
-     * Performs a HTTP GET request.
-     *
-     * @return InputStream with response
-     */
-    InputStream get(URI uri) {
-        return couchDbClient.get(uri);
-    }
-
-
-    Response put(URI uri, Object object, boolean newEntity, int writeQuorum) {
-        return couchDbClient.put(uri, object, newEntity, writeQuorum);
     }
 }
 

--- a/src/main/java/com/cloudant/client/api/Database.java
+++ b/src/main/java/com/cloudant/client/api/Database.java
@@ -160,7 +160,7 @@ public class Database {
      */
     private JsonObject getPermissionsObject() {
         try {
-            return client.get(apiV2DBSecurityURI, JsonObject.class);
+            return client.couchDbClient.get(apiV2DBSecurityURI, JsonObject.class);
         } catch (CouchDbException exception) {
             //currently we can't inspect the HttpResponse code
             //being in this catch block means it was not a 20x code
@@ -206,7 +206,7 @@ public class Database {
     public List<Shard> getShards() {
         InputStream response = null;
         try {
-            response = client.get(buildUri(getDBUri()).path("_shards").build());
+            response = client.couchDbClient.get(buildUri(getDBUri()).path("_shards").build());
             return getResponseList(response, client.getGson(), Shard.class,
                     new TypeToken<List<Shard>>() {
                     }.getType());
@@ -223,7 +223,7 @@ public class Database {
      */
     public Shard getShard(String docId) {
         assertNotEmpty(docId, "docId");
-        return client.get(buildUri(getDBUri()).path("_shards/").path(docId).build(), Shard.class);
+        return client.couchDbClient.get(buildUri(getDBUri()).path("_shards/").path(docId).build(), Shard.class);
     }
 
 
@@ -328,7 +328,7 @@ public class Database {
     public List<Index> listIndices() {
         InputStream response = null;
         try {
-            response = client.get(buildUri(getDBUri()).path("_index/").build());
+            response = client.couchDbClient.get(buildUri(getDBUri()).path("_index/").build());
             return getResponseList(response, client.getGson(), Index.class,
                     new TypeToken<List<Index>>() {
                     }.getType());
@@ -546,7 +546,7 @@ public class Database {
      * @throws DocumentConflictException If a conflict is detected during the save.
      */
     public com.cloudant.client.api.model.Response save(Object object, int writeQuorum) {
-        Response couchDbResponse = client.put(getDBUri(), object, true, writeQuorum);
+        Response couchDbResponse = client.couchDbClient.put(getDBUri(), object, true, writeQuorum);
         com.cloudant.client.api.model.Response response = new com.cloudant.client.api.model
                 .Response(couchDbResponse);
         return response;
@@ -628,7 +628,7 @@ public class Database {
      * @throws DocumentConflictException If a conflict is detected during the update.
      */
     public com.cloudant.client.api.model.Response update(Object object, int writeQuorum) {
-        Response couchDbResponse = client.put(getDBUri(), object, false, writeQuorum);
+        Response couchDbResponse = client.couchDbClient.put(getDBUri(), object, false, writeQuorum);
         com.cloudant.client.api.model.Response response = new com.cloudant.client.api.model
                 .Response(couchDbResponse);
         return response;
@@ -790,7 +790,7 @@ public class Database {
      * @return {@link CouchDbInfo} Containing the DB info.
      */
     public DbInfo info() {
-        return client.get(buildUri(getDBUri()).build(), DbInfo.class);
+        return client.couchDbClient.get(buildUri(getDBUri()).build(), DbInfo.class);
     }
 
 

--- a/src/main/java/com/cloudant/client/api/DbDesign.java
+++ b/src/main/java/com/cloudant/client/api/DbDesign.java
@@ -108,7 +108,7 @@ public class DbDesign {
      */
     public DesignDocument getFromDb(String id) {
         final URI uri = buildUri(dbUri).path(id).build();
-        return client.get(uri, DesignDocument.class);
+        return client.couchDbClient.get(uri, DesignDocument.class);
     }
 
     /**
@@ -122,7 +122,7 @@ public class DbDesign {
         assertNotEmpty(id, "id");
         assertNotEmpty(id, "rev");
         final URI uri = buildUri(dbc.getDBUri()).path(id).query("rev", rev).build();
-        return client.get(uri, DesignDocument.class);
+        return client.couchDbClient.get(uri, DesignDocument.class);
     }
 
     /**


### PR DESCRIPTION
*What*
Remove `get` & `put` methods from `CloudantClient` that just delegated to `CouchDbClient`.
Fixes #126.

*How*
Removed methods, made callers use the already visible `couchDbClient` object.

*Testing*
No new tests needed, existing tests still pass.

reviewer @rhyshort 
reviewer @emlaver 