### PR TITLE
Findbugs low reporting and fixes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,8 @@
   `Expect:100-continue` header on requests.
 - [FIX] Fix issue where design documents would not be updated if only the
   `indexes` field was updated.
+- [FIX] The `equals` and `hashcode` methods for `Document` and `ReplicatorDocument` failed to compare
+  revision identifier and some other fields.
 - [FIX] Issue where connections could leak because streams were not closed.
 - [DEPRECATED] The `InputStream` setters `HttpConnection.setRequestBody(InputStream)` and
   `HttpConnection.setRequestBody(InputStream, long)`. Use of the new `InputStreamGenerator` is

--- a/build.gradle
+++ b/build.gradle
@@ -177,7 +177,7 @@ subprojects {
     findbugs {
         toolVersion = "3.0.1"
         //report only high severity bugs for now
-        reportLevel = "high"
+        reportLevel = "low"
         //the code base is pretty small so use max effort
         effort = "max"
         //we don't want to run findbugs on the test code yet

--- a/cloudant-client/findbugs_excludes.xml
+++ b/cloudant-client/findbugs_excludes.xml
@@ -16,6 +16,7 @@ A list of known findbugs issues that we cannot fix at this time.
 For example because it requires an API change
 -->
 <FindBugsFilter>
+    
     <!-- This bug is because com.cloudant.client.api.model.Document extends
      com.cloudant.org.lightcouch.Document. Eventually we may roll them into one class and then this
      exclude can be removed.
@@ -24,6 +25,7 @@ For example because it requires an API change
         <Bug code="Nm" pattern="NM_SAME_SIMPLE_NAME_AS_SUPERCLASS"/>
         <Class name="com.cloudant.client.api.model.Document"/>
     </Match>
+    
     <!-- This bug is because addAttachment in com.cloudant.client.api.model.Document does not
      override the addAttachment in com.cloudant.org.lightcouch.Document. This is because of the two
      different Attachment classes. This leads to the confusing situation where there are two
@@ -36,4 +38,61 @@ For example because it requires an API change
         <Class name="com.cloudant.client.api.model.Document"/>
         <Method name="addAttachment"/>
     </Match>
+
+    <!-- Some private fields are flagged as never being written to. This fails to take into account
+    the GSON deserialization which reflectively sets the fields, so these findbugs can be ignored.
+    -->
+    <Match>
+        <Bug code="UwF" pattern="UWF_UNWRITTEN_FIELD"/>
+        <Class name="com.cloudant.client.org.lightcouch.Attachment"/>
+    </Match>
+    <Match>
+        <Bug code="UwF" pattern="UWF_UNWRITTEN_FIELD"/>
+        <Class name="com.cloudant.client.org.lightcouch.ChangesResult$Row$Rev"/>
+    </Match>
+
+
+    <!-- Returning null instead of a zero length array has special meaning in these cases.
+     Firstly, null indicates that no keys have been added to the query so we should not write a
+      parameter at all, whereas the empty array would otherwise get written to the request.
+     The remaining three cases are all also cases where a null means don't specify a parameter, but
+      the empty array means the empty set.
+    -->
+    <Match>
+        <Bug code="PZLA" pattern="PZLA_PREFER_ZERO_LENGTH_ARRAYS"/>
+        <Class name="com.cloudant.client.internal.views.ViewQueryParameters"/>
+        <Method name="getKeys"/>
+    </Match>
+    <Match>
+        <Bug code="PZLA" pattern="PZLA_PREFER_ZERO_LENGTH_ARRAYS"/>
+        <Class name="com.cloudant.client.api.model.SearchResult$SearchResultRow"/>
+        <Method name="getOrder"/>
+    </Match>
+    <Match>
+        <Bug code="PZLA" pattern="PZLA_PREFER_ZERO_LENGTH_ARRAYS"/>
+        <Class name="com.cloudant.client.org.lightcouch.ReplicatorDocument"/>
+        <Method name="getDocIds"/>
+    </Match>
+    <Match>
+        <Bug code="PZLA" pattern="PZLA_PREFER_ZERO_LENGTH_ARRAYS"/>
+        <Class name="com.cloudant.client.org.lightcouch.ReplicatorDocument$UserCtx"/>
+        <Method name="getRoles"/>
+    </Match>
+
+    <!-- It is true that a null check is redundant here, but we should keep it for consistency in
+    case the underlying FindByIndexOptions changes -->
+    <Match>
+        <Bug code="RCN" pattern="RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE"/>
+        <Class name="com.cloudant.client.api.Database"/>
+        <Method name="getFindByIndexBody"/>
+    </Match>
+
+    <!-- We catch Exception in where it isn't explicitly thrown. We should probably
+    catch a more specific type, but ignore it for now. -->
+    <Match>
+        <Bug code="REC" pattern="REC_CATCH_EXCEPTION"/>
+        <Class name="com.cloudant.client.org.lightcouch.Changes"/>
+        <Method name="readNextRow"/>
+    </Match>
+
 </FindBugsFilter>

--- a/cloudant-client/src/main/java/com/cloudant/client/api/ClientBuilder.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/ClientBuilder.java
@@ -1,9 +1,7 @@
 package com.cloudant.client.api;
 
-import com.cloudant.client.api.model.Index;
-import com.cloudant.client.api.model.Permissions;
-import com.cloudant.client.api.model.Shard;
 import com.cloudant.client.api.views.Key;
+import com.cloudant.client.internal.util.DeserializationTypes;
 import com.cloudant.client.internal.util.IndexDeserializer;
 import com.cloudant.client.internal.util.SecurityDeserializer;
 import com.cloudant.client.internal.util.ShardDeserializer;
@@ -17,14 +15,11 @@ import com.cloudant.http.interceptors.ProxyAuthInterceptor;
 import com.cloudant.http.interceptors.SSLCustomizerInterceptor;
 import com.cloudant.http.interceptors.TimeoutCustomizationInterceptor;
 import com.google.gson.GsonBuilder;
-import com.google.gson.reflect.TypeToken;
 
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
-import java.util.EnumSet;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import javax.net.ssl.SSLSocketFactory;
@@ -259,13 +254,9 @@ public class ClientBuilder {
         }
         //always register additional TypeAdapaters for derserializing some Cloudant specific
         // types before constructing the CloudantClient
-        gsonBuilder.registerTypeAdapter(new TypeToken<List<Shard>>() {
-        }.getType(), new ShardDeserializer())
-                .registerTypeAdapter(new TypeToken<List<Index>>() {
-                }.getType(), new IndexDeserializer())
-                .registerTypeAdapter(new TypeToken<Map<String, EnumSet<Permissions>>>() {
-                        }.getType(),
-                        new SecurityDeserializer())
+        gsonBuilder.registerTypeAdapter(DeserializationTypes.SHARDS, new ShardDeserializer())
+                .registerTypeAdapter(DeserializationTypes.INDICES, new IndexDeserializer())
+                .registerTypeAdapter(DeserializationTypes.PERMISSIONS_MAP, new SecurityDeserializer())
                 .registerTypeAdapter(Key.ComplexKey.class, new Key.ComplexKeyDeserializer());
 
         return new CloudantClient(props, gsonBuilder);

--- a/cloudant-client/src/main/java/com/cloudant/client/api/CloudantClient.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/CloudantClient.java
@@ -23,6 +23,7 @@ import com.cloudant.client.api.model.IndexField;
 import com.cloudant.client.api.model.Membership;
 import com.cloudant.client.api.model.Task;
 import com.cloudant.client.internal.URIBase;
+import com.cloudant.client.internal.util.DeserializationTypes;
 import com.cloudant.client.org.lightcouch.Changes;
 import com.cloudant.client.org.lightcouch.CouchDbClient;
 import com.cloudant.client.org.lightcouch.CouchDbException;
@@ -32,7 +33,6 @@ import com.cloudant.client.org.lightcouch.Replicator;
 import com.cloudant.http.HttpConnection;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import com.google.gson.reflect.TypeToken;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -179,9 +179,7 @@ public class CloudantClient {
         URI uri = new URIBase(getBaseUri()).path("_active_tasks").build();
         try {
             response = couchDbClient.get(uri);
-            return getResponseList(response, couchDbClient.getGson(),
-                    new TypeToken<List<Task>>() {
-                    }.getType());
+            return getResponseList(response, couchDbClient.getGson(), DeserializationTypes.TASKS);
         } finally {
             close(response);
         }

--- a/cloudant-client/src/main/java/com/cloudant/client/api/Search.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/Search.java
@@ -14,7 +14,7 @@
 
 package com.cloudant.client.api;
 
-import static com.cloudant.client.org.lightcouch.internal.CouchDbUtil.JsonToObject;
+import static com.cloudant.client.org.lightcouch.internal.CouchDbUtil.jsonToObject;
 import static com.cloudant.client.org.lightcouch.internal.CouchDbUtil.assertNotEmpty;
 import static com.cloudant.client.org.lightcouch.internal.CouchDbUtil.close;
 import static com.cloudant.client.org.lightcouch.internal.CouchDbUtil.getAsLong;
@@ -146,7 +146,7 @@ public class Search {
                             "null object will be returned");
                 }
                 for (JsonElement e : json.getAsJsonArray("rows")) {
-                    result.add(JsonToObject(client.getGson(), e, "doc", classOfT));
+                    result.add(jsonToObject(client.getGson(), e, "doc", classOfT));
                 }
             } else {
                 log.warning("No ungrouped result available. Use queryGroups() if grouping set");
@@ -186,7 +186,7 @@ public class Search {
                                 "null object will be returned");
                     }
                     for (JsonElement rows : e.getAsJsonObject().getAsJsonArray("rows")) {
-                        orows.add(JsonToObject(client.getGson(), rows, "doc", classOfT));
+                        orows.add(jsonToObject(client.getGson(), rows, "doc", classOfT));
                     }
                     result.put(groupName, orows);
                 }// end for(groups)
