### PR TITLE
240 dd pfx regr

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 # Unreleased
+- [FIX] Regression where `_design/` was not optional in ID when using `DesignDocumentManager` methods.
 - [FIX] Incorrect method names in overview documentation example for connecting to Cloudant service.
 
 # 2.4.2 (2016-04-07)

--- a/cloudant-client/src/main/java/com/cloudant/client/internal/DatabaseURIHelper.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/internal/DatabaseURIHelper.java
@@ -31,8 +31,6 @@ import java.util.Map;
  */
 public class DatabaseURIHelper extends URIBaseMethods<DatabaseURIHelper> {
 
-    private static final String DESIGN_PREFIX = "_design/";
-
     /**
      * Constructs a {@code DatabaseURIHelper} for a given Cloudant or CouchDB URI and database name.
      */
@@ -166,12 +164,7 @@ public class DatabaseURIHelper extends URIBaseMethods<DatabaseURIHelper> {
     }
 
     public DatabaseURIHelper documentId(String documentId) {
-        //Handle design documents
-        if(documentId.startsWith(DESIGN_PREFIX)) {
-            ensureDesignPrefix(documentId);
-        } else {
-            this.path(documentId);
-        }
+        this.path(documentId);
         return returnThis();
     }
 
@@ -199,17 +192,4 @@ public class DatabaseURIHelper extends URIBaseMethods<DatabaseURIHelper> {
         return returnThis();
     }
 
-    /**
-     * Certify that the id in the design document contains the necessary `_design` prefix.
-     * The _design prefix is passed separately to path method.
-     * @param id The design document's id
-     */
-    private DatabaseURIHelper ensureDesignPrefix(String id)
-    {
-        id = id.startsWith(DESIGN_PREFIX)
-                ? id.replace(DESIGN_PREFIX, "")
-                : id;
-        this.path("_design").path(id);
-        return returnThis();
-    }
 }

--- a/cloudant-client/src/test/java/com/cloudant/tests/util/Utils.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/util/Utils.java
@@ -19,6 +19,7 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 import com.cloudant.client.api.CloudantClient;
 import com.cloudant.client.api.Database;
@@ -208,5 +209,10 @@ public class Utils {
 
     public static void putDesignDocs(Database db) throws FileNotFoundException {
         putDesignDocs(db, DESIGN_DOC_DIR);
+    }
+
+    public static void assertOKResponse(Response r) throws Exception {
+        assertTrue("The response code should be 2XX was " + r.getStatusCode(), r.getStatusCode()
+                / 100 == 2);
     }
 }


### PR DESCRIPTION
## What

Fixed regression where `_design/` had to be specified for `DesignDocumentManager` even though it was documented as being optional.

## How
* Added missing doc on DesignDocumentManager.remove(String, String)
* The optional _design prefix functionality was regressed, ensured that `_design/` is added to design document IDs when using the `DesignDocumentManager` class.
* Since the URI path builder already un-escapes the first “/“ in `_design` or `_local` document IDs there is no need to build the path elements separately so removed that added complexity from `DatabaseURIHelper`.
* Updated `CHANGES.md`.

## Testing
Added new tests to `DesignDocumentsTest` for optional prefix cases:
* `designDocGetNoPrefix()`
* `designDocGetNoPrefixWithRevision()`
* `designDocRemoveNoPrefix()`
* `designDocRemoveNoPrefixWithRevision()`
* `designDocRemoveNoPrefixWithObject()`
* `designDocPutNoPrefix()`

Added new test to `DesignDocumentsTest` to validate deleting a document with an index:
* `deleteDesignDocWithIndex()`

## Reviewers

reviewer @mikerhodes
reviewer @emlaver

## Issues
Fixes #240 
