### PR TITLE
Enable findbugs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -260,8 +260,14 @@ apply plugin: 'findbugs'
 //findbugs
 findbugs {
     toolVersion = "3.0.1"
+    //report only high severity bugs for now
     reportLevel = "high"
+    //the code base is pretty small so use max effort
     effort = "max"
+    //we don't want to run findbugs on the test code yet
+    sourceSets = [sourceSets.main]
+    //exclude a couple of known bugs until we get the chance to fix them
+    excludeFilter = file("findbugs_excludes.xml")
 }
 
 tasks.withType(FindBugs) {

--- a/build.gradle
+++ b/build.gradle
@@ -271,8 +271,10 @@ findbugs {
 }
 
 tasks.withType(FindBugs) {
+    //currently only one report type can be used toggle which with a property
+    boolean generateXML = Boolean.getBoolean("findbugs.xml.report")
     reports {
-        xml.enabled = false
-        html.enabled = true
+        xml.enabled = generateXML
+        html.enabled = !generateXML
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -255,3 +255,18 @@ def deployer = uploadArchives.repositories.mavenDeployer
     }.each { dep -> dep.optional = true }
 }
 
+
+apply plugin: 'findbugs'
+//findbugs
+findbugs {
+    toolVersion = "3.0.1"
+    reportLevel = "high"
+    effort = "max"
+}
+
+tasks.withType(FindBugs) {
+    reports {
+        xml.enabled = false
+        html.enabled = true
+    }
+}

--- a/findbugs_excludes.xml
+++ b/findbugs_excludes.xml
@@ -1,0 +1,39 @@
+<!--
+  ~ Copyright (c) 2015 IBM Corp. All rights reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+  ~ except in compliance with the License. You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software distributed under the
+  ~ License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+  ~ either express or implied. See the License for the specific language governing permissions
+  ~ and limitations under the License.
+  -->
+<!--
+A list of known findbugs issues that we cannot fix at this time.
+For example because it requires an API change
+-->
+<FindBugsFilter>
+    <!-- This bug is because com.cloudant.client.api.model.Document extends
+     com.cloudant.org.lightcouch.Document. Eventually we may roll them into one class and then this
+     exclude can be removed.
+     -->
+    <Match>
+        <Bug code="Nm" pattern="NM_SAME_SIMPLE_NAME_AS_SUPERCLASS"/>
+        <Class name="com.cloudant.client.api.model.Document"/>
+    </Match>
+    <!-- This bug is because addAttachment in com.cloudant.client.api.model.Document does not
+     override the addAttachment in com.cloudant.org.lightcouch.Document. This is because of the two
+     different Attachment classes. This leads to the confusing situation where there are two
+     addAttachment methods on the API document class and it is hard to distinguish which to use.
+     Again this can be resolved if we consolidate the Document and Attachment classes from the two
+     packages.
+     -->
+    <Match>
+        <Bug code="Nm" pattern="NM_WRONG_PACKAGE"/>
+        <Class name="com.cloudant.client.api.model.Document"/>
+        <Method name="addAttachment"/>
+    </Match>
+</FindBugsFilter>

--- a/src/main/java/com/cloudant/client/api/model/Params.java
+++ b/src/main/java/com/cloudant/client/api/model/Params.java
@@ -59,16 +59,28 @@ public class Params {
         return this;
     }
 
-    public boolean equals(Object obj) {
-        return params.equals(obj);
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        Params params1 = (Params) o;
+
+        return params.equals(params1.params);
+
+    }
+
+    @Override
+    public int hashCode() {
+        return params.hashCode();
     }
 
     public List<String> getParams() {
         return params.getParams();
-    }
-
-    public int hashCode() {
-        return params.hashCode();
     }
 
     public Params revsInfo() {


### PR DESCRIPTION
*What*
Enable findbugs static analysis as part of the gradle build. This is intended as a start to prevent any new "high" level issues getting added and we can over time reduce the filtering as we clean up issues.

*Why*
Prevent some issues sneaking through, such as the UTF-8 encoding problems identified in #155.

*How*
Added the findbugs plugin to gradle.
Switched on reporting for "high" severity issues only on the main source set at first. Ideally later we can enable other severity issues and include the test code.
Fixed a bad equals method identified by findbugs for `Params`.
Added excludes for a couple of naming issues, which it would be good to resolve, but would require bigger changes.

*Testing*
Runs in the gradle build `check` and therefore is included in Travis CI.

reviewer @rhyshort