### PR TITLE
Support POST requests in invokeUpdateHandler

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 - [IMPROVED] Consistently encode all parts of request URLs and handle additional special characters.
 - [FIX] Stopped integers in complex key arrays turning into floats when using view pagination with tokens.
 - [FIX] Replaced string operations with GSON objects when parsing JSON.
+- [NEW] 'Database.invokeUpdateHandler' now handles POST requests.
 
 # 2.1.0 (2015-12-04)
 - [IMPROVED] Included error and reason information in message from `CouchDbException` classes.

--- a/src/main/java/com/cloudant/client/api/Database.java
+++ b/src/main/java/com/cloudant/client/api/Database.java
@@ -985,6 +985,7 @@ public class Database {
      *
      * @param updateHandlerUri The Update Handler URI, in the format: <code>designDoc/update1</code>
      * @param docId            The document id to update.
+     *                         If no id is provided, then a document will be created.
      * @param params           The query parameters as {@link Params}.
      * @return The output of the request.
      * @see <a target="_blank"
@@ -994,7 +995,7 @@ public class Database {
     public String invokeUpdateHandler(String updateHandlerUri, String docId,
                                       Params params) {
         assertNotEmpty(params, "params");
-        return db.invokeUpdateHandler(updateHandlerUri, docId, params.getInternalParams());
+        return db.invokeUpdateHandler(updateHandlerUri, docId, params.getInternalParams(), null);
     }
 
     /**

--- a/src/test/java/com/cloudant/tests/UpdateHandlerTest.java
+++ b/src/test/java/com/cloudant/tests/UpdateHandlerTest.java
@@ -16,6 +16,7 @@ package com.cloudant.tests;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import com.cloudant.client.api.Database;
 import com.cloudant.client.api.model.Params;
@@ -65,6 +66,15 @@ public class UpdateHandlerTest {
 
         assertNotNull(output);
         assertEquals(foo.getTitle(), newValue);
+    }
+
+    @Test
+    public void updateHandler_postUuid() {
+        String output =
+                db.invokeUpdateHandler("example/get-uuid", null, new Params());
+
+        assertNotNull(output);
+        assertTrue(output.length() > 0);
     }
 
     @Test

--- a/src/test/resources/design-files/example_design_doc.js
+++ b/src/test/resources/design-files/example_design_doc.js
@@ -59,7 +59,8 @@
        "example_list": "function(head, req) {}\n"
    },
    "updates": {
-       "example_update": "function(doc, req) {\n\tvar field = req.query.field;\n\tvar value = req.query.value;\n\tvar message = 'set '+field+' to '+value;\n\tdoc[field] = value;\n\treturn [doc, message];\n}\n"
+       "example_update": "function(doc, req) {\n\tvar field = req.query.field;\n\tvar value = req.query.value;\n\tvar message = 'set '+field+' to '+value;\n\tdoc[field] = value;\n\treturn [doc, message];\n}\n",
+       "get-uuid" : "function(doc, req) {\n\t return [null, req.uuid];\n}\n"
    },
    "rewrites": [
        {


### PR DESCRIPTION
*What*
`Database.invokeUpdateHandler` only supports PUT requests.  Passing in an empty or null document Id just returns the error `docId is required`.
This fixes #37 by creating a POST request in the update handler when a null document id exists.

*How*
- If no document ID exists, use POST request in `CouchDatabaseBase.invokeUpdateHandler`
- Add new entry for update handler in example's design document. This is used in new test case.

*Testing*
New POST request test case using uuid.

reviewer @ricellis
reviewer @alfinkel