### PR TITLE
186 null id or rev attachments

### DIFF
--- a/src/main/java/com/cloudant/client/api/Database.java
+++ b/src/main/java/com/cloudant/client/api/Database.java
@@ -946,35 +946,35 @@ public class Database {
     }
 
     /**
-         * Creates or updates an attachment on the given document ID and revision.
-         * <P>
-         * If {@code docId} and {@code docRev} are {@code null} a new document will be created.
-         * </P>
-         * <P>
-         * Example usage:
-         * </P>
-         * <pre>
-         * {@code
-         * byte[] bytesToDB = "binary data".getBytes();
-         * ByteArrayInputStream bytesIn = new ByteArrayInputStream(bytesToDB);
-         * Response response = db.saveAttachment(bytesIn, "foo.txt", "text/plain","exampleId","3-rev");
-         * }
-         * </pre>
-         * Saves an attachment to an existing document given both a document id
-         * and revision, or save to a new document given only the id, and rev as {@code null}.
-         * <p>To retrieve an attachment, see {@link #find(Class, String, Params)}</p>
-         *
-         * @param in          The {@link InputStream} providing the binary data.
-         * @param name        The attachment name.
-         * @param contentType The attachment "Content-Type".
-         * @param docId       The document id to save the attachment under, or {@code null} to save
-         *                    under a new document.
-         * @param docRev      The document revision to save the attachment under, or {@code null}
-         *                    when saving to a new document.
-         * @return {@link com.cloudant.client.api.model.Response}
-         * @throws DocumentConflictException if the attachment cannot be saved because of a conflict
-         * @see <a target="_blank" href="https://docs.cloudant.com/attachments.html">Attachments</a>
-         */
+     * Creates or updates an attachment on the given document ID and revision.
+     * <P>
+     * If {@code docId} and {@code docRev} are {@code null} a new document will be created.
+     * </P>
+     * <P>
+     * Example usage:
+     * </P>
+     * <pre>
+     * {@code
+     * byte[] bytesToDB = "binary data".getBytes();
+     * ByteArrayInputStream bytesIn = new ByteArrayInputStream(bytesToDB);
+     * Response response = db.saveAttachment(bytesIn, "foo.txt", "text/plain","exampleId","3-rev");
+     * }
+     * </pre>
+     * Saves an attachment to an existing document given both a document id
+     * and revision, or save to a new document given only the id, and rev as {@code null}.
+     * <p>To retrieve an attachment, see {@link #find(Class, String, Params)}</p>
+     *
+     * @param in          The {@link InputStream} providing the binary data.
+     * @param name        The attachment name.
+     * @param contentType The attachment "Content-Type".
+     * @param docId       The document ID to save the attachment under, or {@code null} to save
+     *                    under a new document with a generated ID.
+     * @param docRev      The document revision to save the attachment under, or {@code null}
+     *                    when saving to a new document.
+     * @return {@link Response}
+     * @throws DocumentConflictException if the attachment cannot be saved because of a conflict
+     * @see <a target="_blank" href="https://docs.cloudant.com/attachments.html">Attachments</a>
+     */
     public com.cloudant.client.api.model.Response saveAttachment(InputStream in, String name,
                                                                  String contentType, String
                                                                          docId, String docRev) {

--- a/src/main/java/com/cloudant/client/org/lightcouch/CouchDatabaseBase.java
+++ b/src/main/java/com/cloudant/client/org/lightcouch/CouchDatabaseBase.java
@@ -16,6 +16,7 @@
 package com.cloudant.client.org.lightcouch;
 
 import static com.cloudant.client.org.lightcouch.internal.CouchDbUtil.assertNotEmpty;
+import static com.cloudant.client.org.lightcouch.internal.CouchDbUtil.assertNull;
 import static com.cloudant.client.org.lightcouch.internal.CouchDbUtil.close;
 import static com.cloudant.client.org.lightcouch.internal.CouchDbUtil.generateUUID;
 import static com.cloudant.client.org.lightcouch.internal.CouchDbUtil.getAsString;
@@ -311,11 +312,7 @@ public abstract class CouchDatabaseBase {
      * @return {@link Response}
      */
     public Response saveAttachment(InputStream in, String name, String contentType) {
-        assertNotEmpty(in, "in");
-        assertNotEmpty(name, "name");
-        assertNotEmpty(contentType, "ContentType");
-        final URI uri = new DatabaseURIHelper(dbUri).attachmentUri(generateUUID(), name);
-        return couchDbClient.put(uri, in, contentType);
+        return saveAttachment(in, name, contentType, null, null);
     }
 
     /**
@@ -338,7 +335,18 @@ public abstract class CouchDatabaseBase {
         assertNotEmpty(in, "in");
         assertNotEmpty(name, "name");
         assertNotEmpty(contentType, "ContentType");
-        assertNotEmpty(docId, "docId");
+        if (docId == null) {
+            docId = generateUUID();
+            // A new doc is being created; there should be no revision specified.
+            assertNull(docRev, "docRev");
+        } else {
+            // The id has been specified, ensure it is not empty
+            assertNotEmpty(docId, "docId");
+            if (docRev != null) {
+                // Existing doc with the specified ID, ensure rev is not empty
+                assertNotEmpty(docRev, "docRev");
+            }
+        }
         final URI uri = new DatabaseURIHelper(dbUri).attachmentUri(docId, docRev, name);
         return couchDbClient.put(uri, in, contentType);
     }


### PR DESCRIPTION
*What*
Fixes #186 regression when saving an attachment to a new document with a given ID (i.e. null revision) and makes `saveAttachment` match the API documentation.

*How*

* Clarified javadoc for the `Database.saveAttachment` with id & rev method.
* Fixed the implementation to generate a UUID instead of throwing an assertion
failure if `null` is passed as a document ID in line with the documentation.
* Added assertions to ensure that we have one of these three combinations

| docId | docRev |
|----|----|
|`null`|`null`|
|not-empty|null|
|not-empty|not-empty|

*Testing*

* New test for a generating a new document with a generated ID when using `saveAttachment`: `attachmentattachmentStandaloneNullIdNullRev`.
* New test for generating a new document with a supplied ID and an attachment: `attachmentStandaloneGivenId`.
* Three new tests for `IllegalArgumentException` cases.
    * `attachmentStandaloneNullDocNonNulLRev`
    * `attachmentStandaloneEmptyDocId`
    * `attachmentStandaloneDocIdEmptyRev`

reviewer @rhyshort 
reviewer @alfinkel