### PR TITLE
215 cxn spec

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Unreleased
 - [NEW] Documentation for logging in project javadoc `overview.html`.
+- [IMPROVED] Upgraded optional okhttp to 2.7.5.
+- [FIX] Issue of `javax.net.ssl.SSLHandshakeException: Received fatal alert: handshake_failure` on
+  IBM Java with okhttp. SSL connections using okhttp are now configured to use the JVM enabled
+   protocols and cipher suites in the same way as the `HttpURLConnection`.
 - [FIX] Issue where a `java.net.ProtocolException` was thrown if the cookie had expired when a
   request that included a body was sent. Note that the client no longer uses the
   `Expect:100-continue` header on requests.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Gradle with [optional `okhttp-urlconnection` dependency](#optional-okhttp-depend
 ```groovy
 dependencies {
     compile group: 'com.cloudant', name: 'cloudant-client', version: '2.3.0'
-    compile group: 'com.squareup.okhttp', name: 'okhttp-urlconnection', version: '2.5.0'
+    compile group: 'com.squareup.okhttp', name: 'okhttp-urlconnection', version: '2.7.5'
 }
 ```
 
@@ -54,7 +54,7 @@ Maven with [optional `okhttp-urlconnection` dependency](#optional-okhttp-depende
 <dependency>
   <groupId>com.squareup.okhttp</groupId>
   <artifactId>okhttp-urlconnection</artifactId>
-  <version>2.5.0</version>
+  <version>2.7.5</version>
 </dependency>
 ~~~
 
@@ -63,7 +63,7 @@ Although Gradle or Maven dependency management is preferred it is also possible 
 * [Commons Codec 1.6](http://commons.apache.org/codec/download_codec.cgi)
 * [Commons IO 2.4](http://commons.apache.org/io/download_io.cgi)
 * [Gson 2.2.4](http://code.google.com/p/google-gson/downloads/list)
-* [OkHttp 2.5.0](http://square.github.io/okhttp/#download) (OPTIONAL) - [more info](#optional-okhttp-dependency)
+* [OkHttp 2.7.5](http://square.github.io/okhttp/#download) (OPTIONAL) - [more info](#optional-okhttp-dependency)
 
 ##### Optional OkHttp dependency
 

--- a/build.gradle
+++ b/build.gradle
@@ -24,12 +24,12 @@ dependencies {
     compile group: 'commons-io', name: 'commons-io', version: '2.4'
     compile group: 'commons-codec', name: 'commons-codec', version: '1.6'
     //needed to compile, but optional for consumers of java-cloudant
-    compile(group: 'com.squareup.okhttp', name: 'okhttp-urlconnection', version: '2.5.0') {
+    compile(group: 'com.squareup.okhttp', name: 'okhttp-urlconnection', version: '2.7.5') {
         ext.optional = true
     }
     //test dependencies
     testCompile group: 'junit', name: 'junit', version: '4.12'
-    testCompile group: 'com.squareup.okhttp', name: 'mockwebserver', version: '2.5.0'
+    testCompile group: 'com.squareup.okhttp', name: 'mockwebserver', version: '2.7.5'
 }
 
 //include variable debug info in the compiled classes

--- a/src/main/java/com/cloudant/http/internal/ok/OkHttpClientHttpUrlConnectionFactory.java
+++ b/src/main/java/com/cloudant/http/internal/ok/OkHttpClientHttpUrlConnectionFactory.java
@@ -15,12 +15,14 @@
 package com.cloudant.http.internal.ok;
 
 import com.cloudant.http.internal.DefaultHttpUrlConnectionFactory;
+import com.squareup.okhttp.ConnectionSpec;
 import com.squareup.okhttp.OkHttpClient;
 import com.squareup.okhttp.OkUrlFactory;
 
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.util.Arrays;
 
 /**
  * Provides HttpUrlConnections by using an OkHttpClient.
@@ -49,6 +51,14 @@ public class OkHttpClientHttpUrlConnectionFactory extends DefaultHttpUrlConnecti
 
     public OkHttpClientHttpUrlConnectionFactory() {
         client = new OkHttpClient();
+        client.setConnectionSpecs(Arrays.asList(
+                new ConnectionSpec[]{
+                        ConnectionSpec.CLEARTEXT, // for http
+                        new ConnectionSpec.Builder(ConnectionSpec.MODERN_TLS)
+                                .allEnabledTlsVersions()
+                                .allEnabledCipherSuites()
+                                .build() // for https
+                }));
         factory = new OkUrlFactory(client);
     }
 


### PR DESCRIPTION
## What

Fixes #215 to prevent `javax.net.ssl.SSLHandshakeException: Received fatal alert: handshake_failure` with okhttp and IBM Java.

## How

Changed the `ConnectionSpec` for okhttp to use the enabled protocols and cipher suites from the JVM rather than the default hardcoded list in okhttp's `MODERN_TLS` spec. This resolves the issue with the cipher suite prefixes not matching and also means that the enabled protocols and cipher suites match for both the okhttp and `HttpURLConnection` cases.
Upgraded okhttp to 2.7.5 to allow use of `allEnabled*` methods on `ConnectionSpec`.

## Testing
No additional tests, tested as working on IBM Java.

## Reviewers
reviewer @rhyshort
reviewer @tomblench 

## Issues
#215 
