### PR TITLE
Use GSON objects to build JSON and not string operations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 - [IMPROVED] Request a session delete on client shutdown.
 - [IMPROVED] Consistently encode all parts of request URLs and handle additional special characters.
 - [FIX] Stopped integers in complex key arrays turning into floats when using view pagination with tokens.
+- [FIX] Replaced string operations with GSON objects when parsing JSON.
 
 # 2.1.0 (2015-12-04)
 - [IMPROVED] Included error and reason information in message from `CouchDbException` classes.

--- a/src/main/java/com/cloudant/client/api/Search.java
+++ b/src/main/java/com/cloudant/client/api/Search.java
@@ -28,6 +28,7 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import com.google.gson.JsonPrimitive;
 
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -351,13 +352,12 @@ public class Search {
      */
     public Search counts(String[] countsfields) {
         assert (countsfields.length > 0);
-        int i = 0;
-        String counts = "[";
-        for (; i < countsfields.length - 1; i++) {
-            counts += "\"" + countsfields[i] + "\",";
+        JsonArray countsJsonArray = new JsonArray();
+        for(String countsfield : countsfields) {
+            JsonPrimitive element = new JsonPrimitive(countsfield);
+            countsJsonArray.add(element);
         }
-        counts += "\"" + countsfields[i] + "\"]";
-        databaseHelper.query("counts", counts);
+        databaseHelper.query("counts", countsJsonArray);
         return this;
     }
 
@@ -371,7 +371,12 @@ public class Search {
     public Search drillDown(String fieldName, String fieldValue) {
         assertNotEmpty(fieldName, "fieldName");
         assertNotEmpty(fieldValue, "fieldValue");
-        databaseHelper.query("drilldown", "[\"" + fieldName + "\",\"" + fieldValue + "\"]");
+        JsonArray drillDownArray = new JsonArray();
+        JsonPrimitive fieldNamePrimitive = new JsonPrimitive(fieldName);
+        drillDownArray.add(fieldNamePrimitive);
+        JsonPrimitive fieldValuePrimitive = new JsonPrimitive(fieldValue);
+        drillDownArray.add(fieldValuePrimitive);
+        databaseHelper.query("drilldown", drillDownArray);
         return this;
     }
 

--- a/src/main/java/com/cloudant/client/api/model/FindByIndexOptions.java
+++ b/src/main/java/com/cloudant/client/api/model/FindByIndexOptions.java
@@ -15,6 +15,8 @@
 package com.cloudant.client.api.model;
 
 import com.cloudant.client.api.Database;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonPrimitive;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -46,7 +48,7 @@ public class FindByIndexOptions {
     private List<IndexField> sort = new ArrayList<IndexField>();
     private List<String> fields = new ArrayList<String>();
     private Integer readQuorum;
-    private String useIndex = null;
+    private JsonArray useIndex = new JsonArray();
 
     /**
      * @param limit limit the number of results return
@@ -105,7 +107,8 @@ public class FindByIndexOptions {
      * @return this to set additional options
      */
     public FindByIndexOptions useIndex(String designDocument) {
-        this.useIndex = "\"" + designDocument + "\"";
+        JsonPrimitive jsonDesign = new JsonPrimitive(designDocument);
+        this.useIndex.add(jsonDesign);
         return this;
     }
 
@@ -117,7 +120,10 @@ public class FindByIndexOptions {
      * @return this to set additional options
      */
     public FindByIndexOptions useIndex(String designDocument, String indexName) {
-        this.useIndex = "[\"" + designDocument + "\",\"" + indexName + "\"]";
+        JsonPrimitive jsonDesign = new JsonPrimitive(designDocument);
+        JsonPrimitive jsonIndex = new JsonPrimitive(indexName);
+        this.useIndex.add(jsonDesign);
+        this.useIndex.add(jsonIndex);
         return this;
     }
 
@@ -142,7 +148,6 @@ public class FindByIndexOptions {
     }
 
     public String getUseIndex() {
-        return useIndex;
+        return useIndex.toString();
     }
-
 }

--- a/src/main/java/com/cloudant/client/org/lightcouch/CouchDatabaseBase.java
+++ b/src/main/java/com/cloudant/client/org/lightcouch/CouchDatabaseBase.java
@@ -273,13 +273,15 @@ public abstract class CouchDatabaseBase {
         InputStream responseStream = null;
         HttpConnection connection;
         try {
-            final String allOrNothingVal = allOrNothing ? "\"all_or_nothing\": true, " : "";
+            final JsonObject jsonObject = new JsonObject();
+            if(allOrNothing) {
+                jsonObject.addProperty("all_or_nothing", true);
+            }
             final URI uri = new DatabaseURIHelper(dbUri).bulkDocsUri();
-            final String json = String.format("{%s%s%s}", allOrNothingVal, "\"docs\": ", getGson
-                    ().toJson(objects));
+            jsonObject.add("docs", getGson().toJsonTree(objects));
             connection = Http.POST(uri, "application/json");
-            if (json != null && !json.isEmpty()) {
-                connection.setRequestBody(json);
+            if (jsonObject.toString().length() != 0) {
+                connection.setRequestBody(jsonObject.toString());
             }
             couchDbClient.execute(connection);
             responseStream = connection.responseAsInputStream();

--- a/src/test/java/com/cloudant/tests/IndexTests.java
+++ b/src/test/java/com/cloudant/tests/IndexTests.java
@@ -26,6 +26,7 @@ import com.cloudant.test.main.RequiresCloudant;
 import com.cloudant.tests.util.CloudantClientResource;
 import com.cloudant.tests.util.DatabaseResource;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonParseException;
 
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -158,13 +159,14 @@ public class IndexTests {
         selector.put("Movie_year", year);
         selector.put("Person_name", "Alec Guinness");
         //check find by using index design doc
-        List<Movie> movies = db.findByIndex(new GsonBuilder().create().toJson(selector), Movie.class,
+        List<Movie> movies = db.findByIndex(new GsonBuilder().create().toJson(selector),
+                Movie.class,
                 new FindByIndexOptions()
                         .sort(new IndexField("Movie_year", SortOrder.desc))
-                .fields("Movie_name").fields("Movie_year")
-                .limit(1)
-                .skip(1)
-                .readQuorum(2).useIndex("Movie_year"));
+                        .fields("Movie_name").fields("Movie_year")
+                        .limit(1)
+                        .skip(1)
+                        .readQuorum(2).useIndex("Movie_year"));
         assertNotNull(movies);
         assert (movies.size() == 1);
         for (Movie m : movies) {
@@ -181,8 +183,9 @@ public class IndexTests {
         selector.put("Movie_year", year);
         selector.put("Person_name", "Alec Guinness");
         //check find by using index design doc and index name
-        List<Movie> movies = db.findByIndex(new GsonBuilder().create().toJson(selector), Movie.class, new
-                FindByIndexOptions().sort(new IndexField("Movie_year", SortOrder.desc))
+        List<Movie> movies = db.findByIndex(new GsonBuilder().create().toJson(selector),
+                Movie.class,
+                new FindByIndexOptions().sort(new IndexField("Movie_year", SortOrder.desc))
                 .fields("Movie_name").fields("Movie_year")
                 .limit(1)
                 .skip(1)
@@ -194,5 +197,17 @@ public class IndexTests {
             assertNotNull(m.getMovie_year());
         }
 
+    }
+
+    @Test(expected = JsonParseException.class)
+    public void invalidSelectorObjectThrowsJsonParseException() {
+        db.findByIndex("\"selector\"invalid", Movie.class);
+    }
+
+    @Test(expected = JsonParseException.class)
+    public void invalidFieldThrowsJsonParseException() {
+        FindByIndexOptions findByIndexOptions = new FindByIndexOptions();
+        findByIndexOptions.fields("\"");
+        db.findByIndex("{\"type\":\"subscription\"}", Movie.class, findByIndexOptions);
     }
 }


### PR DESCRIPTION
*What*
Building JSON using string operations is causing several defects. Use the GSON library to assemble the object instead.
Issue #101 

*How*
- Replace string building implementation with GSON objects in Database, Search, and CouchDatabaseBase class

*Testing*
New test cases to assert that invalid JSON will throw a bad request.

reviewer @ricellis
reviewer @rhyshort