### PR TITLE
Http cxn close

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@
   `Expect:100-continue` header on requests.
 - [FIX] Fix issue where design documents would not be updated if only the
   `indexes` field was updated.
+- [FIX] Issue where connections could leak because streams were not closed.
 - [DEPRECATED] The `InputStream` setters `HttpConnection.setRequestBody(InputStream)` and
   `HttpConnection.setRequestBody(InputStream, long)`. Use of the new `InputStreamGenerator` is
   preferred because it allows for request replays.

--- a/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/CouchDbClient.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/CouchDbClient.java
@@ -328,7 +328,11 @@ public class CouchDbClient {
     public <T> T get(URI uri, Class<T> classType) {
         HttpConnection connection = Http.GET(uri);
         InputStream response = executeToInputStream(connection);
-        return getResponse(response, classType, getGson());
+        try {
+            return getResponse(response, classType, getGson());
+        } finally {
+            close(response);
+        }
     }
 
     /**

--- a/cloudant-client/src/main/java/com/cloudant/library/LibraryVersion.java
+++ b/cloudant-client/src/main/java/com/cloudant/library/LibraryVersion.java
@@ -15,6 +15,7 @@
 package com.cloudant.library;
 
 import com.cloudant.client.org.lightcouch.CouchDbClient;
+import com.cloudant.http.Version;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -24,7 +25,7 @@ import java.util.Properties;
 /**
  * Created by Rhys Short on 03/03/2016.
  */
-public class Version implements com.cloudant.http.Version {
+public class LibraryVersion implements Version {
 
     private static final String USER_AGENT;
 

--- a/cloudant-client/src/test/java/com/cloudant/tests/CloudantClientTests.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/CloudantClientTests.java
@@ -29,7 +29,7 @@ import com.cloudant.client.api.model.Task;
 import com.cloudant.client.org.lightcouch.CouchDbException;
 import com.cloudant.client.org.lightcouch.NoDocumentException;
 import com.cloudant.http.interceptors.BasicAuthInterceptor;
-import com.cloudant.library.Version;
+import com.cloudant.library.LibraryVersion;
 import com.cloudant.test.main.RequiresCloudant;
 import com.cloudant.test.main.RequiresCloudantService;
 import com.cloudant.test.main.RequiresDB;
@@ -112,7 +112,7 @@ public class CloudantClientTests {
     public void testUserAgentHeaderString() {
         assertTrue("The value of the User-Agent header should match the format " +
                 "\"java-cloudant/version [Java jvm.vendor; jvm" +
-                ".version; jvm.runtime.version (os.arch; os.name; os.version)]\"", new Version().getUserAgentString().matches
+                ".version; jvm.runtime.version (os.arch; os.name; os.version)]\"", new LibraryVersion().getUserAgentString().matches
                 (userAgentRegex));
     }
 

--- a/cloudant-http/src/main/java/com/cloudant/http/HttpConnection.java
+++ b/cloudant-http/src/main/java/com/cloudant/http/HttpConnection.java
@@ -274,18 +274,15 @@ public class HttpConnection {
                     connection.setChunkedStreamingMode(1024);
                 }
 
-                int bufSize = 1024;
-                int nRead = 0;
-                byte[] buf = new byte[bufSize];
                 InputStream is = input.getInputStream();
                 OutputStream os = connection.getOutputStream();
-
-                while ((nRead = is.read(buf)) >= 0) {
-                    os.write(buf, 0, nRead);
+                try {
+                    IOUtils.copy(is, os);
+                    os.flush();
+                } finally {
+                    IOUtils.closeQuietly(is);
+                    IOUtils.closeQuietly(os);
                 }
-                os.flush();
-                // we do not call os.close() - on some JVMs this incurs a delay of several seconds
-                // see http://stackoverflow.com/questions/19860436
             }
 
             for (HttpConnectionResponseInterceptor responseInterceptor : responseInterceptors) {

--- a/cloudant-http/src/main/java/com/cloudant/http/HttpConnection.java
+++ b/cloudant-http/src/main/java/com/cloudant/http/HttpConnection.java
@@ -25,6 +25,7 @@ import java.net.URL;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -73,8 +74,8 @@ public class HttpConnection {
     static {
         String ua = "java-cloudant-http/unknown";
         try {
-            Class clazz = Class.forName("com.cloudant.library.Version");
-            com.cloudant.http.Version version = (com.cloudant.http.Version) clazz.newInstance();
+            Class clazz = Class.forName("com.cloudant.library.LibraryVersion");
+            Version version = (Version) clazz.newInstance();
             ua = version.getUserAgentString();
         } catch (Exception e) {
             logger.log(Level.WARNING, "Could not determine version string using default" +
@@ -259,8 +260,8 @@ public class HttpConnection {
 
             //set request properties after interceptors, in case the interceptors have added
             // to the properties map
-            for (String key : requestProperties.keySet()) {
-                connection.setRequestProperty(key, requestProperties.get(key));
+            for (Map.Entry<String, String> property : requestProperties.entrySet()) {
+                connection.setRequestProperty(property.getKey(), property.getValue());
             }
 
             if (input != null) {


### PR DESCRIPTION
## What
Some small improvements identified by leaking connections investigation and findbugs.

## How
Ensured stream closed after typed get calls in `CouchDbClient`.
Closed both input and output streams after writing request bodies in `HttpConnection`.
Used more efficient `entrySet` loop when setting request properties in `HttpConnection`.
Renamed `com.cloudant.library.Version` to `com.cloudant.library.LibraryVersion` to avoid potential name clash.

## Testing
No new tests added, existing tests already exercise these paths.

## Reviewers
@rhyshort 
@tomblench 

