### PR TITLE
172 complex int

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # Unreleased
 - [IMPROVED] Request a session delete on client shutdown.
 - [IMPROVED] Consistently encode all parts of request URLs and handle additional special characters.
+- [FIX] Stopped integers in complex key arrays turning into floats when using view pagination with tokens.
 
 # 2.1.0 (2015-12-04)
 - [IMPROVED] Included error and reason information in message from `CouchDbException` classes.

--- a/src/main/java/com/cloudant/client/internal/util/QueryParameter.java
+++ b/src/main/java/com/cloudant/client/internal/util/QueryParameter.java
@@ -29,6 +29,4 @@ public @interface QueryParameter {
     String USE_FIELD_NAME = "QueryParameter.USE_FIELD_NAME";
 
     String value() default USE_FIELD_NAME;
-
-    boolean json() default false;
 }

--- a/src/main/java/com/cloudant/client/internal/util/QueryParameters.java
+++ b/src/main/java/com/cloudant/client/internal/util/QueryParameters.java
@@ -14,9 +14,6 @@
 
 package com.cloudant.client.internal.util;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-
 import java.lang.reflect.Field;
 import java.util.HashMap;
 import java.util.Map;
@@ -28,9 +25,7 @@ import java.util.Map;
  */
 public class QueryParameters {
 
-    protected Map<String, Object> processParameters(Gson gson) {
-        //if a null Gson was passed in, then use a default gson instance
-        gson = (gson == null) ? new GsonBuilder().create() : gson;
+    protected Map<String, Object> processParameters() {
         Map<String, Object> parameters = new HashMap<String, Object>();
         for (Field field : this.getClass().getFields()) {
             QueryParameter parameter = field.getAnnotation(QueryParameter.class);
@@ -46,9 +41,6 @@ public class QueryParameters {
                             "have the public modifier and as such was not accessible", e);
                 }
                 if (parameterName != null && parameterValue != null) {
-                    if (parameter.json()) {
-                        parameterValue = gson.toJsonTree(parameterValue);
-                    }
                     parameters.put(parameterName, parameterValue);
                 }
             }

--- a/src/main/java/com/cloudant/client/internal/views/PageMetadata.java
+++ b/src/main/java/com/cloudant/client/internal/views/PageMetadata.java
@@ -120,7 +120,7 @@ final class PageMetadata<K, V> {
 
         // Any initial startkey is now the end key because we are reversed from original direction
         if (startkey != null) {
-            reversedParameters.setEndKey(initialQueryParameters.startkey);
+            reversedParameters.endkey = initialQueryParameters.startkey;
         }
         if (startkey_docid != null) {
             reversedParameters.setEndKeyDocId(initialQueryParameters.startkey_docid);

--- a/src/main/java/com/cloudant/client/internal/views/PaginationToken.java
+++ b/src/main/java/com/cloudant/client/internal/views/PaginationToken.java
@@ -16,8 +16,8 @@ package com.cloudant.client.internal.views;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
 import com.google.gson.annotations.SerializedName;
-import com.google.gson.reflect.TypeToken;
 
 import org.apache.commons.codec.binary.Base64;
 
@@ -26,16 +26,14 @@ import java.nio.charset.Charset;
 
 /**
  * This class is purely for serializing the fields necessary to generate an opaque pagination token.
- *
- * @param <K> the key type
  */
-class PaginationToken<K> {
+class PaginationToken {
 
     @SerializedName("d")
     public Boolean descending = null;
 
     @SerializedName("e")
-    public K endkey = null;
+    public JsonElement endkey = null;
 
     @SerializedName("ei")
     public String endkey_docid = null;
@@ -44,7 +42,7 @@ class PaginationToken<K> {
     public Boolean inclusive_end = null;
 
     @SerializedName("s")
-    public K startkey = null;
+    public JsonElement startkey = null;
 
     @SerializedName("si")
     public String startkey_docid = null;
@@ -56,7 +54,7 @@ class PaginationToken<K> {
     PageMetadata.PagingDirection direction;
 
     // Construct a pagination token using the appropriate metadata
-    private PaginationToken(PageMetadata<K, ?> pageMetadata) {
+    private PaginationToken(PageMetadata pageMetadata) {
         this.pageNumber = pageMetadata.pageNumber;
         this.direction = pageMetadata.direction;
         this.descending = pageMetadata.pageRequestParameters.descending;
@@ -86,9 +84,7 @@ class PaginationToken<K> {
         Gson paginationTokenGson = getGsonWithKeyAdapter(initialParameters);
 
         // Deserialize the pagination token JSON, using the appropriate K, V types
-        PaginationToken<K> token = paginationTokenGson.fromJson(json, new
-                TypeToken<PaginationToken<K>>() {
-                }.getType());
+        PaginationToken token = paginationTokenGson.fromJson(json, PaginationToken.class);
 
         // Create new query parameters using the initial ViewQueryParameters as a starting point.
         ViewQueryParameters<K, V> tokenPageParameters = initialParameters.copy();
@@ -109,13 +105,12 @@ class PaginationToken<K> {
      * Generate an opaque pagination token from the supplied PageMetadata.
      *
      * @param pageMetadata page metadata of the page for which the token should be generated
-     * @param <K>          the view key type
      * @return opaque pagination token
      */
-    static <K> String tokenize(PageMetadata<K, ?> pageMetadata) {
+    static String tokenize(PageMetadata<?, ?> pageMetadata) {
         try {
             Gson g = getGsonWithKeyAdapter(pageMetadata.pageRequestParameters);
-            return new String(Base64.encodeBase64URLSafe(g.toJson(new PaginationToken<K>
+            return new String(Base64.encodeBase64URLSafe(g.toJson(new PaginationToken
                     (pageMetadata)).getBytes("UTF-8")),
                     Charset.forName("UTF-8"));
         } catch (UnsupportedEncodingException e) {

--- a/src/test/java/com/cloudant/tests/util/CheckPagination.java
+++ b/src/test/java/com/cloudant/tests/util/CheckPagination.java
@@ -269,7 +269,6 @@ public class CheckPagination {
         CheckPaginationWithMultiValueKey() {
             testViews = new String[]{"example/doc_title", "example/creator_created",
                     "example/creator_boolean_total", "example/created_boolean_creator"};
-            testViews = new String[]{"example/creator_created"};
             viewKeyType = Key.Type.COMPLEX;
         }
 

--- a/src/test/java/com/cloudant/tests/util/ContextCollectingInterceptor.java
+++ b/src/test/java/com/cloudant/tests/util/ContextCollectingInterceptor.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2016 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.tests.util;
+
+import com.cloudant.http.HttpConnectionInterceptorContext;
+import com.cloudant.http.HttpConnectionRequestInterceptor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ContextCollectingInterceptor implements HttpConnectionRequestInterceptor {
+
+    public List<HttpConnectionInterceptorContext> contexts = new
+            ArrayList<HttpConnectionInterceptorContext>();
+
+    @Override
+    public HttpConnectionInterceptorContext interceptRequest
+            (HttpConnectionInterceptorContext context) {
+        contexts.add(context);
+        return context;
+    }
+
+}


### PR DESCRIPTION
*What*
Fixes #172 ensuring `int` in a complex keys is not turned into `float` by token pagination.

*How*
Internally use `JsonElement` for keys instead of the type erased parameter `K`. This prevents the `ComplexKey` being treated as an `Object` and preserves the JSON array representing the complex key.

*Testing*
Added a new test to check that `int` in a complex key start key remains an `int` for subsequent pages requested by token.
Enabled extra views for complex key pagination tests that appeared to have been accidentally disabled.

reviewer @alfinkel 
reviewer @emlaver 