### PR TITLE
Update DesignDocument#equals to include indexes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 # Unreleased
 - [NEW] Documentation for logging in project javadoc `overview.html`.
+- [FIX] Fix issue where design documents would not be updated if only the
+  `indexes` field was updated.
 
 # 2.3.0 (2016-02-12)
 - [NEW] Constructor for `Database` subclasses.

--- a/src/main/java/com/cloudant/client/api/model/DesignDocument.java
+++ b/src/main/java/com/cloudant/client/api/model/DesignDocument.java
@@ -123,100 +123,64 @@ public class DesignDocument extends com.cloudant.client.org.lightcouch.Document 
 
     @Override
     public int hashCode() {
-        final int prime = 31;
         int result = super.hashCode();
-        result = prime * result + ((filters == null) ? 0 : filters.hashCode());
-        result = prime * result + ((language == null) ? 0 : language.hashCode());
-        result = prime * result + ((lists == null) ? 0 : lists.hashCode());
-        result = prime * result + ((shows == null) ? 0 : shows.hashCode());
-        result = prime * result + ((updates == null) ? 0 : updates.hashCode());
-        result = prime * result
-                + ((validateDocUpdate == null) ? 0 : validateDocUpdate.hashCode());
-        result = prime * result + ((rewrites == null) ? 0 : rewrites.hashCode());
-        result = prime * result + ((fulltext == null) ? 0 : fulltext.hashCode());
-        result = prime * result + ((views == null) ? 0 : views.hashCode());
+        result = 31 * result + (language != null ? language.hashCode() : 0);
+        result = 31 * result + (views != null ? views.hashCode() : 0);
+        result = 31 * result + (validateDocUpdate != null ? validateDocUpdate.hashCode() : 0);
+        result = 31 * result + (filters != null ? filters.hashCode() : 0);
+        result = 31 * result + (shows != null ? shows.hashCode() : 0);
+        result = 31 * result + (lists != null ? lists.hashCode() : 0);
+        result = 31 * result + (updates != null ? updates.hashCode() : 0);
+        result = 31 * result + (rewrites != null ? rewrites.hashCode() : 0);
+        result = 31 * result + (fulltext != null ? fulltext.hashCode() : 0);
+        result = 31 * result + (indexes != null ? indexes.hashCode() : 0);
         return result;
     }
 
-    /**
-     * Indicates whether some other design document is equals to this one.
-     */
     @Override
