### PR TITLE
Add HTTP response codes to Response objects

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,5 @@
+# Unreleased
+- [IMPROVED] Add HTTP status code to `Response` objects.
 # 2.0.0 (2015-11-12)
 - [NEW] `DesignDocument.MapReduce` now has a setter for the `dbcopy` field.
 - [NEW] Requests for the `_all_docs` endpoint are made via `Database#getAllDocsRequestBuilder()`

--- a/src/main/java/com/cloudant/client/api/CloudantClient.java
+++ b/src/main/java/com/cloudant/client/api/CloudantClient.java
@@ -178,7 +178,7 @@ public class CloudantClient {
         InputStream response = null;
         try {
             response = couchDbClient.get(buildUri(getBaseUri()).path("_active_tasks").build());
-            return getResponseList(response, couchDbClient.getGson(), Task.class,
+            return getResponseList(response, couchDbClient.getGson(),
                     new TypeToken<List<Task>>() {
                     }.getType());
         } finally {

--- a/src/main/java/com/cloudant/client/api/Database.java
+++ b/src/main/java/com/cloudant/client/api/Database.java
@@ -223,7 +223,7 @@ public class Database {
         InputStream response = null;
         try {
             response = client.couchDbClient.get(buildUri(getDBUri()).path("_shards").build());
-            return getResponseList(response, client.getGson(), Shard.class,
+            return getResponseList(response, client.getGson(),
                     new TypeToken<List<Shard>>() {
                     }.getType());
         } finally {
@@ -394,7 +394,7 @@ public class Database {
         InputStream response = null;
         try {
             response = client.couchDbClient.get(buildUri(getDBUri()).path("_index/").build());
-            return getResponseList(response, client.getGson(), Index.class,
+            return getResponseList(response, client.getGson(),
                     new TypeToken<List<Index>>() {
                     }.getType());
         } finally {

--- a/src/main/java/com/cloudant/client/api/model/Response.java
+++ b/src/main/java/com/cloudant/client/api/model/Response.java
@@ -64,6 +64,12 @@ public class Response {
         return response.getReason();
     }
 
+    /**
+     * @return the HTTP status code returned by the server or 0 if no code was available
+     */
+    public int getStatusCode() {
+        return response.getStatusCode();
+    }
 
     /**
      * @return <tt>id</tt> and <tt>rev</tt> concatenated.

--- a/src/main/java/com/cloudant/client/org/lightcouch/CouchDbClient.java
+++ b/src/main/java/com/cloudant/client/org/lightcouch/CouchDbClient.java
@@ -23,11 +23,11 @@ import static com.cloudant.client.org.lightcouch.internal.CouchDbUtil.getRespons
 import static com.cloudant.client.org.lightcouch.internal.URIBuilder.buildUri;
 
 import com.cloudant.client.org.lightcouch.internal.GsonHelper;
-import com.cloudant.http.internal.DefaultHttpUrlConnectionFactory;
 import com.cloudant.http.Http;
 import com.cloudant.http.HttpConnection;
 import com.cloudant.http.HttpConnectionRequestInterceptor;
 import com.cloudant.http.HttpConnectionResponseInterceptor;
+import com.cloudant.http.internal.DefaultHttpUrlConnectionFactory;
 import com.cloudant.http.internal.ok.OkHttpClientHttpUrlConnectionFactory;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -284,7 +284,12 @@ public class CouchDbClient {
         InputStream is = null;
         try {
             is = this.executeToInputStream(connection);
-            return getResponse(is, Response.class, getGson());
+            Response response = getResponse(is, Response.class, getGson());
+            response.setStatusCode(connection.getConnection().getResponseCode());
+            response.setReason(connection.getConnection().getResponseMessage());
+            return response;
+        } catch (IOException e) {
+            throw new CouchDbException("Error retrieving response code or message.", e);
         } finally {
             close(is);
         }

--- a/src/main/java/com/cloudant/client/org/lightcouch/Response.java
+++ b/src/main/java/com/cloudant/client/org/lightcouch/Response.java
@@ -32,6 +32,8 @@ public class Response {
     private String error;
     private String reason;
 
+    private int code;
+
     /**
      * @return the <tt>id</tt> of the response
      */
@@ -54,11 +56,23 @@ public class Response {
         return reason;
     }
 
+    void setReason(String reason) {
+        this.reason =  reason;
+    }
+
     /**
      * @return <tt>id</tt> and <tt>rev</tt> concatenated.
      */
     @Override
     public String toString() {
         return "Response [id=" + id + ", rev=" + rev + "]";
+    }
+
+    public int getStatusCode() {
+        return code;
+    }
+
+    void setStatusCode(int code) {
+        this.code = code;
     }
 }

--- a/src/main/java/com/cloudant/client/org/lightcouch/internal/CouchDbUtil.java
+++ b/src/main/java/com/cloudant/client/org/lightcouch/internal/CouchDbUtil.java
@@ -188,10 +188,9 @@ final public class CouchDbUtil {
 
     /**
      * @param response The response from {@link com.cloudant.http.HttpConnection}
-     * @param klazz
      * @return {@link Response}
      */
-    public static <T> List<T> getResponseList(InputStream response, Gson gson, Class<T> klazz,
+    public static <T> List<T> getResponseList(InputStream response, Gson gson,
                                               Type typeofT) throws CouchDbException {
         try {
             Reader reader = new InputStreamReader(response, "UTF-8");

--- a/src/test/java/com/cloudant/tests/ResponseTest.java
+++ b/src/test/java/com/cloudant/tests/ResponseTest.java
@@ -1,0 +1,93 @@
+package com.cloudant.tests;
+
+import static org.junit.Assert.assertEquals;
+
+import com.cloudant.client.api.Database;
+import com.cloudant.client.api.model.Response;
+import com.cloudant.client.org.lightcouch.CouchDbException;
+import com.cloudant.client.org.lightcouch.DocumentConflictException;
+import com.cloudant.client.org.lightcouch.NoDocumentException;
+import com.cloudant.tests.util.CloudantClientResource;
+import com.cloudant.tests.util.DatabaseResource;
+import com.cloudant.tests.util.Utils;
+
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Test cases to verify status code from Response object.
+ * Assert status codes in CouchDbException and its subclasses.
+ */
+public class ResponseTest {
+    
+    public static CloudantClientResource clientResource = new CloudantClientResource();
+    public static DatabaseResource dbResource = new DatabaseResource(clientResource);
+    @ClassRule
+    public static RuleChain chain = RuleChain.outerRule(clientResource).around(dbResource);
+
+    private Foo foo;
+    private static Database db;
+
+    @Before
+    public void setup() {
+        db = dbResource.get();
+        foo = new Foo(Utils.generateUUID());
+    }
+
+    @Test
+    public void verifyDocumentSaved() {
+        Response response = db.save(foo);
+        assertEquals(201, response.getStatusCode());
+    }
+
+    @Test
+    public void verifyDocumentNotFound() {
+        try {
+            db.find(Response.class, "no_id");
+        } catch (NoDocumentException e) {
+            assertEquals(404, e.getStatusCode());
+            assertEquals("missing", e.getReason());
+        }
+    }
+
+    @Test
+    public void verifyDocumentConflict() {
+        try {
+            Response response = db.save(foo);
+            assertEquals(201, response.getStatusCode());
+
+            db.save(foo);
+        } catch (DocumentConflictException e) {
+            assertEquals(409, e.getStatusCode());
+        }
+    }
+
+    @Test
+    public void verifyBadRequest() {
+        try {
+            foo.set_rev("bad_rev");
+            db.update(foo);
+        } catch (CouchDbException e) {
+            assertEquals(400, e.getStatusCode());
+        }
+
+    }
+
+    @Test
+    public void verifyBulkDocumentRequest() {
+        ArrayList<Foo> foos = new ArrayList<Foo>();
+        foos.add(new Foo(Utils.generateUUID()));
+        foos.add(new Foo(Utils.generateUUID()));
+        foos.add(new Foo(Utils.generateUUID()));
+
+        List<Response> responses = db.bulk(foos);
+        for(Response response : responses) {
+            assertEquals(201, response.getStatusCode());
+        }
+    }
+}


### PR DESCRIPTION
*What*
The Response class does not include the HTTP response code. We should add this information to help people align client behavior to the more general Cloudant documentation.
#136 

*How*
- Add setters for http connection's response code and message to Response class
- Set code and message in executeToResponse and in response list of bulk method
- Remove unnecessary class parameter in getResponseList

*Testing*
Add ResponseTest class for asserting response code in returned Response object and in status code for CouchDbException and subclasses.

reviewer @ricellis