### PR TITLE
Added _session DELETE request to shutdown method

### DIFF
--- a/src/main/java/com/cloudant/client/org/lightcouch/CouchDbClient.java
+++ b/src/main/java/com/cloudant/client/org/lightcouch/CouchDbClient.java
@@ -134,6 +134,11 @@ public class CouchDbClient {
      * Connection manager is no longer used.
      */
     public void shutdown() {
+        // Delete the cookie _session if there is one
+        HttpConnection conn = execute(Http.DELETE(buildUri(getBaseUri()).path("_session")
+                .build()));
+
+        // The execute method handles non-2xx response codes by throwing a CouchDbException.
     }
 
     /**

--- a/src/test/java/com/cloudant/tests/CloudantClientTests.java
+++ b/src/test/java/com/cloudant/tests/CloudantClientTests.java
@@ -324,4 +324,18 @@ public class CloudantClientTests {
         //ensure that building a URL from it does not throw any exceptions
         new URL(c.getBaseUri().toString());
     }
+
+    @Test
+    public void sessionDeleteOnShutdown() throws Exception {
+        MockWebServer server = new MockWebServer();
+        // Mock a 200 OK for the _session DELETE request
+        server.enqueue(new MockResponse().setResponseCode(200).setBody("{\"ok\":\"true\"}"));
+
+        CloudantClient c = CloudantClientHelper.newMockWebServerClientBuilder(server).build();
+        c.shutdown();
+
+        RecordedRequest request = server.takeRequest(10, TimeUnit.SECONDS);
+        assertEquals("The request method should be DELETE", "DELETE", request.getMethod());
+        assertEquals("The request should be to the _session path", "/_session", request.getPath());
+    }
 }


### PR DESCRIPTION
*What*
Logout session when `client.shutdown()` is called.

*Why*
Fixes #152 - the session should not be left active when the client work is finished.

*How*
Added _session DELETE request to shutdown method.

*Testing*
Added new test with mock server to assert delete request send on
client.shutdown() call.

reviewer @rhyshort 
reviewer @alfinkel 