### PR TITLE
Trimmed selector string before parsing

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# Unreleased
+- [FIX] Regression where `JsonParseException` would be thrown if `Database.findByIndex` selector
+  contained leading whitespace.
+
 # 2.4.1 (2016-03-10)
 - [NEW] Documentation for logging in project javadoc `overview.html`.
 - [IMPROVED] Upgraded optional okhttp to 2.7.5.

--- a/cloudant-client/src/main/java/com/cloudant/client/api/Database.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/Database.java
@@ -15,6 +15,7 @@
 package com.cloudant.client.api;
 
 import static com.cloudant.client.org.lightcouch.internal.CouchDbUtil.assertNotEmpty;
+import static com.cloudant.client.org.lightcouch.internal.CouchDbUtil.assertNotNull;
 import static com.cloudant.client.org.lightcouch.internal.CouchDbUtil.close;
 import static com.cloudant.client.org.lightcouch.internal.CouchDbUtil.createPost;
 import static com.cloudant.client.org.lightcouch.internal.CouchDbUtil.getAsString;
@@ -373,6 +374,9 @@ public class Database {
      */
     public <T> List<T> findByIndex(String selectorJson, Class<T> classOfT, FindByIndexOptions
             options) {
+        assertNotNull(selectorJson, "selectorJson");
+        // If it wasn't null we can safely trim
+        selectorJson = selectorJson.trim();
         assertNotEmpty(selectorJson, "selectorJson");
         assertNotEmpty(options, "options");
 

--- a/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/internal/CouchDbUtil.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/internal/CouchDbUtil.java
@@ -55,10 +55,15 @@ final public class CouchDbUtil {
 
     public static void assertNotEmpty(Object object, String prefix) throws
             IllegalArgumentException {
+        assertNotNull(object, prefix);
+        if (object instanceof String && ((String) object).length() == 0) {
+            throw new IllegalArgumentException(format("%s may not be empty.", prefix));
+        }
+    }
+
+    public static void assertNotNull(Object object, String prefix) throws IllegalArgumentException {
         if (object == null) {
             throw new IllegalArgumentException(format("%s may not be null.", prefix));
-        } else if (object instanceof String && ((String) object).length() == 0) {
-            throw new IllegalArgumentException(format("%s may not be empty.", prefix));
         }
     }
 

--- a/cloudant-client/src/test/java/com/cloudant/tests/IndexTests.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/IndexTests.java
@@ -168,6 +168,21 @@ public class IndexTests {
     }
 
     @Test
+    public void testNotNullIndexMovieNameAndYearSelectorStringWithSpace() {
+        List<Movie> movies = db.findByIndex("    \"selector\"   :      {    \"Movie_year\"    :  " +
+                        "{\"$gt\": 1960}, \"Person_name\": \"Alec Guinness\" }     ", Movie.class,
+                new FindByIndexOptions()
+                        .sort(new IndexField("Movie_year", SortOrder.desc))
+                        .fields("Movie_name").fields("Movie_year"));
+        assertNotNull(movies);
+        assert (movies.size() > 0);
+        for (Movie m : movies) {
+            assertNotNull(m.getMovie_name());
+            assertNotNull(m.getMovie_year());
+        }
+    }
+
+    @Test
     public void testIndexMovieNameAndYearWithLimitSkipOptions() {
         List<Movie> movies = db.findByIndex("\"selector\": { \"Movie_year\": {\"$gt\": 1960}, " +
                         "\"Person_name\": \"Alec Guinness\" }",


### PR DESCRIPTION
## What
Fixed regression where a selector with leading whitespace caused a `JsonParseException`.

## How
Trimmed selector string before parsing.

## Testing
Added a new test `testNotNullIndexMovieNameAndYearSelectorStringWithSpace` with whitespace at the start (and within) the selector string.

## Reviewers
