### PR TITLE
239 dd remove rev HEAD

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,6 @@
 # Unreleased
+- [IMPROVED] Use a more efficient HEAD request for getting revision information when using
+  `DesignDocumentManager.remove(String id)`.
 - [FIX] Regression where `_design/` was not optional in ID when using `DesignDocumentManager` methods.
 - [FIX] Incorrect method names in overview documentation example for connecting to Cloudant service.
 

--- a/cloudant-client/src/main/java/com/cloudant/client/api/Database.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/Database.java
@@ -466,7 +466,7 @@ public class Database {
      * @see DesignDocumentManager
      */
     public DesignDocumentManager getDesignDocumentManager() {
-        return new DesignDocumentManager(this);
+        return new DesignDocumentManager(client, this);
     }
 
     /**

--- a/cloudant-client/src/test/java/com/cloudant/tests/CloudantClientTests.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/CloudantClientTests.java
@@ -34,9 +34,9 @@ import com.cloudant.test.main.RequiresCloudant;
 import com.cloudant.test.main.RequiresCloudantService;
 import com.cloudant.test.main.RequiresDB;
 import com.cloudant.tests.util.CloudantClientResource;
+import com.cloudant.tests.util.MockWebServerResource;
 import com.cloudant.tests.util.TestLog;
 import com.cloudant.tests.util.Utils;
-import com.squareup.okhttp.mockwebserver.Dispatcher;
 import com.squareup.okhttp.mockwebserver.MockResponse;
 import com.squareup.okhttp.mockwebserver.MockWebServer;
 import com.squareup.okhttp.mockwebserver.RecordedRequest;
@@ -247,13 +247,8 @@ public class CloudantClientTests {
 
         //start a simple http server
         MockWebServer server = new MockWebServer();
-        server.setDispatcher(new Dispatcher() {
-            @Override
-            public MockResponse dispatch(RecordedRequest request) throws InterruptedException {
-                Thread.sleep(READ_TIMEOUT * 2);
-                return new MockResponse();
-            }
-        });
+        server.setDispatcher(new MockWebServerResource.SleepingDispatcher(READ_TIMEOUT * 2,
+                TimeUnit.MILLISECONDS));
 
         try {
             server.start();

--- a/cloudant-client/src/test/java/com/cloudant/tests/util/MockWebServerResource.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/util/MockWebServerResource.java
@@ -14,14 +14,17 @@
 
 package com.cloudant.tests.util;
 
+import com.squareup.okhttp.mockwebserver.Dispatcher;
 import com.squareup.okhttp.mockwebserver.MockResponse;
 import com.squareup.okhttp.mockwebserver.MockWebServer;
+import com.squareup.okhttp.mockwebserver.RecordedRequest;
 
 import org.junit.rules.ExternalResource;
 
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.security.KeyStore;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -91,6 +94,27 @@ public class MockWebServerResource extends ExternalResource {
         } catch (Exception e) {
             logger.log(Level.SEVERE, "Error initializing SimpleHttpsServer", e);
             return null;
+        }
+    }
+
+    /**
+     * A dispatcher that sleeps for the time specified at construction on each request before
+     * responding. Useful for getting a SocketTimeoutException.
+     */
+    public static class SleepingDispatcher extends Dispatcher {
+
+        private final long sleepTime;
+        private final TimeUnit unit;
+
+        public SleepingDispatcher(long sleepTime, TimeUnit unit) {
+            this.sleepTime = sleepTime;
+            this.unit = unit;
+        }
+
+        @Override
+        public MockResponse dispatch(RecordedRequest request) throws InterruptedException {
+            unit.sleep(sleepTime);
+            return new MockResponse();
         }
     }
 }


### PR DESCRIPTION
## What

Avoid deserializing design documents on remove calls.

## How

Used a `HEAD` request and `ETag` header to get revision information instead of doing a `find()` which did a `GET` of the entire document content plus deserialization.

## Testing

Code path is covered by the `DesignDocumentsTest#designDocRemoveNoPrefix`.
Added two new tests for exception cases:
* couchDbExceptionIfIOExceptionDuringDDocRemove
* couchDbExceptionIfNoETagOnDDocRemove

## Reviewers
reviewer @emlaver
reviewer @alfinkel

## Issues
This addresses the second part of #239.