@@ -432,10 +432,10 @@ public class Search {
             SearchResult<T>.SearchResultRow row = sr.new SearchResultRow();
             JsonObject oe = e.getAsJsonObject();
             row.setId(oe.get("id").getAsString());
-            row.setOrder(JsonToObject(client.getGson(), e, "order", Object[].class));
-            row.setFields(JsonToObject(client.getGson(), e, "fields", classOfT));
+            row.setOrder(jsonToObject(client.getGson(), e, "order", Object[].class));
+            row.setFields(jsonToObject(client.getGson(), e, "fields", classOfT));
             if (includeDocs) {
-                row.setDoc(JsonToObject(client.getGson(), e, "doc", classOfT));
+                row.setDoc(jsonToObject(client.getGson(), e, "doc", classOfT));
             }
             ret.add(row);
         }

--- a/cloudant-client/src/main/java/com/cloudant/client/api/model/Index.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/model/Index.java
@@ -65,13 +65,15 @@ public class Index {
     }
 
     public String toString() {
-        String index = "ddoc: " + ddoc + ", name: " + name + ", type: " + type + ", fields: [";
+        StringBuilder index = new StringBuilder("ddoc: " + ddoc + ", name: " + name + ", type: "
+                + type + ", fields: [");
         Iterator<IndexField> flds = getFields();
         while (flds.hasNext()) {
-            index += flds.next().toString() + ",";
+            index.append(flds.next().toString());
+            index.append(",");
         }
-        index += "]";
-        return index;
+        index.append("]");
+        return index.toString();
     }
 
 