-    public boolean equals(Object obj) {
-        if (this == obj) {
+    public boolean equals(Object o) {
+        if (this == o) {
             return true;
         }
-        if (!super.equals(obj)) {
+        if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        if (getClass() != obj.getClass()) {
+        if (!super.equals(o)) {
             return false;
         }
-        DesignDocument other = (DesignDocument) obj;
-        if (filters == null) {
-            if (other.filters != null) {
-                return false;
-            }
-        } else if (!filters.equals(other.filters)) {
+
+        DesignDocument that = (DesignDocument) o;
+
+        if (language != null ? !language.equals(that.language) : that.language != null) {
             return false;
         }
-        if (language == null) {
-            if (other.language != null) {
-                return false;
-            }
-        } else if (!language.equals(other.language)) {
+        if (views != null ? !views.equals(that.views) : that.views != null) {
             return false;
         }
-        if (lists == null) {
-            if (other.lists != null) {
-                return false;
-            }
-        } else if (!lists.equals(other.lists)) {
+        if (validateDocUpdate != null ? !validateDocUpdate.equals(that.validateDocUpdate) : that
+                .validateDocUpdate != null) {
             return false;
         }
-        if (shows == null) {
-            if (other.shows != null) {
-                return false;
-            }
-        } else if (!shows.equals(other.shows)) {
+        if (filters != null ? !filters.equals(that.filters) : that.filters != null) {
             return false;
         }
-        if (updates == null) {
-            if (other.updates != null) {
-                return false;
-            }
-        } else if (!updates.equals(other.updates)) {
+        if (shows != null ? !shows.equals(that.shows) : that.shows != null) {
             return false;
         }
-        if (validateDocUpdate == null) {
-            if (other.validateDocUpdate != null) {
-                return false;
-            }
-        } else if (!validateDocUpdate.equals(other.validateDocUpdate)) {
+        if (lists != null ? !lists.equals(that.lists) : that.lists != null) {
             return false;
         }
-        if (rewrites == null) {
-            if (other.rewrites != null) {
-                return false;
-            }
-        } else if (!rewrites.equals(other.rewrites)) {
+        if (updates != null ? !updates.equals(that.updates) : that.updates != null) {
             return false;
         }
-        if (fulltext == null) {
-            if (other.fulltext != null) {
-                return false;
-            }
-        } else if (!fulltext.equals(other.fulltext)) {
+        if (rewrites != null ? !rewrites.equals(that.rewrites) : that.rewrites != null) {
             return false;
         }
-        if (views == null) {
-            if (other.views != null) {
-                return false;
-            }
-        } else if (!views.equals(other.views)) {
+        if (fulltext != null ? !fulltext.equals(that.fulltext) : that.fulltext != null) {
             return false;
         }
-        return true;
+        return !(indexes != null ? !indexes.equals(that.indexes) : that.indexes != null);
+
     }
 
     /**

--- a/src/test/java/com/cloudant/tests/DesignDocumentTest.java
+++ b/src/test/java/com/cloudant/tests/DesignDocumentTest.java
@@ -1,0 +1,275 @@
+/*
+ * Copyright (c) 2016 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.tests;
+
+import com.cloudant.client.api.model.DesignDocument;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Created by Rhys Short on 24/02/2016.
+ */
+@RunWith(Enclosed.class)
+public class DesignDocumentTest {
+
+    static Gson gson = new GsonBuilder().create();
+
+    enum Field {
+        mrView,
+        listFunction,
+        showFunction,
+        updateFunction,
+        filterFunction,
+        rewriteRule,
+        indexes,
+        validateDocUpdate
+    }
+
+    private static DesignDocument getDesignDocument() {
+        return getDesignDocumentWithFields(EnumSet.allOf(Field.class));
+    }
+
+    private static DesignDocument getDesignDocumentWithFields(EnumSet<Field> fields) {
+        DesignDocument designDocument = new DesignDocument();
+        for (Field f : fields) {
+            switch (f) {
+                case mrView:
+                    mrView(designDocument);
+                    break;
+                case listFunction:
+                    listFunction(designDocument);
+                    break;
+                case showFunction:
+                    showFunction(designDocument);
+                    break;
+                case updateFunction:
+                    updateFunction(designDocument);
+                    break;
+                case filterFunction:
+                    filterFunction(designDocument);
+                    break;
+                case rewriteRule:
+                    rewriteRule(designDocument);
+                    break;
+                case indexes:
+                    indexes(designDocument);
+                    break;
+                case validateDocUpdate:
+                    validateDocUpdate(designDocument);
+                    break;
+                default:
+                    break;
+            }
+        }
+        return designDocument;
+    }
+
+    private static DesignDocument getDesignDocumentWithDifferent(Field f) {
+        DesignDocument designDocument = getDesignDocument();
+
+        switch (f) {
+            case mrView:
+                DesignDocument.MapReduce mapReduce = new DesignDocument.MapReduce();
+                mapReduce.setMap("function(doc){emit(doc.hello);}");
+                mapReduce.setReduce("_count");
+                mapReduce.setDbCopy("myOtherDB");
+                designDocument.getViews().put("view2", mapReduce);
+                break;
+            case listFunction:
+                designDocument.getLists().put("myList2", "function(head,req){ send(toJson(getRow)" +
+                        "; }");
+                break;
+            case showFunction:
+                designDocument.getShows().put("myShow2", "function(doc,req){ if(doc){return " +
+                        "\"hello " +
+                        "world!\"}");
+                break;
+            case updateFunction:
+                designDocument.getUpdates().put("myUpdate2", "function(doc,req){return [doc, " +
+                        "'Edited" +
+                        " " +
+                        "World!'];}");
+                break;
+            case filterFunction:
+                designDocument.getFilters().put("myOtherFilter", "function(doc,req){return false;" +
+                        "}");
+                break;
+            case rewriteRule:
+                List<Map<String, Object>> rewrites = new ArrayList<Map<String, Object>>();
+                Map<String, Object> rewrite = new HashMap<String, Object>();
+                rewrite.put("from", "/index.php");
+                rewrite.put("to", "index.html");
+                rewrite.put("method", "GET");
+                rewrite.put("query", new HashMap<String, String>());
+                rewrites.add(0, rewrite);
+
+                JsonArray rewriteJson = (JsonArray) gson.toJsonTree(rewrites);
+                designDocument.setRewrites(rewriteJson);
+                break;
+            case indexes:
+                Map<String, Map<String, String>> indexes = new HashMap<String, Map<String,
+                        String>>();
+
+                Map<String, String> index = new HashMap<String, String>();
+                index.put("index", "function(doc){....}");
+                indexes.put("movie", index);
+
+                JsonObject indexesJson = (JsonObject) gson.toJsonTree(indexes);
+                designDocument.setIndexes(indexesJson);
+                break;
+            case validateDocUpdate:
+                designDocument.setValidateDocUpdate("throw({ unauthorized: 'Error message here.' " +
+                        "});");
+                break;
+            default:
+                break;
+        }
+        return designDocument;
+    }
+
+    public static class OneOffEqualityTests {
+        @Test
+        public void testDesignDocEqualsForAllFields() {
+            Assert.assertEquals(getDesignDocument(), getDesignDocument());
+        }
+    }
+
+    @RunWith(Parameterized.class)
+    public static final class ParameterizedEqualityTests {
+
+        /**
+         * Parameters for these tests so we run each test multiple times.
+         * We run with a single key or a complex key and both ascending and descending.
+         */
+        @Parameterized.Parameters(name = "Field:{0}")
+        public static Collection<Field> data() {
+            return EnumSet.allOf(Field.class);
+        }
+
+        @Parameterized.Parameter
+        public Field field;
+
+        /**
+         * Tests the design docs are equal for each field in turn.
+         */
+        @Test
+        public void testDesignDocEqualsForEachField() {
+            Assert.assertEquals(getDesignDocumentWithFields(EnumSet.of(field)),
+                    getDesignDocumentWithFields(EnumSet.of(field)));
+        }
+
+        /**
+         * Tests the design docs are not equal when each field is empty in one of the compared docs.
+         *
+         * @throws Exception
+         */
+        @Test
+        public void testDesignDocNotEqualEmpty() throws Exception {
+            Assert.assertNotEquals(getDesignDocument(), getDesignDocumentWithFields(EnumSet
+                    .complementOf(EnumSet.of(field))));
+        }
+
+        /**
+         * Tests the design docs are not equal when each field is different in one of the
+         * compared docs.
+         *
+         * @throws Exception
+         */
+        @Test
+        public void testDesignDocNotEqualDifferent() throws Exception {
+            Assert.assertNotEquals(getDesignDocument(), getDesignDocumentWithDifferent(field));
+        }
+
+    }
+
+    private static void indexes(DesignDocument designDocument) {
+        Map<String, Map<String, String>> indexes = new HashMap<String, Map<String, String>>();
+
+        Map<String, String> index = new HashMap<String, String>();
+        index.put("index", "function(doc){....}");
+        indexes.put("animal", index);
+
+        JsonObject indexesJson = (JsonObject) gson.toJsonTree(indexes);
+        designDocument.setIndexes(indexesJson);
+    }
+
+    private static void rewriteRule(DesignDocument designDocument) {
+        List<Map<String, Object>> rewrites = new ArrayList<Map<String, Object>>();
+        Map<String, Object> rewrite = new HashMap<String, Object>();
+        rewrite.put("from", "/");
+        rewrite.put("to", "index.html");
+        rewrite.put("method", "GET");
+        rewrite.put("query", new HashMap<String, String>());
+        rewrites.add(0, rewrite);
+
+        JsonArray rewriteJson = (JsonArray) gson.toJsonTree(rewrites);
+        designDocument.setRewrites(rewriteJson);
+    }
+
+    private static void filterFunction(DesignDocument designDocument) {
+        Map<String, String> filterFunctions = new HashMap<String, String>();
+        filterFunctions.put("myFilter", "function(doc,req){return false;}");
+        designDocument.setFilters(filterFunctions);
+    }
+
+    private static void updateFunction(DesignDocument designDocument) {
+        Map<String, String> updateFunctions = new HashMap<String, String>();
+        updateFunctions.put("myUpdate", "function(doc,req){return [doc, 'Edited World!'];}");
+        designDocument.setUpdates(updateFunctions);
+    }
+
+    private static void showFunction(DesignDocument designDocument) {
+        Map<String, String> showFunctions = new HashMap<String, String>();
+        showFunctions.put("myShow", "function(doc,req){ if(doc){return \"hello world!\"}");
+        designDocument.setShows(showFunctions);
+    }
+
+    private static void listFunction(DesignDocument designDocument) {
+        Map<String, String> listFunctions = new HashMap<String, String>();
+        listFunctions.put("myList", "function(head,req){ send(toJson(getRow); }");
+        designDocument.setLists(listFunctions);
+    }
+
+    private static void mrView(DesignDocument designDocument) {
+        DesignDocument.MapReduce mapReduce = new DesignDocument.MapReduce();
+        mapReduce.setMap("function(doc){emit(doc.hello);}");
+        mapReduce.setReduce("_stats");
+        mapReduce.setDbCopy("myOtherDB");
+        Map<String, DesignDocument.MapReduce> views = new HashMap<String, DesignDocument
+                .MapReduce>();
+        views.put("helloWorldView", mapReduce);
+        designDocument.setViews(views);
+    }
+
+    private static void validateDocUpdate(DesignDocument designDocument) {
+        designDocument.setValidateDocUpdate("throw({ forbidden: 'Error message here.' });");
+    }
+
+}


### PR DESCRIPTION
## What

Correct Issue where ddocs would not be updated if only the `indexes` field had changed.

## How

Regenerate DesignDocument#equals and DesignDocument#hashCode to take
account of the indexes field.

## Testing

New tests added for the `DesignDocument.equals` method in `DesignDocumentTest`, and a test which updates the `indexes` field of a ddoc and saves to the server in `DesignDocumentsTest`.

## Reviewers
reviewer @ricellis 

## Issues

Fixes #212