### PR TITLE
145 stateless pagination

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # Unreleased
 - [IMPROVED] Included error and reason information in message from `CouchDbException` classes.
 - [IMPROVED] Added HTTP status code to `Response` objects.
+- [IMPROVED] Added parameter pagination option for views. See `ViewRequest.getResponse(String)`.
 - [FIX] Too many bytes written exception caused by inconsistent encoding between UTF-8 and the
   JVM default. UTF-8 is now correctly used for the request body content length and throughout.
 - [FIX] Fixed deserialization of `ReplicatorDocument` where the source or target url is a JSON

--- a/src/main/java/com/cloudant/client/api/views/ViewRequest.java
+++ b/src/main/java/com/cloudant/client/api/views/ViewRequest.java
@@ -46,6 +46,40 @@ public interface ViewRequest<K, V> {
     ViewResponse<K, V> getResponse() throws IOException;
 
     /**
+     * Performs view request for the page represented by a pagination token obtained from a
+     * previous request.
+     * <P>
+     * Example usage for stateless pagination:
+     * </P>
+     * <pre>
+     * {@code
+     * ViewResponse<String, String> responsePage1 = db.getViewRequestBuilder("designDoc","viewName")
+     *                   .newRequest(Key.Type.STRING, String.class)
+     *                   .build()
+     *                   .getResponse();
+     * String tokenForPage2 = responsePage1.getNextPageToken();
+     *
+     * // To request the next page:
+     * // 1. Recreate the view request by supplying the same parameters to the builder.
+     * // 2. Execute the request using the pagination token retrieved above.
+     * ViewResponse<String, String> responsePage2 = db.getViewRequestBuilder("designDoc","viewName")
+     *                   .newRequest(Key.Type.STRING, String.class)
+     *                   .build()
+     *                   .getResponse(tokenForPage2);
+     * }
+     * </pre>
+     *
+     * @param paginationToken obtained from a previous ViewResponse, {@code null} is equivalent to
+     *                        {@link #getResponse()}
+     * @return the response object
+     * @throws IOException if there is an error communicating with the server
+     * @see ViewResponse#getNextPageToken()
+     * @see ViewResponse#getPreviousPageToken()
+     * @since 2.1.0
+     */
+    ViewResponse<K, V> getResponse(String paginationToken) throws IOException;
+
+    /**
      * Performs the request and returns a single value.
      * <P>
      * This is primarily intended for retrieving a single result (e.g. count) from a reduced view.

--- a/src/main/java/com/cloudant/client/api/views/ViewResponse.java
+++ b/src/main/java/com/cloudant/client/api/views/ViewResponse.java
@@ -140,6 +140,29 @@ public interface ViewResponse<K, V> extends Iterable<ViewResponse<K, V>> {
     ViewResponse<K, V> previousPage() throws IOException;
 
     /**
+     * Returns an opaque pagination token for the next page of results, which can be used with
+     * {@link ViewRequest#getResponse(String)} to retrieve the next page without keeping
+     * ViewResponse state.
+     *
+     * @return opaque pagination token for the next page, or {@code null} if there is no next page
+     * @see ViewRequest#getResponse(String)
+     * @since 2.1.0
+     */
+    String getNextPageToken();
+
+    /**
+     * Returns an opaque pagination token for the previous page of results, which can be used with
+     * {@link ViewRequest#getResponse(String)} to retrieve the previous page without keeping
+     * ViewResponse state.
+     *
+     * @return opaque pagination token for the previous page, or {@code null} if there is no
+     * previous page
+     * @see ViewRequest#getResponse(String)
+     * @since 2.1.0
+     */
+    String getPreviousPageToken();
+
+    /**
      * <P>
      * Get the page number of this response.
      * </P>

--- a/src/main/java/com/cloudant/client/internal/views/PageMetadata.java
+++ b/src/main/java/com/cloudant/client/internal/views/PageMetadata.java
@@ -14,15 +14,17 @@
 
 package com.cloudant.client.internal.views;
 
+import com.google.gson.annotations.SerializedName;
+
 /**
  * <P>
- * Object for serializing metadata about a page.
+ * This class encapsulates metadata about a page: its number, direction and the query parameters
+ * needed to request it. A {@link ViewResponseImpl} generates instances of this class to pass that
+ * data to a request when nextPage() or previousPage() is called.
  * </P>
  * <P>
- * This class is used to persist the parameter values for a page. A {@link ViewResponseImpl}
- * calculates the parameters required to get the pages preceding and following it and generates
- * instances of this class to pass that data to a request when nextPage() or previousPage() is
- * called.
+ * Provides static methods for generating page query parameters for forward or backward pages based
+ * on specified start keys and paging directions.
  * </P>
  */
 final class PageMetadata<K, V> {
@@ -30,23 +32,101 @@ final class PageMetadata<K, V> {
     /**
      * The parameters needed to request the page described by this metadata
      */
-    ViewQueryParameters<K, V> pageRequestParameters;
+    final ViewQueryParameters<K, V> pageRequestParameters;
 
     /**
      * The page number of the page to retrieve
      */
-    long pageNumber;
+    final long pageNumber;
     /**
      * Indicate the paging direction for this metadata
      */
-    PagingDirection direction;
+    final PagingDirection direction;
 
     enum PagingDirection {
+        @SerializedName("F")
         FORWARD,
+        @SerializedName("B")
         BACKWARD
     }
 
-    PageMetadata(PagingDirection direction) {
+    /**
+     * Construct metadata that encapsulates the request query for an additional page.
+     *
+     * @param direction             the direction of the page
+     * @param pageNumber            the number of the page
+     * @param pageRequestParameters the query parameters to request the page
+     */
+    PageMetadata(PagingDirection direction, long pageNumber, ViewQueryParameters<K, V>
+            pageRequestParameters) {
+        // Set the direction and page number.
         this.direction = direction;
+        this.pageNumber = pageNumber;
+        this.pageRequestParameters = pageRequestParameters;
     }
+
+    /**
+     * Generate query parameters for a forward page with the specified start key.
+     *
+     * @param initialQueryParameters page 1 query parameters
+     * @param startkey               the startkey for the forward page
+     * @param startkey_docid         the doc id for the startkey (in case of duplicate keys)
+     * @param <K>                    the view key type
+     * @param <V>                    the view value type
+     * @return the query parameters for the forward page
+     */
+    static <K, V> ViewQueryParameters<K, V> forwardPaginationQueryParameters
+    (ViewQueryParameters<K, V> initialQueryParameters, K startkey, String startkey_docid) {
+
+        // Copy the initial query parameters
+        ViewQueryParameters<K, V> pageParameters = initialQueryParameters.copy();
+
+        // Now override with the start keys provided
+        pageParameters.setStartKey(startkey);
+        pageParameters.setStartKeyDocId(startkey_docid);
+
+        return pageParameters;
+    }
+
+    /**
+     * Generate query parameters for the backward page with the specified startkey.
+     * <P>
+     * Pages only have a reference to the start key, when paging backwards this is the
+     * startkey of the following page (i.e. the last element of the previous page) so to
+     * correctly present page results when paging backwards requires some parameters to
+     * be reversed for the previous page request
+     * </P>
+     *
+     * @param initialQueryParameters page 1 query parameters
+     * @param startkey               the startkey for the backward page
+     * @param startkey_docid         the doc id for the start key (in case of duplicate keys)
+     * @param <K>                    the view key type
+     * @param <V>                    the view value type
+     * @return the query parameters for the backward page.
+     */
+    static <K, V> ViewQueryParameters<K, V> reversePaginationQueryParameters
+    (ViewQueryParameters<K, V> initialQueryParameters, K startkey, String startkey_docid) {
+        // Get a copy of the parameters, using the forward pagination method
+        ViewQueryParameters<K, V> reversedParameters = forwardPaginationQueryParameters
+                (initialQueryParameters, startkey,
+                        startkey_docid);
+
+        // Now reverse some of the parameters to page backwards.
+        // Paging backward is descending from the original direction.
+        reversedParameters.setDescending(!initialQueryParameters.getDescending());
+
+        // We must always include our start key if paging backwards so inclusive end is true
+        reversedParameters.setInclusiveEnd(true);
+
+        // Any initial startkey is now the end key because we are reversed from original direction
+        if (startkey != null) {
+            reversedParameters.setEndKey(initialQueryParameters.startkey);
+        }
+        if (startkey_docid != null) {
+            reversedParameters.setEndKeyDocId(initialQueryParameters.startkey_docid);
+        }
+
+        return reversedParameters;
+    }
+
 }

--- a/src/main/java/com/cloudant/client/internal/views/PaginationToken.java
+++ b/src/main/java/com/cloudant/client/internal/views/PaginationToken.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2015 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.client.internal.views;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.annotations.SerializedName;
+import com.google.gson.reflect.TypeToken;
+
+import org.apache.commons.codec.binary.Base64;
+
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.Charset;
+
+/**
+ * This class is purely for serializing the fields necessary to generate an opaque pagination token.
+ *
+ * @param <K> the key type
+ */
+class PaginationToken<K> {
+
+    @SerializedName("d")
+    public Boolean descending = null;
+
+    @SerializedName("e")
+    public K endkey = null;
+
+    @SerializedName("ei")
+    public String endkey_docid = null;
+
+    @SerializedName("i")
+    public Boolean inclusive_end = null;
+
+    @SerializedName("s")
+    public K startkey = null;
+
+    @SerializedName("si")
+    public String startkey_docid = null;
+
+    @SerializedName("n")
+    long pageNumber;
+
+    @SerializedName("dr")
+    PageMetadata.PagingDirection direction;
+
+    // Construct a pagination token using the appropriate metadata
+    private PaginationToken(PageMetadata<K, ?> pageMetadata) {
+        this.pageNumber = pageMetadata.pageNumber;
+        this.direction = pageMetadata.direction;
+        this.descending = pageMetadata.pageRequestParameters.descending;
+        this.endkey = pageMetadata.pageRequestParameters.endkey;
+        this.endkey_docid = pageMetadata.pageRequestParameters.endkey_docid;
+        this.inclusive_end = pageMetadata.pageRequestParameters.inclusive_end;
+        this.startkey = pageMetadata.pageRequestParameters.startkey;
+        this.startkey_docid = pageMetadata.pageRequestParameters.startkey_docid;
+    }
+
+    /**
+     * Generate a PageMetadata object for the page represented by the specified pagination token.
+     *
+     * @param paginationToken   opaque pagination token
+     * @param initialParameters the initial view query parameters (i.e. for the page 1 request).
+     * @param <K>               the view key type
+     * @param <V>               the view value type
+     * @return PageMetadata object for the given page
+     */
+    static <K, V> PageMetadata<K, V> mergeTokenAndQueryParameters(String paginationToken, final
+    ViewQueryParameters<K, V> initialParameters) {
+
+        // Decode the base64 token into JSON
+        String json = new String(Base64.decodeBase64(paginationToken), Charset.forName("UTF-8"));
+
+        // Get a suitable Gson, we need any adapter registered for the K key type
+        Gson paginationTokenGson = getGsonWithKeyAdapter(initialParameters);
+
+        // Deserialize the pagination token JSON, using the appropriate K, V types
+        PaginationToken<K> token = paginationTokenGson.fromJson(json, new
+                TypeToken<PaginationToken<K>>() {
+                }.getType());
+
+        // Create new query parameters using the initial ViewQueryParameters as a starting point.
+        ViewQueryParameters<K, V> tokenPageParameters = initialParameters.copy();
+
+        // Merge the values from the token into the new query parameters
+        tokenPageParameters.descending = token.descending;
+        tokenPageParameters.endkey = token.endkey;
+        tokenPageParameters.endkey_docid = token.endkey_docid;
+        tokenPageParameters.inclusive_end = token.inclusive_end;
+        tokenPageParameters.startkey = token.startkey;
+        tokenPageParameters.startkey_docid = token.startkey_docid;
+
+        return new PageMetadata<K, V>(token.direction, token
+                .pageNumber, tokenPageParameters);
+    }
+
+    /**
+     * Generate an opaque pagination token from the supplied PageMetadata.
+     *
+     * @param pageMetadata page metadata of the page for which the token should be generated
+     * @param <K>          the view key type
+     * @return opaque pagination token
+     */
+    static <K> String tokenize(PageMetadata<K, ?> pageMetadata) {
+        try {
+            Gson g = getGsonWithKeyAdapter(pageMetadata.pageRequestParameters);
+            return new String(Base64.encodeBase64URLSafe(g.toJson(new PaginationToken<K>
+                    (pageMetadata)).getBytes("UTF-8")),
+                    Charset.forName("UTF-8"));
+        } catch (UnsupportedEncodingException e) {
+            //all JVMs should support UTF-8
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static <K, V> Gson getGsonWithKeyAdapter(ViewQueryParameters<K, V> vqp) {
+        return new GsonBuilder().registerTypeAdapter(vqp.getKeyType(), vqp.getClient().getGson()
+                .getAdapter(vqp.getKeyType())).create();
+    }
+}

--- a/src/main/java/com/cloudant/client/internal/views/ViewQueryParameters.java
+++ b/src/main/java/com/cloudant/client/internal/views/ViewQueryParameters.java
@@ -97,7 +97,7 @@ public class ViewQueryParameters<K, V> extends QueryParameters {
      *
      * @param parameters to copy information from
      */
-    public ViewQueryParameters(ViewQueryParameters<K, V> parameters) {
+    ViewQueryParameters(ViewQueryParameters<K, V> parameters) {
         this(parameters.client, parameters.db, parameters.designDoc, parameters.viewName,
                 parameters.keyType, parameters.valueType);
     }
@@ -264,7 +264,7 @@ public class ViewQueryParameters<K, V> extends QueryParameters {
 
     /* Parameter output methods */
 
-    public HttpConnection asGetRequest() {
+    HttpConnection asGetRequest() {
         URIBuilder builder = getViewURIBuilder();
         for (Map.Entry<String, Object> queryParameter : processParameters(gson).entrySet()) {
             builder.query(queryParameter.getKey(), queryParameter.getValue());
@@ -277,7 +277,7 @@ public class ViewQueryParameters<K, V> extends QueryParameters {
                 "/_view/" + viewName);
     }
 
-    public JsonElement asJson() {
+    JsonElement asJson() {
         Map<String, Object> parameters = processParameters(gson);
         return gson.toJsonTree(parameters);
     }

--- a/src/main/java/com/cloudant/client/internal/views/ViewQueryParameters.java
+++ b/src/main/java/com/cloudant/client/internal/views/ViewQueryParameters.java
@@ -28,7 +28,7 @@ import com.google.gson.JsonElement;
 import java.util.Arrays;
 import java.util.Map;
 
-public class ViewQueryParameters<K, V> extends QueryParameters {
+public class ViewQueryParameters<K, V> extends QueryParameters implements Cloneable {
 
     private final CloudantClient client;
     private final Database db;
@@ -282,69 +282,28 @@ public class ViewQueryParameters<K, V> extends QueryParameters {
         return gson.toJsonTree(parameters);
     }
 
-    public ViewQueryParameters<K, V> forwardPaginationQueryParameters(K startkey, String
-            startkey_docid) {
-        ViewQueryParameters<K, V> pageParameters = new ViewQueryParameters<K, V>(this);
-        //set the start parameters
-        pageParameters.setStartKey(startkey);
-        pageParameters.setStartKeyDocId(startkey_docid);
-
-        //stay the same for forward
-        pageParameters.inclusive_end = inclusive_end;
-        pageParameters.descending = descending;
-        if (endkey != null) {
-            pageParameters.setEndKey(endkey);
-        }
-        pageParameters.setEndKeyDocId(endkey_docid);
-
-        //all other parameters stay the same
-        //note we set directly rather than using the setter so that unset parameters retain their
-        //unset state
-        pageParameters.limit = limit;
-        pageParameters.group_level = group_level;
-        pageParameters.group = group;
-        pageParameters.include_docs = include_docs;
-        pageParameters.reduce = reduce;
-        pageParameters.stale = stale;
-        //use the setter for keys because of the array handling
-        pageParameters.setKeys(getKeys());
-        return pageParameters;
-    }
-
-    //pages only have a reference to the start key, when paging backwards this is the
-    // startkey of the following page (i.e. the last element of the previous page) so to
-    // correctly present page results when paging backwards requires some parameters to
-    // be reversed for the previous page request
-    public ViewQueryParameters<K, V> reversePaginationQueryParameters(K startkey, String
-            startkey_docid) {
-        //get a copy of the parameters, using the forward pagination method
-        ViewQueryParameters<K, V> reversedParameters = forwardPaginationQueryParameters(startkey,
-                startkey_docid);
-
-        //now reverse some of the parameters to page backwards
-        //paging backward is descending from the original direction
-        reversedParameters.setDescending(!getDescending());
-
-        //we must always include our start key if paging backwards so inclusive end is true
-        reversedParameters.setInclusiveEnd(true);
-
-        //any initial startkey is now the end key because we are reversed from original direction
-        if (startkey != null) {
-            reversedParameters.setEndKey(this.startkey);
-        }
-        if (startkey_docid != null) {
-            reversedParameters.setEndKeyDocId(this.startkey_docid);
-        }
-
-        return reversedParameters;
-    }
-
     public Class<K> getKeyType() {
         return this.keyType;
     }
 
     public Class<V> getValueType() {
         return this.valueType;
+    }
+
+    /**
+     * Used instead of calling clone() directly to isolate CloneNotSupportedException handling in
+     * this class.
+     *
+     * @return a shallow copy of this ViewQueryParameters
+     */
+    @SuppressWarnings("unchecked")
+    ViewQueryParameters<K, V> copy() {
+        try {
+            return (ViewQueryParameters<K, V>) this.clone();
+        } catch (CloneNotSupportedException e) {
+            //should not reach this code as this class implements Cloneable
+            throw new RuntimeException(e);
+        }
     }
 
 }

--- a/src/main/java/com/cloudant/client/internal/views/ViewRequestImpl.java
+++ b/src/main/java/com/cloudant/client/internal/views/ViewRequestImpl.java
@@ -25,7 +25,7 @@ class ViewRequestImpl<K, V> implements ViewRequest<K, V> {
 
     private final ViewQueryParameters<K, V> viewQueryParameters;
 
-    public ViewRequestImpl(ViewQueryParameters<K, V> viewQueryParameters) {
+    ViewRequestImpl(ViewQueryParameters<K, V> viewQueryParameters) {
         this.viewQueryParameters = viewQueryParameters;
     }
 

--- a/src/main/java/com/cloudant/client/internal/views/ViewRequestImpl.java
+++ b/src/main/java/com/cloudant/client/internal/views/ViewRequestImpl.java
@@ -36,6 +36,19 @@ class ViewRequestImpl<K, V> implements ViewRequest<K, V> {
     }
 
     @Override
+    public ViewResponse<K, V> getResponse(String paginationToken) throws IOException {
+        if (paginationToken == null) {
+            return getResponse();
+        } else {
+            //decode the PageMetadata
+            PageMetadata<K, V> pageMetadata = PaginationToken.mergeTokenAndQueryParameters
+                    (paginationToken, viewQueryParameters);
+            return new ViewResponseImpl<K, V>(viewQueryParameters, ViewRequester
+                    .getResponseAsJson(pageMetadata.pageRequestParameters), pageMetadata);
+        }
+    }
+
+    @Override
     public V getSingleValue() throws IOException {
         List<V> values = getResponse().getValues();
         if (values.size() > 0) {

--- a/src/main/java/com/cloudant/client/internal/views/ViewResponseImpl.java
+++ b/src/main/java/com/cloudant/client/internal/views/ViewResponseImpl.java
@@ -44,12 +44,12 @@ class ViewResponseImpl<K, V> implements ViewResponse<K, V> {
     private List<V> values = null;
     private List<Document> docs = null;
 
-    public ViewResponseImpl(ViewQueryParameters<K, V> viewQueryParameters, JsonObject response) {
+    ViewResponseImpl(ViewQueryParameters<K, V> viewQueryParameters, JsonObject response) {
         this(viewQueryParameters, response, null);
     }
 
-    public ViewResponseImpl(ViewQueryParameters<K, V> initialQueryParameters, JsonObject response,
-                            PageMetadata<K, V> pageMetadata) {
+    ViewResponseImpl(ViewQueryParameters<K, V> initialQueryParameters, JsonObject response,
+                     PageMetadata<K, V> pageMetadata) {
         this.initialQueryParameters = initialQueryParameters;
 
         if (pageMetadata == null) {

--- a/src/main/java/com/cloudant/client/internal/views/ViewResponseImpl.java
+++ b/src/main/java/com/cloudant/client/internal/views/ViewResponseImpl.java
@@ -52,13 +52,15 @@ class ViewResponseImpl<K, V> implements ViewResponse<K, V> {
                      PageMetadata<K, V> pageMetadata) {
         this.initialQueryParameters = initialQueryParameters;
 
+        PageMetadata.PagingDirection thisPageDirection;
         if (pageMetadata == null) {
             previousPageMetadata = null;
             pageNumber = 1l;
             //from a first page we can only page FORWARD
-            pageMetadata = new PageMetadata<K, V>(PageMetadata.PagingDirection.FORWARD);
+            thisPageDirection = PageMetadata.PagingDirection.FORWARD;
         } else {
             this.pageNumber = pageMetadata.pageNumber;
+            thisPageDirection = pageMetadata.direction;
         }
 
         //build the rows from the response
@@ -85,7 +87,7 @@ class ViewResponseImpl<K, V> implements ViewResponse<K, V> {
         // last page
         hasNext = resultRows > rowsPerPage;
 
-        if (PageMetadata.PagingDirection.BACKWARD == pageMetadata.direction) {
+        if (PageMetadata.PagingDirection.BACKWARD == thisPageDirection) {
             //Result needs reversing because to implement backward paging the view reading
             // order is reversed
             Collections.reverse(rows);
@@ -94,16 +96,13 @@ class ViewResponseImpl<K, V> implements ViewResponse<K, V> {
         //set previous page links if not the first page
         if (this.pageNumber > 1) {
             hasPrevious = true;
-            //set up previous page data, i.e. paging backward
+            // Construct the previous page metadata (i.e. paging backward)
+            // Decrement the page number by 1
+            // The startKey of this page is also the start key of the previous page, but using a
+            // descending lookup indicated by the paging direction.
             previousPageMetadata = new PageMetadata<K, V>(PageMetadata.PagingDirection
-                    .BACKWARD);
-            //decrement the page number for the previous page
-            previousPageMetadata.pageNumber = this.pageNumber - 1l;
-            //this page's startKey will also be the startKey for the previous page, but with a
-            // descending lookup indicated by the paging direction
-            previousPageMetadata.pageRequestParameters = initialQueryParameters
-                    .reversePaginationQueryParameters(rows.get(0).getKey(), rows
-                            .get(0).getId());
+                    .BACKWARD, this.pageNumber - 1l, PageMetadata.reversePaginationQueryParameters
+                    (initialQueryParameters, rows.get(0).getKey(), rows.get(0).getId()));
         } else {
             hasPrevious = false;
         }
@@ -115,16 +114,17 @@ class ViewResponseImpl<K, V> implements ViewResponse<K, V> {
         // to the user.
         int lastIndex = resultRows - 1;
         if (hasNext) {
-            //Construct the next page metadata (i.e. paging forward)
+            // Construct the next page metadata (i.e. paging forward)
+            // Increment the page number by 1
+            // The last element is the start of the next page so use the key and ID from that
+            // element for creating the next page query parameters.
             nextPageMetadata = new PageMetadata<K, V>(PageMetadata.PagingDirection
-                    .FORWARD);
-            //the last element is the start of the next page
-            nextPageMetadata.pageRequestParameters = initialQueryParameters
-                    .forwardPaginationQueryParameters(rows.get(lastIndex).getKey
-                            (), rows.get(lastIndex).getId());
-            //increment the page number for the next page
-            nextPageMetadata.pageNumber = this.pageNumber + 1l;
-            //the final element is the first element of the next page, so remove from the list
+                    .FORWARD, this.pageNumber + 1l, PageMetadata.forwardPaginationQueryParameters
+                    (initialQueryParameters, rows.get(lastIndex).getKey(), rows.get(lastIndex)
+                            .getId()));
+
+            // The final element is the first element of the next page, so remove from the list that
+            // will be returned.
             rows.remove(lastIndex);
         } else {
             nextPageMetadata = null;
@@ -216,6 +216,22 @@ class ViewResponseImpl<K, V> implements ViewResponse<K, V> {
         } else {
             return null;
         }
+    }
+
+    @Override
+    public String getNextPageToken() {
+        if (hasNext) {
+            return PaginationToken.tokenize(nextPageMetadata);
+        }
+        return null;
+    }
+
+    @Override
+    public String getPreviousPageToken() {
+        if (hasPrevious) {
+            return PaginationToken.tokenize(previousPageMetadata);
+        }
+        return null;
     }
 
     @Override


### PR DESCRIPTION
*What*
Enable 1.x style string parameter based paging for 2.x.

*Why*
Fixes #145. There is a use case for passing a String parameter out of the Java application and avoiding keeping any state. The 2.x style paging relied on keeping `ViewResponse` state.

*How*
Added new methods:
* `ViewResponse.getNextPageToken()`
* `ViewResponse.getPreviousPageToken()`
* `ViewRequest.getResponse(String paginationToken)`

Under the covers this requires serialization to JSON of the `PageMetadata` and some `ViewQueryParameters` (`startkey ` `startkey_docid` `endkey ` `endkey_docid` `descending` ` inclusive_end`) followed by Base64 encoding into the token. The new `PaginationToken` class is used for this.

Methods for manipulating the query parameters for paging were moved from `ViewRequestParameters` to `PageMetadata` ensuring isolation of the pagination functions from the query parameters.

*Testing*
Added new `stateless` parameter to `ViewPaginationTests`.
Added new test for `inclusiveEnd=false` to ensure that works with all kinds of paging.

reviewer @brynh 
reviewer @mikerhodes