--- a/cloudant-client/src/main/java/com/cloudant/client/api/model/Membership.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/model/Membership.java
@@ -43,15 +43,16 @@ public class Membership {
     }
 
     public String toString() {
-        String ret = "all_nodes: ";
+        StringBuilder ret = new StringBuilder("all_nodes: ");
         for (String s : all_nodes) {
-            ret += s + ",";
+            ret.append(s + ",");
         }
-        ret += " cluster_nodes: ";
+        ret.append(" cluster_nodes: ");
         for (String s : cluster_nodes) {
-            ret += s + ",";
+            ret.append(s);
+            ret.append(",");
         }
-        return ret;
+        return ret.toString();
     }
 
     Membership() {

--- a/cloudant-client/src/main/java/com/cloudant/client/api/model/Params.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/model/Params.java
@@ -35,7 +35,7 @@ public class Params {
     private com.cloudant.client.org.lightcouch.Params params = new com.cloudant.client.org.lightcouch.Params();
 
     public Params readQuorum(int quorum) {
-        params.addParam("r", new Integer(quorum).toString());
+        params.addParam("r", Integer.toString(quorum));
         return this;
     }
 

--- a/cloudant-client/src/main/java/com/cloudant/client/api/model/ReplicatorDocument.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/model/ReplicatorDocument.java
@@ -14,13 +14,11 @@
 
 package com.cloudant.client.api.model;
 
-import com.google.gson.JsonObject;
-
 import com.cloudant.client.org.lightcouch.Attachment;
 import com.cloudant.client.org.lightcouch.Replicator;
+import com.google.gson.JsonObject;
 
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Map;
 
 /**
@@ -54,14 +52,9 @@ public class ReplicatorDocument {
         Map<String, Attachment> couchDbAttachments = replicatorDocument.getAttachments();
         Map<String, com.cloudant.client.api.model.Attachment> attachments = new HashMap<String,
                 com.cloudant.client.api.model.Attachment>();
-        Iterator<String> iterator = couchDbAttachments.keySet().iterator();
-        while (iterator.hasNext()) {
-            String key = (String) iterator.next();
-            Attachment couchDbAttachment = couchDbAttachments.get(key);
-            com.cloudant.client.api.model.Attachment attachment = new com.cloudant.client.api
-                    .model.Attachment(couchDbAttachment);
-            attachments.put(key, attachment);
-
+        for (Map.Entry<String, Attachment> attachment : couchDbAttachments.entrySet()) {
+            attachments.put(attachment.getKey(), new com.cloudant.client.api
+                    .model.Attachment(attachment.getValue()));
         }
         return attachments;
     }
@@ -76,12 +69,10 @@ public class ReplicatorDocument {
 
     public void setAttachments(Map<String, com.cloudant.client.api.model.Attachment> attachments) {
         Map<String, Attachment> lightCouchAttachments = new HashMap<String, Attachment>();
-        Iterator<String> iterator = attachments.keySet().iterator();
-        while (iterator.hasNext()) {
-            String key = (String) iterator.next();
-            com.cloudant.client.api.model.Attachment attachment = attachments.get(key);
-            Attachment lightCouchAttachment = attachment.getAttachement();
-            lightCouchAttachments.put(key, lightCouchAttachment);
+
+        for (Map.Entry<String, com.cloudant.client.api.model.Attachment> attachment : attachments
+                .entrySet()) {
+            lightCouchAttachments.put(attachment.getKey(), attachment.getValue().getAttachement());
         }
         replicatorDocument.setAttachments(lightCouchAttachments);
     }
@@ -237,11 +228,11 @@ public class ReplicatorDocument {
     }
 
 
-    public class UserCtx {
+    public static class UserCtx {
         private com.cloudant.client.org.lightcouch.ReplicatorDocument.UserCtx userCtx;
 
         public UserCtx() {
-            this.userCtx = replicatorDocument.new UserCtx();
+            this.userCtx = new com.cloudant.client.org.lightcouch.ReplicatorDocument.UserCtx();
         }
 
         UserCtx(com.cloudant.client.org.lightcouch.ReplicatorDocument.UserCtx userCtx) {

--- a/cloudant-client/src/main/java/com/cloudant/client/api/model/SearchResult.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/model/SearchResult.java
@@ -17,6 +17,7 @@ package com.cloudant.client.api.model;
 import com.google.gson.annotations.SerializedName;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -142,7 +143,7 @@ public class SearchResult<T> {
          * @param order the order to set
          */
         public void setOrder(Object[] order) {
-            this.order = order;
+            this.order = Arrays.copyOf(order, order.length);
         }
 
         /**
@@ -170,7 +171,7 @@ public class SearchResult<T> {
          * @return the order (each element can be a String/Number)
          */
         public Object[] getOrder() {
-            return order;
+            return (order != null) ? Arrays.copyOf(order, order.length) : null;
         }
 
         /**

--- a/cloudant-client/src/main/java/com/cloudant/client/internal/util/DeserializationTypes.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/internal/util/DeserializationTypes.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2016 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.client.internal.util;
+
+import com.cloudant.client.api.model.Index;
+import com.cloudant.client.api.model.Permissions;
+import com.cloudant.client.api.model.Shard;
+import com.cloudant.client.api.model.Task;
+import com.cloudant.client.org.lightcouch.Response;
+import com.google.gson.reflect.TypeToken;
+
+import java.lang.reflect.Type;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
+
+public class DeserializationTypes {
+
+    public static final Type SHARDS = new TypeToken<List<Shard>>() {
+    }.getType();
+
+    public static final Type INDICES = new TypeToken<List<Index>>() {
+    }.getType();
+
+    public static final TypeToken<Map<String, EnumSet<Permissions>>> PERMISSIONS_MAP_TOKEN = new
+            TypeToken<Map<String, EnumSet<Permissions>>>
+                    () {
+            };
+    public static final Type PERMISSIONS_MAP = PERMISSIONS_MAP_TOKEN.getType();
+
+    public static final Type PERMISSIONS = new TypeToken<EnumSet<Permissions>>() {
+    }.getType();
+
+    public static final Type TASKS = new TypeToken<List<Task>>() {
+    }.getType();
+
+    public static final Type STRINGS = new TypeToken<List<String>>() {
+    }.getType();
+
+    public static final Type LC_RESPONSES = new TypeToken<List<Response>>() {
+    }.getType();
+}

--- a/cloudant-client/src/main/java/com/cloudant/client/internal/util/SecurityDeserializer.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/internal/util/SecurityDeserializer.java
@@ -19,7 +19,6 @@ import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParseException;
-import com.google.gson.reflect.TypeToken;
 
 import java.lang.reflect.Type;
 import java.util.EnumSet;
@@ -42,9 +41,8 @@ public class SecurityDeserializer implements JsonDeserializer<Map<String, EnumSe
         Set<Map.Entry<String, JsonElement>> permList = elem.getAsJsonObject().entrySet();
         for (Map.Entry<String, JsonElement> entry : permList) {
             String user = entry.getKey();
-            EnumSet<Permissions> p = context.deserialize(entry.getValue(), new
-                    TypeToken<EnumSet<Permissions>>() {
-                    }.getType());
+            EnumSet<Permissions> p = context.deserialize(entry.getValue(), DeserializationTypes
+                    .PERMISSIONS);
             perms.put(user, p);
         }
         return perms;

--- a/cloudant-client/src/main/java/com/cloudant/client/internal/util/ShardDeserializer.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/internal/util/ShardDeserializer.java
@@ -20,7 +20,6 @@ import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
-import com.google.gson.reflect.TypeToken;
 
 import java.lang.reflect.Type;
 import java.util.ArrayList;
@@ -42,9 +41,8 @@ public class ShardDeserializer implements JsonDeserializer<List<Shard>> {
 
         for (Map.Entry<String, JsonElement> entry : shardsObj) {
             String range = entry.getKey();
-            List<String> nodeNames = context.deserialize(entry.getValue(), new
-                    TypeToken<List<String>>() {
-                    }.getType());
+            List<String> nodeNames = context.deserialize(entry.getValue(), DeserializationTypes
+                    .STRINGS);
             shards.add(new Shard(range, nodeNames));
         }
 

--- a/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/Changes.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/Changes.java
@@ -175,7 +175,7 @@ public class Changes {
             if (!stop) {
                 while (true) {
                     String row = getReader().readLine();
-                    if (row.isEmpty()) {
+                    if (row != null && row.isEmpty()) {
                         continue;
                     }
                     if (row != null && !row.startsWith("{\"last_seq\":")) {

--- a/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/CouchDatabaseBase.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/CouchDatabaseBase.java
@@ -25,11 +25,11 @@ import static com.cloudant.client.org.lightcouch.internal.CouchDbUtil.getRespons
 import static com.cloudant.client.org.lightcouch.internal.CouchDbUtil.streamToString;
 
 import com.cloudant.client.internal.DatabaseURIHelper;
+import com.cloudant.client.internal.util.DeserializationTypes;
 import com.cloudant.http.Http;
 import com.cloudant.http.HttpConnection;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
-import com.google.gson.reflect.TypeToken;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -287,8 +287,7 @@ public abstract class CouchDatabaseBase {
             couchDbClient.execute(connection);
             responseStream = connection.responseAsInputStream();
             List<Response> bulkResponses = getResponseList(responseStream, getGson(),
-                    new TypeToken<List<Response>>() {
-                    }.getType());
+                    DeserializationTypes.LC_RESPONSES);
             for(Response response : bulkResponses) {
                 response.setStatusCode(connection.getConnection().getResponseCode());
                 response.setReason(connection.getConnection().getResponseMessage());

--- a/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/Document.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/Document.java
@@ -74,32 +74,32 @@ public class Document {
     }
 
     @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + ((id == null) ? 0 : id.hashCode());
-        return result;
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        Document document = (Document) o;
+
+        if (id != null ? !id.equals(document.id) : document.id != null) {
+            return false;
+        }
+        if (revision != null ? !revision.equals(document.revision) : document.revision != null) {
+            return false;
+        }
+        return !(attachments != null ? !attachments.equals(document.attachments) : document
+                .attachments != null);
+
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (this == obj) {
-            return true;
-        }
-        if (obj == null) {
-            return false;
-        }
-        if (getClass() != obj.getClass()) {
-            return false;
-        }
-        Document other = (Document) obj;
-        if (id == null) {
-            if (other.id != null) {
-                return false;
-            }
-        } else if (!id.equals(other.id)) {
-            return false;
-        }
-        return true;
+    public int hashCode() {
+        int result = id != null ? id.hashCode() : 0;
+        result = 31 * result + (revision != null ? revision.hashCode() : 0);
+        result = 31 * result + (attachments != null ? attachments.hashCode() : 0);
+        return result;
     }
 }

--- a/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/Replicator.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/Replicator.java
@@ -113,7 +113,7 @@ public class Replicator {
         assertNotEmpty(replicatorDoc.getSource(), "Source");
         assertNotEmpty(replicatorDoc.getTarget(), "Target");
         if (userCtxName != null) {
-            UserCtx ctx = replicatorDoc.new UserCtx();
+            UserCtx ctx = new ReplicatorDocument.UserCtx();
             ctx.setName(userCtxName);
             ctx.setRoles(userCtxRoles);
             replicatorDoc.setUserCtx(ctx);

--- a/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/ReplicatorDocument.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/ReplicatorDocument.java
@@ -20,6 +20,8 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
 import com.google.gson.annotations.SerializedName;
 
+import java.util.Arrays;
+
 /**
  * Represents a replication document in the <tt>_replicator</tt> database.
  *
@@ -98,7 +100,7 @@ public class ReplicatorDocument extends Document {
     }
 
     public String[] getDocIds() {
-        return docIds;
+        return (docIds != null) ? Arrays.copyOf(docIds, docIds.length) : null;
     }
 
     public String getProxy() {
@@ -166,7 +168,7 @@ public class ReplicatorDocument extends Document {
     }
 
     public void setDocIds(String[] docIds) {
-        this.docIds = docIds;
+        this.docIds = Arrays.copyOf(docIds, docIds.length);
     }
 
     public void setProxy(String proxy) {
@@ -221,7 +223,7 @@ public class ReplicatorDocument extends Document {
         this.sinceSeq = sinceSeq;
     }
 
-    public class UserCtx {
+    public static class UserCtx {
         private String name;
         private String[] roles;
 
@@ -230,7 +232,7 @@ public class ReplicatorDocument extends Document {
         }
 
         public String[] getRoles() {
-            return roles;
+            return (roles != null) ? Arrays.copyOf(roles, roles.length) : null;
         }
 
         public void setName(String name) {
@@ -238,7 +240,110 @@ public class ReplicatorDocument extends Document {
         }
 
         public void setRoles(String[] roles) {
-            this.roles = roles;
+            this.roles = Arrays.copyOf(roles, roles.length);
         }
     } // /class UserCtx
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+
+        ReplicatorDocument that = (ReplicatorDocument) o;
+
+        if (source != null ? !source.equals(that.source) : that.source != null) {
+            return false;
+        }
+        if (target != null ? !target.equals(that.target) : that.target != null) {
+            return false;
+        }
+        if (continuous != null ? !continuous.equals(that.continuous) : that.continuous != null) {
+            return false;
+        }
+        if (filter != null ? !filter.equals(that.filter) : that.filter != null) {
+            return false;
+        }
+        if (queryParams != null ? !queryParams.equals(that.queryParams) : that.queryParams !=
+                null) {
+            return false;
+        }
+        if (!Arrays.equals(docIds, that.docIds)) {
+            return false;
+        }
+        if (proxy != null ? !proxy.equals(that.proxy) : that.proxy != null) {
+            return false;
+        }
+        if (createTarget != null ? !createTarget.equals(that.createTarget) : that.createTarget !=
+                null) {
+            return false;
+        }
+        if (replicationId != null ? !replicationId.equals(that.replicationId) : that
+                .replicationId != null) {
+            return false;
+        }
+        if (replicationState != null ? !replicationState.equals(that.replicationState) : that
+                .replicationState != null) {
+            return false;
+        }
+        if (replicationStateTime != null ? !replicationStateTime.equals(that
+                .replicationStateTime) : that.replicationStateTime != null) {
+            return false;
+        }
+        if (workerProcesses != null ? !workerProcesses.equals(that.workerProcesses) : that
+                .workerProcesses != null) {
+            return false;
+        }
+        if (workerBatchSize != null ? !workerBatchSize.equals(that.workerBatchSize) : that
+                .workerBatchSize != null) {
+            return false;
+        }
+        if (httpConnections != null ? !httpConnections.equals(that.httpConnections) : that
+                .httpConnections != null) {
+            return false;
+        }
+        if (connectionTimeout != null ? !connectionTimeout.equals(that.connectionTimeout) : that
+                .connectionTimeout != null) {
+            return false;
+        }
+        if (retriesPerRequest != null ? !retriesPerRequest.equals(that.retriesPerRequest) : that
+                .retriesPerRequest != null) {
+            return false;
+        }
+        if (userCtx != null ? !userCtx.equals(that.userCtx) : that.userCtx != null) {
+            return false;
+        }
+        return !(sinceSeq != null ? !sinceSeq.equals(that.sinceSeq) : that.sinceSeq != null);
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (source != null ? source.hashCode() : 0);
+        result = 31 * result + (target != null ? target.hashCode() : 0);
+        result = 31 * result + (continuous != null ? continuous.hashCode() : 0);
+        result = 31 * result + (filter != null ? filter.hashCode() : 0);
+        result = 31 * result + (queryParams != null ? queryParams.hashCode() : 0);
+        result = 31 * result + (docIds != null ? Arrays.hashCode(docIds) : 0);
+        result = 31 * result + (proxy != null ? proxy.hashCode() : 0);
+        result = 31 * result + (createTarget != null ? createTarget.hashCode() : 0);
+        result = 31 * result + (replicationId != null ? replicationId.hashCode() : 0);
+        result = 31 * result + (replicationState != null ? replicationState.hashCode() : 0);
+        result = 31 * result + (replicationStateTime != null ? replicationStateTime.hashCode() : 0);
+        result = 31 * result + (workerProcesses != null ? workerProcesses.hashCode() : 0);
+        result = 31 * result + (workerBatchSize != null ? workerBatchSize.hashCode() : 0);
+        result = 31 * result + (httpConnections != null ? httpConnections.hashCode() : 0);
+        result = 31 * result + (connectionTimeout != null ? connectionTimeout.hashCode() : 0);
+        result = 31 * result + (retriesPerRequest != null ? retriesPerRequest.hashCode() : 0);
+        result = 31 * result + (userCtx != null ? userCtx.hashCode() : 0);
+        result = 31 * result + (sinceSeq != null ? sinceSeq.hashCode() : 0);
+        return result;
+    }
 }

--- a/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/internal/CouchDbUtil.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/internal/CouchDbUtil.java
@@ -74,7 +74,7 @@ final public class CouchDbUtil {
 
     // JSON
 
-    public static <T> T JsonToObject(Gson gson, JsonElement elem, String key, Class<T> classType) {
+    public static <T> T jsonToObject(Gson gson, JsonElement elem, String key, Class<T> classType) {
         if(elem != null && !elem.isJsonNull()) {
             JsonElement keyElem = elem.getAsJsonObject().get(key);
             if(keyElem != null && !keyElem.isJsonNull()) {

--- a/cloudant-client/src/test/java/com/cloudant/tests/CouchDbUtilTest.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/CouchDbUtilTest.java
@@ -16,7 +16,7 @@ package com.cloudant.tests;
 
 
 import static org.junit.Assert.assertEquals;
-import static com.cloudant.client.org.lightcouch.internal.CouchDbUtil.JsonToObject;
+import static com.cloudant.client.org.lightcouch.internal.CouchDbUtil.jsonToObject;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
@@ -28,7 +28,7 @@ public class CouchDbUtilTest {
 
     /**
      * Assert that if doc's value in JSON object
-     * is null, the result from JsonToObject
+     * is null, the result from jsonToObject
      * will be null and no exception occurs.
      */
     @Test
@@ -38,7 +38,7 @@ public class CouchDbUtilTest {
         Gson gson = new Gson();
         JsonObject jsonFromSearchQuery = new JsonParser()
                 .parse(queryResult).getAsJsonObject();
-        JsonObject mockResult = JsonToObject(gson, jsonFromSearchQuery, "doc", JsonObject.class);
+        JsonObject mockResult = jsonToObject(gson, jsonFromSearchQuery, "doc", JsonObject.class);
 
         assertEquals(null, mockResult);
     }

--- a/cloudant-client/src/test/java/com/cloudant/tests/DesignDocumentsTest.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/DesignDocumentsTest.java
@@ -80,7 +80,9 @@ public class DesignDocumentsTest {
     @Test
     public void designDocCompare() throws Exception {
         DesignDocument designDoc1 = DesignDocumentManager.fromFile(designDocExample);
-        designManager.put(designDoc1);
+        Response response = designManager.put(designDoc1);
+        // Assign the revision to our local DesignDocument object (needed for equality)
+        designDoc1.setRevision(response.getRev());
 
         DesignDocument designDoc11 = db.getDesignDocumentManager().get("_design/example");
 

--- a/cloudant-client/src/test/java/com/cloudant/tests/ReplicateBaseTest.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/ReplicateBaseTest.java
@@ -14,9 +14,7 @@
 
 package com.cloudant.tests;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 import com.cloudant.client.api.CloudantClient;
 import com.cloudant.client.api.Database;
@@ -64,6 +62,8 @@ public class ReplicateBaseTest {
         ViewResponse<Key.ComplexKey, String> conflicts = db.getViewRequestBuilder
                 ("conflicts", "conflict").newRequest(Key.Type.COMPLEX, String.class).build()
                 .getResponse();
-        assertThat(conflicts.getRows().size(), is(not(0)));
+        int conflictCount = conflicts.getRows().size();
+        assertTrue("There should be at least 1 conflict, there were " + conflictCount,
+                conflictCount > 0);
     }
 }

--- a/cloudant-http/findbugs_excludes.xml
+++ b/cloudant-http/findbugs_excludes.xml
@@ -1,0 +1,38 @@
+<!--
+  ~ Copyright (c) 2016 IBM Corp. All rights reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+  ~ except in compliance with the License. You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software distributed under the
+  ~ License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+  ~ either express or implied. See the License for the specific language governing permissions
+  ~ and limitations under the License.
+  -->
+<!--
+A list of known findbugs issues that we cannot fix at this time.
+For example because it requires an API change
+-->
+<FindBugsFilter>
+
+    <!-- Returning null instead of a zero length array has special meaning in this case.
+    Firstly, null indicates that no keys have been added to the query so we should not write a
+      parameter at all, whereas the empty array would otherwise get written to the request.
+    -->
+    <Match>
+        <Bug code="PZLA" pattern="PZLA_PREFER_ZERO_LENGTH_ARRAYS"/>
+        <Class name="com.cloudant.http.interceptors.SSLCustomizerInterceptor$1"/>
+        <Method name="getAcceptedIssuers"/>
+    </Match>
+
+    <!-- We catch Exception where it isn't explicitly thrown. We should probably
+    catch a more specific type, but ignore it for now. -->
+    <Match>
+        <Bug code="REC" pattern="REC_CATCH_EXCEPTION"/>
+        <Class name="com.cloudant.http.internal.Base64OutputStreamFactory"/>
+        <Method name="get"/>
+    </Match>
+
+</FindBugsFilter>

--- a/cloudant-http/src/main/java/com/cloudant/http/internal/Base64OutputStreamFactory.java
+++ b/cloudant-http/src/main/java/com/cloudant/http/internal/Base64OutputStreamFactory.java
@@ -16,6 +16,7 @@ package com.cloudant.http.internal;
 
 import java.io.OutputStream;
 import java.lang.reflect.Constructor;
+import java.util.Locale;
 
 /**
  * Created by tomblench on 07/07/2014.
@@ -26,7 +27,7 @@ public class Base64OutputStreamFactory {
 
     static {
         String javaRuntime = System.getProperty("java.runtime.name", "");
-        runningOnAndroid = javaRuntime.toLowerCase().contains("android runtime");
+        runningOnAndroid = javaRuntime.toLowerCase(Locale.ENGLISH).contains("android runtime");
     }
 
     public static OutputStream get(OutputStream os) {


### PR DESCRIPTION
## What
Enabled the findbugs low level reporting and fixed or excluded existing medium/low issues.

## How
Renamed `JsonToObject` to `jsonToObject` to meet Java naming conventions 56d79ef.
Fixed potential NPE in `Changes` 76c504c.
Fixed inefficient boxing/toString of integers 91af7f4.
Fixed inefficient concatenation in some `toString` methods bac3fc9.
Fixed inefficient iterators where more efficient `Map.entrySet()`could be used b568c19.
Removed some anonymous inner classes in favour of statics 64d421d.
Removed dead local store from `shutdown()` 82251ec.
Fixed `toLowerCase()` calls that failed to specify a  `Locale` internationalisation issue 8ec2ce9.
Fixed `equals`/`hashcode` for `Document` and `ReplicatorDocument` 5303880.
Fixed risk of arrays being modified when used by reference 64d9f30.
Moved error stream `close` into finally block where it is known to be non-null 8432ae8.
Fixed missing `throw` from `setPermissions()` b04dc55.
Enabled "low" findbugs level and added excludes 	ebdc589.

## Testing
Fixed `designDocCompare` test to correctly set revision f03591e.
Improved assertion message in `assertConflictsNotZero` 884b2f4.
Existing tests pass against CouchDB and Cloudant service.

## Reviewers

reviewer: @alfinkel
reviewer @tomblench