### PR TITLE
Changed to use JVM default chunk size

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 # Unreleased
+- [IMPROVED] Use the JVM default chunk size for HTTP content of unknown length.
 - [FIX] Regression where `JsonParseException` would be thrown if `Database.findByIndex` selector
   contained leading whitespace.
 


### PR DESCRIPTION
## What
Changed to use JVM default chunk size.

## How
Changed call to `setChunkedStreamingMode(0)` to use JVM default.
Moved call to before request interceptors to allow the size to be changed in an interceptor if necessary.
Increased size of buffer used for HTTP output stream to avoid artificially limiting the chunk size. It is worth noting that current `HttpURLConnection` implementations appear to treat the chunk size as a preference only and in testing the output buffer size was more likely to be used as the chunk size than the size suggested by `setChunkedStreamingMode()`.

## Testing
Added new test with chunking `HttpTest#testChunking`.

## Reviewers
reviewer @rhyshort 
reviewer @brynh 