### PR TITLE
Set the User-Agent via a Version object loaded at runtime

### DIFF
--- a/src/main/java/com/cloudant/http/Version.java
+++ b/src/main/java/com/cloudant/http/Version.java
@@ -1,0 +1,29 @@
+/*
+ *  Copyright (c) 2016 IBM Corp. All rights reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ *  except in compliance with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software distributed under the
+ *   License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ *  either express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+
+package com.cloudant.http;
+
+/**
+ * Interface to provide the Version string for the user agent
+ */
+public interface Version {
+
+
+    /**
+     *
+     * @return a version string for the user-agent e.g. java-cloudant/1.3.0 (Java 1.7 Windows 6.2 IBM)
+     */
+    String getUserAgentString();
+
+}

--- a/src/main/java/com/cloudant/library/Version.java
+++ b/src/main/java/com/cloudant/library/Version.java
@@ -1,18 +1,18 @@
 /*
- * Copyright (c) 2015 IBM Corp. All rights reserved.
+ *  Copyright (c) 2016 IBM Corp. All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
- * except in compliance with the License. You may obtain a copy of the License at
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ *  except in compliance with the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the
- * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
- * either express or implied. See the License for the specific language governing permissions
- * and limitations under the License.
+ *  Unless required by applicable law or agreed to in writing, software distributed under the
+ *   License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ *  either express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
  */
 
-package com.cloudant.http.internal;
+package com.cloudant.library;
 
 import com.cloudant.client.org.lightcouch.CouchDbClient;
 
@@ -21,12 +21,12 @@ import java.io.InputStream;
 import java.net.URL;
 import java.util.Properties;
 
-public class AgentHelper {
+/**
+ * Created by Rhys Short on 03/03/2016.
+ */
+public class Version implements com.cloudant.http.Version {
 
-    /**
-     * The {@code User-Agent} identifier for this client.
-     */
-    public static final String USER_AGENT;
+    private static final String USER_AGENT;
 
     //init the string, based on a properties file or fallback to some defaults
     static {
@@ -53,15 +53,19 @@ public class AgentHelper {
                 }
             }
         }
-        USER_AGENT = String.format("%s/%s [Java (%s; %s; %s) %s; %s; %s]",
+        USER_AGENT = String.format("%s/%s [Java %s; %s; %s (%s; %s; %s)]",
                 ua,
                 version,
-                System.getProperty("os.arch"),
-                System.getProperty("os.name"),
-                System.getProperty("os.version"),
                 System.getProperty("java.vendor"),
                 System.getProperty("java.version"),
-                System.getProperty("java.runtime.version"));
+                System.getProperty("java.runtime.version"),
+                System.getProperty("os.arch"),
+                System.getProperty("os.name"),
+                System.getProperty("os.version"));
     }
 
+    @Override
+    public String getUserAgentString() {
+        return this.USER_AGENT;
+    }
 }

--- a/src/test/java/com/cloudant/tests/CloudantClientTests.java
+++ b/src/test/java/com/cloudant/tests/CloudantClientTests.java
@@ -28,7 +28,7 @@ import com.cloudant.client.api.model.Membership;
 import com.cloudant.client.api.model.Task;
 import com.cloudant.client.org.lightcouch.CouchDbException;
 import com.cloudant.client.org.lightcouch.NoDocumentException;
-import com.cloudant.http.internal.AgentHelper;
+import com.cloudant.library.Version;
 import com.cloudant.test.main.RequiresCloudant;
 import com.cloudant.test.main.RequiresCloudantService;
 import com.cloudant.test.main.RequiresDB;
@@ -100,8 +100,8 @@ public class CloudantClientTests {
     }
 
     private final String userAgentRegex = "java-cloudant/[^\\s]+ " +
-            "\\[Java \\([^;]*;[^;]*;[^;]*\\) [^;]*;[^;]*;" +
-            "[^;]*\\]";
+            "\\[Java [^;]*;[^;]*;" +
+            "[^;]* \\([^;]*;[^;]*;[^;]*\\)\\]";
 
     /**
      * Assert that the User-Agent header is of the expected form.
@@ -109,8 +109,8 @@ public class CloudantClientTests {
     @Test
     public void testUserAgentHeaderString() {
         assertTrue("The value of the User-Agent header should match the format " +
-                "\"java-cloudant/version [Java (os.arch; os.name; os.version) jvm.vendor; jvm" +
-                ".version; jvm.runtime.version]\"", AgentHelper.USER_AGENT.matches
+                "\"java-cloudant/version [Java jvm.vendor; jvm" +
+                ".version; jvm.runtime.version (os.arch; os.name; os.version)]\"", new Version().getUserAgentString().matches
                 (userAgentRegex));
     }
 
@@ -139,9 +139,10 @@ public class CloudantClientTests {
                     userAgentHeader);
             assertTrue("The value of the User-Agent header value on the request should match the " +
                     "format " +
-                    "\"java-cloudant/version [Java (os.arch; os.name; os.version) jvm" +
+                    "\"java-cloudant/version [Java jvm" +
                     ".vendor; jvm" +
-                    ".version; jvm.runtime.version]\"", userAgentHeader.matches(userAgentRegex));
+                    ".version; jvm.runtime.version (os.arch; os.name; os.version)]\"",
+                    userAgentHeader.matches(userAgentRegex));
         } finally {
             server.shutdown();
         }


### PR DESCRIPTION
## What

Change how the user-agent is generated for HTTP requests in preparation for the splitting out the HTTP classes as a separate jar.

## How

- Created a new Interface `Version` which contains a single method `getVersionString()` which returns the string to be used as the user-agent. 
- AgentHelper is renamed to Version in the new `com.cloudant.library` package.
- The HTTPConnection will load the class at Runtime and default to the JVM default user-agent if it fails.

## Testing

No new tests, only modified a test case to use the renamed class and interface method.

## Reviewers

reviewer @tomblench 
reviewer @ricellis 
