### PR TITLE
Added jdk8 to travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ sudo: false
 
 jdk:
   - openjdk7
+  - oraclejdk8
 
 services:
   - couchdb


### PR DESCRIPTION
*What*
Add JDK8 to the Travis checks.

*Why*
Java 8 checks javadoc more stringently than Java 7.

*Testing*
Travis executed successful builds on both JDKs.

reviewer @rhyshort 