### PR TITLE
202 query param semicolon

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 # Unreleased
 - [NEW] Constructor for `Database` subclasses.
 - [IMPROVED] Documentation for `Database.findByIndex` to show complete selector.
+- [FIX] `CouchDbException: 400 Bad Request: bad_request: invalid_json` when a
+  query parameter contains a semicolon.
 - [FIX] `NullPointerException` when using `Database.saveAttachment` with a `null`
   revision to attach to a new document with the specified ID.
 - [FIX] `CouchDbException` when using `Database.saveAttachment` to update

--- a/src/main/java/com/cloudant/client/internal/HierarchicalUriComponents.java
+++ b/src/main/java/com/cloudant/client/internal/HierarchicalUriComponents.java
@@ -136,10 +136,23 @@ public class HierarchicalUriComponents {
         QUERY_PARAM {
             @Override
             public boolean isAllowed(int c) {
-                if ('=' == c || '+' == c || '&' == c) {
+                // The query component defined in RFC 3986 does not specify the structure of data
+                // within a query or query parameter, which is deferred to the URI's scheme.
+                // The HTTP scheme in turn does not specify any restrictions on the structure of
+                // data within the query component, only that it must conform to RFC 3986.
+                // As a result the valid characters are determined by the server processing the
+                // request, so in this case we defer to the HTML application/x-www-form-urlencoded
+                // specification https://www.w3.org/TR/html401/interact/forms.html#h-17.13.4.1
+                // and appendix B.2.2 https://www.w3.org/TR/html401/appendix/notes.html#h-B.2.2
+                // to force encoding of the following:
+                //   '+' as otherwise it would interpreted as a space
+                //   '=' as the key value separator
+                //   '&' and ';' as query parameter delimiters
+                // before deferring to RFC 3986.
+                if ('=' == c || '+' == c || '&' == c || ';' == c) {
                     return false;
-                }
-                else {
+                } else {
+                    // These are the RFC 3986 allowed characters for a query
                     return isPchar(c) || '/' == c || '?' == c;
                 }
             }

--- a/src/test/java/com/cloudant/tests/ViewsTest.java
+++ b/src/test/java/com/cloudant/tests/ViewsTest.java
@@ -67,10 +67,12 @@ public class ViewsTest {
 
 
     private static ContextCollectingInterceptor cci = new ContextCollectingInterceptor();
-    public static CloudantClientResource interceptedClient = new CloudantClientResource(CloudantClientHelper.getClientBuilder().interceptors(cci));
+    public static CloudantClientResource interceptedClient = new CloudantClientResource
+            (CloudantClientHelper.getClientBuilder().interceptors(cci));
     public static DatabaseResource interceptedDB = new DatabaseResource(interceptedClient);
     @ClassRule
-    public static RuleChain intercepted = RuleChain.outerRule(interceptedClient).around(interceptedDB);
+    public static RuleChain intercepted = RuleChain.outerRule(interceptedClient).around
+            (interceptedDB);
     private Database db;
 
     @Before
@@ -637,7 +639,8 @@ public class ViewsTest {
         db.save(new Foo()).getId();
         db.save(new Foo()).getId();
 
-        List<String> allDocIds = db.getAllDocsRequestBuilder().keys(id1, id2).build().getResponse().getDocIds();
+        List<String> allDocIds = db.getAllDocsRequestBuilder().keys(id1, id2).build().getResponse()
+                .getDocIds();
         assertThat(allDocIds.size(), is(2));
     }
 


### PR DESCRIPTION
*What*
Fixes #202 encoding `;` in query parameters.

*How*
Added `;` to the list of characters to encode in the `HierarchicalUriComponents.Type#QUERY_PARAM`.
Clarified method documentation on why the characters were chosen.

*Testing*
Added new `ViewTests.testUriReservedCharsInStartKey` that makes requests using all URI reserved characters in a view start key to ensure no `400 bad request` is encountered.

reviewer @tomblench 
reviewer @rhyshort 