### PR TITLE
Fixed standalone attachment update issue

### DIFF
--- a/src/main/java/com/cloudant/client/internal/DatabaseURIHelper.java
+++ b/src/main/java/com/cloudant/client/internal/DatabaseURIHelper.java
@@ -176,7 +176,7 @@ public class DatabaseURIHelper extends URIBaseMethods<DatabaseURIHelper> {
     }
 
     private DatabaseURIHelper revId(String revId) {
-        this.path(revId);
+        this.query("rev", revId);
         return returnThis();
     }
 


### PR DESCRIPTION
*What*
Fixed issue where rev was being added to URL path instead of query for standalone attachment saves

*How*
Added revision ID as “rev” query parameter.

*Testing*
Added new test `com.cloudant.tests.AttachmentsTest#attachmentStandaloneUpdate `for updating an attachment.

reviewer @emlaver
reviewer @rhyshort