### PR TITLE
155 utf8 encoding

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # Unreleased
 - [IMPROVED] Add HTTP status code to `Response` objects.
+- [FIX] Inconsistent encoding between UTF-8 and the JVM default was being used in some places.
+  UTF-8 is now used throughout.
+
 # 2.0.0 (2015-11-12)
 - [NEW] `DesignDocument.MapReduce` now has a setter for the `dbcopy` field.
 - [NEW] Requests for the `_all_docs` endpoint are made via `Database#getAllDocsRequestBuilder()`

--- a/src/main/java/com/cloudant/client/api/DesignDocumentManager.java
+++ b/src/main/java/com/cloudant/client/api/DesignDocumentManager.java
@@ -25,8 +25,10 @@ import com.google.gson.Gson;
 import org.apache.commons.io.FileUtils;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.FileNotFoundException;
-import java.io.FileReader;
+import java.io.InputStreamReader;
+import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -205,7 +207,7 @@ public class DesignDocumentManager {
     /**
      * Deserialize a javascript design document file to a DesignDocument object.
      *
-     * @param file the design document javascript file
+     * @param file the design document javascript file (UTF-8 encoded)
      * @return {@link DesignDocument}
      * @throws FileNotFoundException if the file does not exist or cannot be read
      */
@@ -213,10 +215,16 @@ public class DesignDocumentManager {
         assertNotEmpty(file, "Design js file");
         DesignDocument designDocument;
         Gson gson = new Gson();
-        //Deserialize JS file contents into DesignDocument object
-        designDocument = gson.fromJson(new FileReader(file), DesignDocument.class);
+        try {
+            //Deserialize JS file contents into DesignDocument object
+            designDocument = gson.fromJson(new InputStreamReader(new FileInputStream(file),
+                    "UTF-8"), DesignDocument.class);
 
-        return designDocument;
+            return designDocument;
+        } catch (UnsupportedEncodingException e) {
+            //UTF-8 should be supported on all JVMs
+            throw new RuntimeException(e);
+        }
     }
 
 }

--- a/src/main/java/com/cloudant/client/org/lightcouch/CouchDbClient.java
+++ b/src/main/java/com/cloudant/client/org/lightcouch/CouchDbClient.java
@@ -492,7 +492,7 @@ public class CouchDbClient {
                 if (es != null) {
                     Class<? extends CouchDbException> exceptionClass = ex.getClass();
                     try {
-                        ex = getGson().fromJson(new InputStreamReader(es),
+                        ex = getGson().fromJson(new InputStreamReader(es, "UTF-8"),
                                 exceptionClass);
                     } catch (JsonParseException e) {
                         //suppress and just throw ex momentarily

--- a/src/main/java/com/cloudant/client/org/lightcouch/internal/CouchDbUtil.java
+++ b/src/main/java/com/cloudant/client/org/lightcouch/internal/CouchDbUtil.java
@@ -117,7 +117,7 @@ final public class CouchDbUtil {
     }
 
     public static String streamToString(InputStream in) {
-        Scanner s = new Scanner(in);
+        Scanner s = new Scanner(in, "UTF-8");
         s.useDelimiter("\\A");
         String str = s.hasNext() ? s.next() : null;
         close(in);

--- a/src/main/java/com/cloudant/http/HttpConnection.java
+++ b/src/main/java/com/cloudant/http/HttpConnection.java
@@ -114,14 +114,16 @@ public class HttpConnection  {
 
     /**
      * Set the String of request body data to be sent to the server.
+     *
      * @param input String of request body data to be sent to the server
-     * @return an {@link HttpConnection} for method chaining 
+     * @return an {@link HttpConnection} for method chaining
      */
     public HttpConnection setRequestBody(final String input) {
         try {
-            this.input = new ByteArrayInputStream(input.getBytes("UTF-8"));
+            byte[] inputBytes = input.getBytes("UTF-8");
+            this.input = new ByteArrayInputStream(inputBytes);
             // input is in bytes, not characters
-            this.inputLength = input.getBytes().length;
+            this.inputLength = inputBytes.length;
         } catch (UnsupportedEncodingException e) {
             // This should never happen as every implementation of the java platform is required
             // to support UTF-8.

--- a/src/main/java/com/cloudant/http/interceptors/BasicAuthInterceptor.java
+++ b/src/main/java/com/cloudant/http/interceptors/BasicAuthInterceptor.java
@@ -50,10 +50,10 @@ public class BasicAuthInterceptor implements HttpConnectionRequestInterceptor {
         try {
             ByteArrayOutputStream baos = new ByteArrayOutputStream();
             OutputStream bos = Base64OutputStreamFactory.get(baos);
-            bos.write(userInfo.getBytes());
+            bos.write(userInfo.getBytes("UTF-8"));
             bos.flush();
             bos.close();
-            return baos.toString();
+            return baos.toString("UTF-8");
         } catch (IOException e) {
             Logger.getLogger(BasicAuthInterceptor.class.getName()).log(Level.SEVERE, "IOException" +
                     "during credential encoding", e);

--- a/src/main/java/com/cloudant/http/interceptors/CookieInterceptor.java
+++ b/src/main/java/com/cloudant/http/interceptors/CookieInterceptor.java
@@ -161,17 +161,22 @@ public class CookieInterceptor implements HttpConnectionRequestInterceptor,
     }
 
     private boolean sessionHasStarted(InputStream responseStream) {
-        //check the response body
-        Gson gson = new Gson();
-        JsonObject jsonResponse = gson.fromJson(new InputStreamReader(responseStream), JsonObject
-                .class);
+        try {
+            //check the response body
+            Gson gson = new Gson();
+            JsonObject jsonResponse = gson.fromJson(new InputStreamReader(responseStream,
+                    "UTF-8"), JsonObject.class);
 
-        // only check for ok:true, https://issues.apache.org/jira/browse/COUCHDB-1356
-        // means we cannot check that the name returned is the one we sent.
-        return jsonResponse != null
-                && jsonResponse.has("ok")
-                && jsonResponse.get("ok").isJsonPrimitive()
-                && jsonResponse.getAsJsonPrimitive("ok").isBoolean()
-                && jsonResponse.getAsJsonPrimitive("ok").getAsBoolean();
+            // only check for ok:true, https://issues.apache.org/jira/browse/COUCHDB-1356
+            // means we cannot check that the name returned is the one we sent.
+            return jsonResponse != null
+                    && jsonResponse.has("ok")
+                    && jsonResponse.get("ok").isJsonPrimitive()
+                    && jsonResponse.getAsJsonPrimitive("ok").isBoolean()
+                    && jsonResponse.getAsJsonPrimitive("ok").getAsBoolean();
+        } catch (UnsupportedEncodingException e) {
+            //UTF-8 should be supported on all JVMs
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/src/test/java/com/cloudant/tests/DocumentsCRUDTest.java
+++ b/src/test/java/com/cloudant/tests/DocumentsCRUDTest.java
@@ -248,6 +248,13 @@ public class DocumentsCRUDTest {
         assertEquals(idWithSlash, responseRemove.getId());
     }
 
+    @Test
+    public void testCedilla() {
+        Foo f = new Foo();
+        f.setTitle("François");
+        db.save(f);
+    }
+
     // Helper
 
     private static String generateUUID() {


### PR DESCRIPTION
*What*
Always specify `UTF-8` instead of using the default codepage. Fixes #155.

*How*
Find and fix all instances in the codebase that don't specify the codepage.

*Testing*
Added new test for ç, but it would only currently fail if executed on a non `UTF-8` codepage.

reviewer @tomblench 
reviewer @rhyshort 