### PR TITLE
153 rep doc url

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,8 @@
 - [IMPROVED] Added HTTP status code to `Response` objects.
 - [FIX] Too many bytes written exception caused by inconsistent encoding between UTF-8 and the
   JVM default. UTF-8 is now correctly used for the request body content length and throughout.
+- [FIX] Fixed deserialization of `ReplicatorDocument` where the source or target url is a JSON
+  object not a string.
 
 # 2.0.0 (2015-11-12)
 - [NEW] `DesignDocument.MapReduce` now has a setter for the `dbcopy` field.

--- a/src/main/java/com/cloudant/client/org/lightcouch/ReplicatorDocument.java
+++ b/src/main/java/com/cloudant/client/org/lightcouch/ReplicatorDocument.java
@@ -15,7 +15,9 @@
 
 package com.cloudant.client.org.lightcouch;
 
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
 import com.google.gson.annotations.SerializedName;
 
 /**
@@ -28,9 +30,9 @@ import com.google.gson.annotations.SerializedName;
 public class ReplicatorDocument extends Document {
 
     @SerializedName("source")
-    private String source;
+    private JsonElement source;
     @SerializedName("target")
-    private String target;
+    private JsonElement target;
     @SerializedName("continuous")
     private Boolean continuous;
     @SerializedName("filter")
@@ -65,11 +67,22 @@ public class ReplicatorDocument extends Document {
     private Integer sinceSeq;
 
     public String getSource() {
-        return source;
+        return getEndpointUrl(source);
     }
 
     public String getTarget() {
-        return target;
+        return getEndpointUrl(target);
+    }
+
+    private String getEndpointUrl(JsonElement element) {
+        JsonPrimitive urlString = null;
+        if (element.isJsonPrimitive()) {
+            urlString = element.getAsJsonPrimitive();
+        } else {
+            JsonObject replicatorEndpointObject = element.getAsJsonObject();
+            urlString = replicatorEndpointObject.getAsJsonPrimitive("url");
+        }
+        return urlString.getAsString();
     }
 
     public Boolean getContinuous() {
@@ -133,11 +146,11 @@ public class ReplicatorDocument extends Document {
     }
 
     public void setSource(String source) {
-        this.source = source;
+        this.source = new JsonPrimitive(source);
     }
 
     public void setTarget(String target) {
-        this.target = target;
+        this.target = new JsonPrimitive(target);
     }
 
     public void setContinuous(Boolean continuous) {


### PR DESCRIPTION
*What*
Correct deserialization of `ReplicatorDocument` for object source/target URLs. Fixes #153.

*How*
Changed the source & target fields in `ReplicatorDocument` to`JsonElement` from String so they can support both String or `JsonObject`.
Modified the setters and getters to work with the `JsonElement`.

*Testing*
Resolves the failure of `com.cloudant.tests.ReplicatorTest#replicatorDB` when running against the Cloudant service.

reviewer @rhyshort 
reviewer @alfinkel 