### PR TITLE
Include exception types in javadoc

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -140,18 +140,9 @@ task sourcesJar(type: Jar, dependsOn: classes) {
 javadoc {
     options.setMemberLevel JavadocMemberLevel.PUBLIC
     options.overview = "overview.html"
-    exclude("**/com/cloudant/tests/**",
-            "**/com/cloudant/test/**",
-            "**/resources/**",
-            "**/internal/**",
-            "**/lightcouch/**",
-            "**internal/**",
-            "**/http/interceptors/**")
-    include("**/lightcouch/PreconditionFailedException.java",
-            "**/lightcouch/DocumentConflictException.java",
-            "**/lightcouch/NoDocumentException.java",
-            "**/lightcouch/CouchDbException.java",
-            "**")
+    include("**/lightcouch/*Exception.java",
+            "**/client/api/**",
+            "**/http/*")
     //add a logging listener to check for javadoc warnings and fail the build if there are any
     boolean hasJavaDocWarnings = false;
     doFirst {


### PR DESCRIPTION
*What*
Re-include exception classes in javadoc output. Fixes #146.

*How*
Update the javadoc includes and use only include patterns, not a mix of includes and excludes.

*Testing*
Javadoc builds cleanly and exception classes are included.

reviewer @emlaver 
reviewer @rhyshort 