### PR TITLE
142 alldocs parms

### DIFF
--- a/src/main/java/com/cloudant/client/internal/util/QueryParameters.java
+++ b/src/main/java/com/cloudant/client/internal/util/QueryParameters.java
@@ -32,7 +32,7 @@ public class QueryParameters {
         //if a null Gson was passed in, then use a default gson instance
         gson = (gson == null) ? new GsonBuilder().create() : gson;
         Map<String, Object> parameters = new HashMap<String, Object>();
-        for (Field field : this.getClass().getDeclaredFields()) {
+        for (Field field : this.getClass().getFields()) {
             QueryParameter parameter = field.getAnnotation(QueryParameter.class);
             if (parameter != null) {
                 //use the field name as the parameter name unless one was specified

--- a/src/test/java/com/cloudant/tests/ViewsTest.java
+++ b/src/test/java/com/cloudant/tests/ViewsTest.java
@@ -622,6 +622,18 @@ public class ViewsTest {
         }
     }
 
+    @Test
+    public void allDocsWithKeys() throws Exception {
+        init();
+        String id1 = db.save(new Foo()).getId();
+        String id2 = db.save(new Foo()).getId();
+        //create 3 and 4, but we don't care about the IDs
+        db.save(new Foo()).getId();
+        db.save(new Foo()).getId();
+
+        List<String> allDocIds = db.getAllDocsRequestBuilder().keys(id1, id2).build().getResponse().getDocIds();
+        assertThat(allDocIds.size(), is(2));
+    }
 
     /**
      * @param index the index to encode.


### PR DESCRIPTION
*What*
Ensure query parameters are honoured for `_all_docs` requests.
Fixes #142.

*How*
The `AllDocsRequestBuilder` uses a subclass of `ViewQueryParameters` so the `getDeclaredFields()` call in `processParameters()` was not able to see the inherited fields and hence the parameters were not appended to the request.
By using `getFields()` there is visibility of the superclass fields (which have public visibility anyway so there is no need to use `getDeclaredFields()`).

*Testing*
Added a new test for an `_all_docs` request using keys to ensure that parameters are used.

reviewer @rhyshort 
reviewer @alfinkel 