### PR TITLE
Refactored tests to use dynamic DB names

### DIFF
--- a/src/test/java/com/cloudant/tests/AttachmentsTest.java
+++ b/src/test/java/com/cloudant/tests/AttachmentsTest.java
@@ -17,18 +17,20 @@ package com.cloudant.tests;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertNotNull;
 
-import com.cloudant.client.api.CloudantClient;
 import com.cloudant.client.api.Database;
 import com.cloudant.client.api.model.Attachment;
 import com.cloudant.client.api.model.Params;
 import com.cloudant.client.api.model.Response;
 import com.cloudant.test.main.RequiresDB;
+import com.cloudant.tests.util.CloudantClientResource;
+import com.cloudant.tests.util.DatabaseResource;
 
 import org.apache.commons.codec.binary.Base64;
-import org.junit.After;
-import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.rules.RuleChain;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -38,21 +40,19 @@ import java.io.InputStream;
 @Category(RequiresDB.class)
 public class AttachmentsTest {
 
+    public static CloudantClientResource clientResource = new CloudantClientResource();
+    public static DatabaseResource dbResource = new DatabaseResource(clientResource);
+    @ClassRule
+    public static RuleChain chain = RuleChain.outerRule(clientResource).around(dbResource);
+
 
     private static Database db;
-    private CloudantClient account;
 
-    @Before
-    public void setUp() {
-        account = CloudantClientHelper.getClient();
-        db = account.database("lightcouch-db-test", true);
+    @BeforeClass
+    public static void setUp() {
+        db = dbResource.get();
     }
 
-    @After
-    public void tearDown() {
-        account.deleteDB("lightcouch-db-test");
-        account.shutdown();
-    }
 
     @Test
     public void attachmentInline() {

--- a/src/test/java/com/cloudant/tests/BulkDocumentTest.java
+++ b/src/test/java/com/cloudant/tests/BulkDocumentTest.java
@@ -17,16 +17,18 @@ package com.cloudant.tests;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
-import com.cloudant.client.api.CloudantClient;
 import com.cloudant.client.api.Database;
 import com.cloudant.client.api.model.Response;
 import com.cloudant.test.main.RequiresDB;
+import com.cloudant.tests.util.CloudantClientResource;
+import com.cloudant.tests.util.DatabaseResource;
 import com.google.gson.JsonObject;
 
-import org.junit.After;
-import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.rules.RuleChain;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -34,20 +36,17 @@ import java.util.List;
 @Category(RequiresDB.class)
 public class BulkDocumentTest {
 
+    public static CloudantClientResource clientResource = new CloudantClientResource();
+    public static DatabaseResource dbResource = new DatabaseResource(clientResource);
+    @ClassRule
+    public static RuleChain chain = RuleChain.outerRule(clientResource).around(dbResource);
+
+
     private static Database db;
-    private CloudantClient account;
 
-    @Before
-
-    public void setUp() {
-        account = CloudantClientHelper.getClient();
-        db = account.database("lightcouch-db-test", true);
-    }
-
-    @After
-    public void tearDown() {
-        account.deleteDB("lightcouch-db-test");
-        account.shutdown();
+    @BeforeClass
+    public static void setUp() {
+        db = dbResource.get();
     }
 
     @Test
@@ -56,10 +55,6 @@ public class BulkDocumentTest {
         newDocs.add(new Foo());
         newDocs.add(new JsonObject());
 
-        //	boolean allOrNothing = true;
-
-        // allorNothing is not supported in cloudant
-        //	List<Response> responses = db.bulk(newDocs, allOrNothing);
         List<Response> responses = db.bulk(newDocs);
 
         assertThat(responses.size(), is(2));

--- a/src/test/java/com/cloudant/tests/CloudantClientTests.java
+++ b/src/test/java/com/cloudant/tests/CloudantClientTests.java
@@ -15,7 +15,7 @@
 package com.cloudant.tests;
 
 import static com.cloudant.client.org.lightcouch.internal.CouchDbUtil.createPost;
-import static junit.framework.TestCase.assertEquals;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -35,6 +35,7 @@ import com.cloudant.test.main.RequiresDB;
 import com.cloudant.tests.util.CloudantClientResource;
 import com.cloudant.tests.util.SimpleHttpServer;
 import com.cloudant.tests.util.TestLog;
+import com.cloudant.tests.util.Utils;
 
 import org.apache.commons.io.IOUtils;
 import org.junit.ClassRule;
@@ -167,15 +168,17 @@ public class CloudantClientTests {
     @Test
     @Category(RequiresDB.class)
     public void existingDatabaseCreateException() {
+        String id = Utils.generateUUID();
+        String dbName = "existing" + id;
         try {
             //create a DB for this test
-            account.createDB("existing");
+            account.createDB(dbName);
 
             //do a get with create true for the already existing DB
-            account.database("existing", true);
+            account.database(dbName, true);
         } finally {
             //clean up the DB created by this test
-            account.deleteDB("existing");
+            account.deleteDB(dbName);
         }
     }
 
@@ -224,7 +227,8 @@ public class CloudantClientTests {
             CloudantClient c = CloudantClientHelper.newSimpleHttpServerClient(server)
                     .connectTimeout(100, TimeUnit.MILLISECONDS).build();
 
-            c.createDB("test");
+            //the database doesn't really need a unique name, but have one for failure cases
+            c.createDB("test" + Utils.generateUUID());
         } catch (CouchDbException e) {
             //unwrap the CouchDbException
             if (e.getCause() != null) {

--- a/src/test/java/com/cloudant/tests/DBServerTest.java
+++ b/src/test/java/com/cloudant/tests/DBServerTest.java
@@ -23,31 +23,32 @@ import com.cloudant.client.api.CloudantClient;
 import com.cloudant.client.api.Database;
 import com.cloudant.client.api.model.DbInfo;
 import com.cloudant.test.main.RequiresDB;
+import com.cloudant.tests.util.CloudantClientResource;
+import com.cloudant.tests.util.DatabaseResource;
 
-import org.junit.After;
-import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.rules.RuleChain;
 
 import java.util.List;
 
 @Category(RequiresDB.class)
 public class DBServerTest {
 
+    public static CloudantClientResource clientResource = new CloudantClientResource();
+    public static DatabaseResource dbResource = new DatabaseResource(clientResource);
+    @ClassRule
+    public static RuleChain chain = RuleChain.outerRule(clientResource).around(dbResource);
+
+    private static CloudantClient account;
     private static Database db;
-    private CloudantClient account;
 
-
-    @Before
-    public void setUp() {
-        account = CloudantClientHelper.getClient();
-        db = account.database("lightcouch-db-test", true);
-    }
-
-    @After
-    public void tearDown() {
-        account.deleteDB("lightcouch-db-test");
-        account.shutdown();
+    @BeforeClass
+    public static void setUp() {
+        account = clientResource.get();
+        db = dbResource.get();
     }
 
 

--- a/src/test/java/com/cloudant/tests/DocumentsCRUDTest.java
+++ b/src/test/java/com/cloudant/tests/DocumentsCRUDTest.java
@@ -27,13 +27,16 @@ import com.cloudant.client.org.lightcouch.DocumentConflictException;
 import com.cloudant.client.org.lightcouch.NoDocumentException;
 import com.cloudant.test.main.RequiresCouch;
 import com.cloudant.test.main.RequiresDB;
+import com.cloudant.tests.util.CloudantClientResource;
+import com.cloudant.tests.util.DatabaseResource;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 
-import org.junit.After;
-import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.rules.RuleChain;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -44,23 +47,18 @@ import java.util.UUID;
 @Category(RequiresDB.class)
 public class DocumentsCRUDTest {
 
+    public static CloudantClientResource clientResource = new CloudantClientResource();
+    public static DatabaseResource dbResource = new DatabaseResource(clientResource);
+    @ClassRule
+    public static RuleChain chain = RuleChain.outerRule(clientResource).around(dbResource);
 
+    private static CloudantClient account = clientResource.get();
     private static Database db;
-    private CloudantClient account;
 
-
-    @Before
-    public void setUp() {
-        account = CloudantClientHelper.getClient();
-        db = account.database("lightcouch-db-test", true);
+    @BeforeClass
+    public static void setUp() {
+        db = dbResource.get();
     }
-
-    @After
-    public void tearDown() {
-        account.deleteDB("lightcouch-db-test");
-        account.shutdown();
-    }
-
 
     // Find
 

--- a/src/test/java/com/cloudant/tests/HttpProxyTest.java
+++ b/src/test/java/com/cloudant/tests/HttpProxyTest.java
@@ -14,8 +14,8 @@
 
 package com.cloudant.tests;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import com.cloudant.client.api.CloudantClient;
 import com.cloudant.http.Http;

--- a/src/test/java/com/cloudant/tests/HttpTest.java
+++ b/src/test/java/com/cloudant/tests/HttpTest.java
@@ -16,9 +16,9 @@ import com.google.gson.JsonObject;
 import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Ignore;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.rules.RuleChain;
 
 import java.io.BufferedOutputStream;
 import java.io.BufferedReader;
@@ -44,12 +44,11 @@ public class HttpTest {
 
     private String data = "{\"hello\":\"world\"}";
 
-    @ClassRule
     public static CloudantClientResource clientResource = new CloudantClientResource();
-    @Rule
-    public final DatabaseResource dbResource = new DatabaseResource(clientResource);
+    public static DatabaseResource dbResource = new DatabaseResource(clientResource);
+    @ClassRule
+    public static RuleChain chain = RuleChain.outerRule(clientResource).around(dbResource);
 
-    private final CloudantClient account = clientResource.get();
 
     /*
      * Test "Expect: 100-Continue" header works as expected

--- a/src/test/java/com/cloudant/tests/ReplicatorTest.java
+++ b/src/test/java/com/cloudant/tests/ReplicatorTest.java
@@ -14,10 +14,10 @@
 
 package com.cloudant.tests;
 
-import static junit.framework.TestCase.assertTrue;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 import com.cloudant.client.api.model.ReplicatorDocument;
 import com.cloudant.client.api.model.Response;

--- a/src/test/java/com/cloudant/tests/UpdateHandlerTest.java
+++ b/src/test/java/com/cloudant/tests/UpdateHandlerTest.java
@@ -17,38 +17,34 @@ package com.cloudant.tests;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
-import com.cloudant.client.api.CloudantClient;
 import com.cloudant.client.api.Database;
 import com.cloudant.client.api.model.Params;
 import com.cloudant.client.api.model.Response;
 import com.cloudant.test.main.RequiresDB;
+import com.cloudant.tests.util.CloudantClientResource;
+import com.cloudant.tests.util.DatabaseResource;
 import com.cloudant.tests.util.Utils;
 
-import org.junit.After;
-import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-
-import java.io.FileNotFoundException;
+import org.junit.rules.RuleChain;
 
 @Category(RequiresDB.class)
 public class UpdateHandlerTest {
 
+    public static CloudantClientResource clientResource = new CloudantClientResource();
+    public static DatabaseResource dbResource = new DatabaseResource(clientResource);
+    @ClassRule
+    public static RuleChain chain = RuleChain.outerRule(clientResource).around(dbResource);
+
     private static Database db;
-    private CloudantClient account;
 
-
-    @Before
-    public void setUp() throws FileNotFoundException {
-        account = CloudantClientHelper.getClient();
-        db = account.database("lightcouch-db-test", true);
+    @BeforeClass
+    public static void setUp() throws Exception {
+        db = dbResource.get();
         Utils.putDesignDocs(db);
-    }
-
-    @After
-    public void tearDown() {
-        account.deleteDB("lightcouch-db-test");
-        account.shutdown();
     }
 
     @Test

--- a/src/test/java/com/cloudant/tests/ViewPaginationTests.java
+++ b/src/test/java/com/cloudant/tests/ViewPaginationTests.java
@@ -16,20 +16,21 @@ package com.cloudant.tests;
 
 import static org.junit.Assert.assertEquals;
 
-import com.cloudant.client.api.CloudantClient;
 import com.cloudant.client.api.Database;
 import com.cloudant.client.api.views.Key;
 import com.cloudant.client.api.views.ViewResponse;
 import com.cloudant.tests.util.CheckPagination;
+import com.cloudant.tests.util.CloudantClientResource;
+import com.cloudant.tests.util.DatabaseResource;
 import com.cloudant.tests.util.Utils;
 
-import org.junit.After;
 import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import java.io.FileNotFoundException;
 import java.util.Arrays;
 
 @RunWith(Parameterized.class)
@@ -55,23 +56,18 @@ public class ViewPaginationTests {
     @Parameterized.Parameter(value = 1)
     public boolean descending;
 
+
+    @ClassRule
+    public static CloudantClientResource clientResource = new CloudantClientResource();
+    @Rule
+    public DatabaseResource dbResource = new DatabaseResource(clientResource);
+
     private Database db;
-    private String dbName;
-    private CloudantClient account;
 
     @Before
-    public void setUp() throws FileNotFoundException {
-        account = CloudantClientHelper.getClient();
-        dbName = "view-pagination-test-" + Utils.generateUUID();
-        db = account.database(dbName, true);
-
+    public void setUp() throws Exception {
+        db = dbResource.get();
         Utils.putDesignDocs(db);
-    }
-
-    @After
-    public void tearDown() {
-        account.deleteDB(dbName);
-        account.shutdown();
     }
 
     /**

--- a/src/test/java/com/cloudant/tests/ViewsTest.java
+++ b/src/test/java/com/cloudant/tests/ViewsTest.java
@@ -22,7 +22,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 
-import com.cloudant.client.api.CloudantClient;
 import com.cloudant.client.api.Database;
 import com.cloudant.client.api.views.Key;
 import com.cloudant.client.api.views.ViewMultipleRequest;
@@ -31,18 +30,20 @@ import com.cloudant.client.api.views.ViewRequestBuilder;
 import com.cloudant.client.api.views.ViewResponse;
 import com.cloudant.test.main.RequiresCloudant;
 import com.cloudant.test.main.RequiresDB;
+import com.cloudant.tests.util.CloudantClientResource;
+import com.cloudant.tests.util.DatabaseResource;
 import com.cloudant.tests.util.Utils;
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 
-import org.junit.After;
 import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -54,23 +55,17 @@ import java.util.Map;
 @Category(RequiresDB.class)
 public class ViewsTest {
 
+    @ClassRule
+    public static CloudantClientResource clientResource = new CloudantClientResource();
+    @Rule
+    public DatabaseResource dbResource = new DatabaseResource(clientResource);
 
-    private static Database db;
-    private CloudantClient account;
+    private Database db;
 
     @Before
-    public void setUp() throws FileNotFoundException {
-        account = CloudantClientHelper.getClient();
-
-        db = account.database("lightcouch-db-test", true);
-
+    public void setUp() throws Exception {
+        db = dbResource.get();
         Utils.putDesignDocs(db);
-    }
-
-    @After
-    public void tearDown() {
-        account.deleteDB("lightcouch-db-test");
-        account.shutdown();
     }
 
     @Test
@@ -643,7 +638,7 @@ public class ViewsTest {
         return String.format("%03d", index);
     }
 
-    private static void init() {
+    private void init() {
         Foo foo = null;
 
         foo = new Foo("id-1", "key-1");

--- a/src/test/java/com/cloudant/tests/util/CloudantClientResource.java
+++ b/src/test/java/com/cloudant/tests/util/CloudantClientResource.java
@@ -14,17 +14,27 @@
 
 package com.cloudant.tests.util;
 
+import com.cloudant.client.api.ClientBuilder;
 import com.cloudant.client.api.CloudantClient;
 import com.cloudant.tests.CloudantClientHelper;
 
 import org.junit.rules.ExternalResource;
 
 public class CloudantClientResource extends ExternalResource {
+    private ClientBuilder clientBuilder;
     private CloudantClient client;
+
+    public CloudantClientResource() {
+        this.clientBuilder = CloudantClientHelper.getClientBuilder();
+    }
+
+    public CloudantClientResource(ClientBuilder clientBuilder) {
+        this.clientBuilder = clientBuilder;
+    }
 
     @Override
     public void before() {
-        client = CloudantClientHelper.getClient();
+        client = clientBuilder.build();
     }
 
     @Override

--- a/src/test/java/com/cloudant/tests/util/DatabaseResource.java
+++ b/src/test/java/com/cloudant/tests/util/DatabaseResource.java
@@ -22,6 +22,8 @@ import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 
 import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class DatabaseResource extends ExternalResource {
 
@@ -68,6 +70,17 @@ public class DatabaseResource extends ExternalResource {
      * @return sanitized name
      */
     private static String sanitizeDbName(String name) {
+        //database name is limited to 128 characters on the Cloudant service
+        //forego the package name in favour of test details and UUID
+        int excess;
+        if ((excess = name.length() - 128) > 0) {
+            name = name.substring(excess, name.length());
+            //if the new name doesn't start with a letter use the bit from the first letter
+            Matcher m = Pattern.compile("[^a-z](.*)").matcher(name);
+            if (m.matches()) {
+                name = m.group(1);
+            }
+        }
         //lowercase to remove any caps that will not be permitted
         name = name.toLowerCase(Locale.ENGLISH);
         //replace any characters that are not permitted with underscores

--- a/src/test/java/com/cloudant/tests/util/Utils.java
+++ b/src/test/java/com/cloudant/tests/util/Utils.java
@@ -34,10 +34,8 @@ import com.cloudant.http.HttpConnectionResponseInterceptor;
 
 import java.io.File;
 import java.io.FileNotFoundException;
-import java.io.InputStream;
 import java.net.URI;
 import java.util.List;
-import java.util.Properties;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -50,32 +48,6 @@ public class Utils {
     //Design documents directory
     private static final File DESIGN_DOC_DIR
             = new File(System.getProperty("user.dir") + "/src/test/resources/design-files");
-
-    public static Properties getProperties(String configFile, TestLog log) {
-        Properties properties = new Properties();
-        try {
-            InputStream instream = CloudantClient.class.getClassLoader().getResourceAsStream
-                    (configFile);
-            properties.load(instream);
-        } catch (Exception e) {
-            String msg = "Could not read configuration file from the classpath: " + configFile;
-            log.logger.severe(msg);
-            throw new IllegalStateException(msg, e);
-        }
-        return properties;
-
-    }
-
-    public static String getHostName(String account) {
-        if (account.startsWith("http://")) {
-            return account.substring(7);
-        } else if (account.startsWith("https://")) {
-            return account.substring(8);
-        } else {
-            return account + ".cloudant.com";
-        }
-
-    }
 
     public static void removeReplicatorTestDoc(CloudantClient account, String replicatorDocId)
             throws Exception {


### PR DESCRIPTION
*What*
Use dynamically named DBs for testing. Fixes #139.

*How*
Refactored tests to use the DatabaseResource.
Made tests share databases where possible to save time.
Added sanitisation to stop tests exceeding 128 char db names.
Cleaned up unused test code.

*Testing*
No new tests, all tests pass against local CouchDB and Cloudant service.

reviewer @emlaver 
reviewer @alfinkel 