### PR TITLE
Updated seq ids to use JSON

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 # Unreleased
 - [NEW] Documentation for logging in project javadoc `overview.html`.
 - [IMPROVED] Upgraded optional okhttp to 2.7.5.
+- [FIX] Issues with the changes feed, replication, or getting database info when using Cloudant Data
+  Layer Local Edition because sequence IDs were incorrectly always treated as strings not JSON.
 - [FIX] Issue of `javax.net.ssl.SSLHandshakeException: Received fatal alert: handshake_failure` on
   IBM Java with okhttp. SSL connections using okhttp are now configured to use the JVM enabled
    protocols and cipher suites in the same way as the `HttpURLConnection`.

--- a/cloudant-client/src/main/java/com/cloudant/client/api/model/DbInfo.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/model/DbInfo.java
@@ -15,6 +15,7 @@
 package com.cloudant.client.api.model;
 
 
+import com.google.gson.JsonElement;
 import com.google.gson.annotations.SerializedName;
 
 /**
@@ -30,7 +31,7 @@ public class DbInfo {
     @SerializedName("doc_del_count")
     private String docDelCount;
     @SerializedName("update_seq")
-    private String updateSeq;
+    private JsonElement updateSeq;
     @SerializedName("purge_seq")
     private long purgeSeq;
     @SerializedName("compact_running")
@@ -55,7 +56,7 @@ public class DbInfo {
     }
 
     public String getUpdateSeq() {
-        return updateSeq;
+        return updateSeq.toString();
     }
 
     public long getPurgeSeq() {

--- a/cloudant-client/src/main/java/com/cloudant/client/api/model/Task.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/model/Task.java
@@ -14,6 +14,8 @@
 
 package com.cloudant.client.api.model;
 
+import com.google.gson.JsonElement;
+
 import java.util.Date;
 
 /**
@@ -36,14 +38,14 @@ public class Task {
     private long doc_write_failures;
     private String doc_id;
     private boolean continuous;
-    private String checkpointed_source_seq;
+    private JsonElement checkpointed_source_seq;
     private long changes_pending;
     private long docs_written;
     private long missing_revisions_found;
     private String replication_id;
     private long revisions_checked;
     private String source;
-    private String source_seq;
+    private JsonElement source_seq;
 
 
     private long changes_done;
@@ -136,7 +138,7 @@ public class Task {
      * @return the checkpointed_source_seq
      */
     public String getCheckpointed_source_seq() {
-        return checkpointed_source_seq;
+        return checkpointed_source_seq.toString();
     }
 
     /**
@@ -185,7 +187,7 @@ public class Task {
      * @return the source_seq
      */
     public String getSource_seq() {
-        return source_seq;
+        return source_seq.toString();
     }
 
     /**

--- a/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/ChangesResult.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/ChangesResult.java
@@ -15,6 +15,7 @@
 
 package com.cloudant.client.org.lightcouch;
 
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.annotations.SerializedName;
 
@@ -30,28 +31,28 @@ import java.util.List;
 public class ChangesResult {
     private List<ChangesResult.Row> results;
     @SerializedName("last_seq")
-    private String lastSeq;
+    private JsonElement lastSeq;
 
     public List<ChangesResult.Row> getResults() {
         return results;
     }
 
     public String getLastSeq() {
-        return lastSeq;
+        return lastSeq.toString();
     }
 
     /**
      * Represent a row in Changes result.
      */
     public static class Row {
-        private String seq;
+        private JsonElement seq;
         private String id;
         private List<Row.Rev> changes;
         private boolean deleted;
         private JsonObject doc;
 
         public String getSeq() {
-            return seq;
+            return seq.toString();
         }
 
         public String getId() {

--- a/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/CouchDbInfo.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/CouchDbInfo.java
@@ -15,6 +15,7 @@
 
 package com.cloudant.client.org.lightcouch;
 
+import com.google.gson.JsonElement;
 import com.google.gson.annotations.SerializedName;
 
 /**
@@ -31,7 +32,7 @@ public class CouchDbInfo {
     @SerializedName("doc_del_count")
     private String docDelCount;
     @SerializedName("update_seq")
-    private String updateSeq;
+    private JsonElement updateSeq;
     @SerializedName("purge_seq")
     private long purgeSeq;
     @SerializedName("compact_running")
@@ -56,7 +57,7 @@ public class CouchDbInfo {
     }
 
     public String getUpdateSeq() {
-        return updateSeq;
+        return updateSeq.toString();
     }
 
     public long getPurgeSeq() {

--- a/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/ReplicationResult.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/ReplicationResult.java
@@ -15,6 +15,7 @@
 
 package com.cloudant.client.org.lightcouch;
 
+import com.google.gson.JsonElement;
 import com.google.gson.annotations.SerializedName;
 
 import java.util.List;
@@ -32,7 +33,7 @@ public class ReplicationResult {
     @SerializedName("session_id")
     private String sessionId;
     @SerializedName("source_last_seq")
-    private String sourceLastSeq;
+    private JsonElement sourceLastSeq;
     @SerializedName("_local_id")
     private String localId;
     @SerializedName("history")
@@ -47,7 +48,7 @@ public class ReplicationResult {
     }
 
     public String getSourceLastSeq() {
-        return sourceLastSeq;
+        return sourceLastSeq.toString();
     }
 
     public String getLocalId() {
@@ -71,11 +72,11 @@ public class ReplicationResult {
         @SerializedName("end_time")
         private String endTime;
         @SerializedName("start_last_seq")
-        private String startLastSeq;
+        private JsonElement startLastSeq;
         @SerializedName("end_last_seq")
-        private String endLastSeq;
+        private JsonElement endLastSeq;
         @SerializedName("recorded_seq")
-        private String recordedSeq;
+        private JsonElement recordedSeq;
         @SerializedName("missing_checked")
         private long missingChecked;
         @SerializedName("missing_found")
@@ -100,15 +101,15 @@ public class ReplicationResult {
         }
 
         public String getStartLastSeq() {
-            return startLastSeq;
+            return startLastSeq.toString();
         }
 
         public String getEndLastSeq() {
-            return endLastSeq;
+            return endLastSeq.toString();
         }
 
         public String getRecordedSeq() {
-            return recordedSeq;
+            return recordedSeq.toString();
         }
 
         public long getMissingChecked() {


### PR DESCRIPTION
## What
Updated seq ids to use JSON

## How
Updated the classes:
`ChangesResult`
`ReplicationResult`
`DbInfo`
`CouchDbInfo`
`Task`
to use `JsonElement` internally for storing the sequence ids for compatibility with non-String seq id
 (e.g. those used by some versions of Cloudant Local). Return the String representation of JSON for API compatibility. Note that some seq ids are still treated as numbers, but may be updated later if the API changes.

Updated CHANGES.md.

## Testing
Ran tests successfully with Cloudant Data Layer Local Edition.

## Reviewers
reviewer @rhyshort 

## Issues
#175