### PR TITLE
Updated response code assertions

### DIFF
--- a/src/test/java/com/cloudant/tests/ResponseTest.java
+++ b/src/test/java/com/cloudant/tests/ResponseTest.java
@@ -52,7 +52,7 @@ public class ResponseTest {
     @Test
     public void verifyDocumentSaved() {
         Response response = db.save(foo);
-        assertEquals(201, response.getStatusCode());
+        assertEquals(2, response.getStatusCode() / 100);
     }
 
     @Test
@@ -81,7 +81,7 @@ public class ResponseTest {
     public void verifyDocumentConflict() {
         try {
             Response response = db.save(foo);
-            assertEquals(201, response.getStatusCode());
+            assertEquals(2, response.getStatusCode() / 100);
 
             db.save(foo);
             fail("A DocumentConflictException should be thrown");
@@ -111,7 +111,7 @@ public class ResponseTest {
 
         List<Response> responses = db.bulk(foos);
         for (Response response : responses) {
-            assertEquals(201, response.getStatusCode());
+            assertEquals(2, response.getStatusCode() / 100);
         }
     }
 

--- a/src/test/java/com/cloudant/tests/UnicodeTest.java
+++ b/src/test/java/com/cloudant/tests/UnicodeTest.java
@@ -267,7 +267,7 @@ public class UnicodeTest {
             conn.requestProperties.put("Accept", "application/json");
             conn.setRequestBody("{\"foo\":\"" + TESTSTRING + "\"}");
             clientResource.get().executeRequest(conn);
-            assertEquals(201, conn.getConnection().getResponseCode());
+            assertEquals(2, conn.getConnection().getResponseCode() / 100);
             closeResponse(conn);
         }
         {
@@ -302,7 +302,7 @@ public class UnicodeTest {
             conn.requestProperties.put("Accept", "application/json");
             conn.setRequestBody("{\"foo\":\"" + TESTSTRING_ESCAPED + "\"}");
             clientResource.get().executeRequest(conn);
-            assertEquals(201, conn.getConnection().getResponseCode());
+            assertEquals(2, conn.getConnection().getResponseCode() / 100);
             closeResponse(conn);
         }
         {


### PR DESCRIPTION
*What*
Fixes #206 - intermittent test failures with `202` response.

*How*
Change the assertions in `UnicodeTest` & `ResponseTest` to check for `2XX`.

*Testing*
No new tests, modifications to existing tests.