### PR TITLE
Http InputStreamGenerator

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 - [NEW] Documentation for logging in project javadoc `overview.html`.
 - [FIX] Fix issue where design documents would not be updated if only the
   `indexes` field was updated.
+- [DEPRECATED] The `InputStream` setters `HttpConnection.setRequestBody(InputStream)` and
+  `HttpConnection.setRequestBody(InputStream, long)`. Use of the new `InputStreamGenerator` is
+  preferred because it allows for request replays.
 
 # 2.3.0 (2016-02-12)
 - [NEW] Constructor for `Database` subclasses.


### PR DESCRIPTION
## What

Added `InputStreamGenerator` for HTTP request replays.

## How

Added `HttpConnection.InputStreamGenerator` interface.
Deprecated `HttpConnection.setRequestBody(InputStream)` method variants.

## Testing
Added new tests to `HttpTest`:
`inputStreamRetryString()`
`inputStreamRetryBytes()`
`inputStreamRetry()`
`inputStreamRetryWithLength()`
`inputStreamRetryGenerator()` 
`inputStreamRetryGeneratorWithLength()`

## Reviewers

reviewer @rhyshort
reviewer @tomblench 