### PR TITLE
157 cookie renew

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
   JVM default. UTF-8 is now correctly used for the request body content length and throughout.
 - [FIX] Fixed deserialization of `ReplicatorDocument` where the source or target url is a JSON
   object not a string.
+- [FIX] Renew cookies when the server returns a 403 status code with `{"error":"credentials_expired"}`.
 
 # 2.0.0 (2015-11-12)
 - [NEW] `DesignDocument.MapReduce` now has a setter for the `dbcopy` field.

--- a/src/main/java/com/cloudant/http/interceptors/HttpConnectionInterceptorException.java
+++ b/src/main/java/com/cloudant/http/interceptors/HttpConnectionInterceptorException.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2015 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.http.interceptors;
+
+public class HttpConnectionInterceptorException extends RuntimeException {
+
+    public final String error;
+    public final String reason;
+
+    HttpConnectionInterceptorException(String error) {
+        this(error, null);
+    }
+
+    HttpConnectionInterceptorException(String error, String reason) {
+        super(error + ((reason != null) ? ": " + reason : ""));
+        this.error = error;
+        this.reason = reason;
+    }
+}


### PR DESCRIPTION
*What*
Renew the session cookie if a 403 is received for expiry. Fixes #157.

*Why*
Expired cookies from Cloudant generate a 403 (whereas CouchDB 1.6.1 generates a 401).

*How*
Added 403 status code checks to the `CookieInterceptor` and read the error stream to identify if it was an expiry case.
In non-expiry 403 cases a new `HttpConnectionInterceptorException` is thrown that contains the error information read from the error stream. This is necessary because otherwise the error information would be lost in 403 responses that were not due to cookie expiry. This is not ideal, but is the strategic fix that doesn't involve breaking the interceptor APIs.

*Testing*
Added new tests for a 403 in both expiry and non-expiry cases.

reviewer @mikerhodes 
reviewer @emlaver 