### PR TITLE
Update stored cookie when a Set-Cookie header is received

### DIFF
--- a/src/main/java/com/cloudant/http/interceptors/CookieInterceptor.java
+++ b/src/main/java/com/cloudant/http/interceptors/CookieInterceptor.java
@@ -97,6 +97,13 @@ public class CookieInterceptor implements HttpConnectionRequestInterceptor,
     public HttpConnectionInterceptorContext interceptResponse(HttpConnectionInterceptorContext
                                                                       context) {
         HttpURLConnection connection = context.connection.getConnection();
+
+        String cookieHeader = connection.getHeaderField("Set-Cookie");
+        if(cookieHeader != null){
+            cookie = this.extractCookieFromHeaderValue(cookieHeader);
+            return context;
+        }
+
         try {
             boolean renewCookie = false;
             int statusCode = connection.getResponseCode();
@@ -174,7 +181,7 @@ public class CookieInterceptor implements HttpConnectionRequestInterceptor,
             if (responseCode / 100 == 2) {
 
                 if (sessionHasStarted(connection.getInputStream())) {
-                    return cookieHeader.substring(0, cookieHeader.indexOf(";"));
+                    return this.extractCookieFromHeaderValue(cookieHeader);
                 } else {
                     return null;
                 }
@@ -224,5 +231,9 @@ public class CookieInterceptor implements HttpConnectionRequestInterceptor,
             //UTF-8 should be supported on all JVMs
             throw new RuntimeException(e);
         }
+    }
+
+    private String extractCookieFromHeaderValue(String cookieHeaderValue){
+        return cookieHeaderValue.substring(0, cookieHeaderValue.indexOf(";"));
     }
 }

--- a/src/test/java/com/cloudant/tests/HttpTest.java
+++ b/src/test/java/com/cloudant/tests/HttpTest.java
@@ -46,6 +46,7 @@ import java.net.ProtocolException;
 import java.net.URL;
 import java.net.URLDecoder;
 import java.nio.charset.Charset;
+import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Pattern;
@@ -403,6 +404,50 @@ public class HttpTest {
         assertEquals("The server should have received 4 requests", 4, mockWebServer
                 .getRequestCount());
 
+    }
+
+    /**
+     * This test check that the cookie is renewed if the server presents a Set-Cookie header
+     * after the cookie authentication.
+     * @throws Exception
+     */
+    @Test
+    public void cookieRenewal() throws Exception {
+
+        final String renewalCookieValue =
+                "AuthSession=\"RenewCookie_a2ltc3RlYmVsOjUxMzRBQTUzOtiY2_IDUIdsTJEVNEjObAbyhrgz\";";
+        // Request sequence
+        // _session request to get Cookie
+        // GET request -> 403
+        // _session for new cookie
+        // GET replay -> 200
+        mockWebServer.enqueue(MockWebServerResource.OK_COOKIE);
+        mockWebServer.enqueue(new MockResponse().setResponseCode(200).addHeader("Set-Cookie",
+                String.format(Locale.ENGLISH, "%s;", renewalCookieValue))
+                .setBody("{\"hello\":\"world\"}\r\n"));
+        mockWebServer.enqueue(new MockResponse());
+
+        CloudantClient c = CloudantClientHelper.newMockWebServerClientBuilder(mockWebServer)
+                .username("a")
+                .password("b")
+                .build();
+
+
+        c.executeRequest(Http.GET(c.getBaseUri()));
+        c.executeRequest(Http.GET(c.getBaseUri()));
+
+
+        // also assert that there were 3 calls
+        assertEquals("The server should have received 3 requests", 3, mockWebServer
+                .getRequestCount());
+
+        mockWebServer.takeRequest(); // cookie
+        mockWebServer.takeRequest(); // actual get
+
+        // this is the request that should have the new cookie.
+        RecordedRequest request = mockWebServer.takeRequest();
+        String headerValue = request.getHeader("Cookie");
+        Assert.assertEquals("AuthSession=\"RenewCookie_a2ltc3RlYmVsOjUxMzRBQTUzOtiY2_IDUIdsTJEVNEjObAbyhrgz\"", headerValue);
     }
 
     /**


### PR DESCRIPTION
## What

Update stored cookie when a Set-Cookie header is received.

## How
Check for the `Set-Cookie` HTTP header, and if its present extract the cookie form its value and replace
the one in memory with the newly issued cookie. Although we already do this for the expiry case it is possible for the server to send a renewed cookie before expiry, so by handling those cases we can avoid the extra round trips of the "expired cookie failed request"/"get new cookie"/"repeat failed request" cycle.

## Testing

Added an extra test to simulate a `Set-Cookie` header being sent to the client.

## Reviewers
@ricellis

## Issues

- #195 
