### PR TITLE
Fixed regressions in use_index option

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 - [IMPROVED] Use a more efficient HEAD request for getting revision information when using
   `DesignDocumentManager.remove(String id)`.
 - [FIX] Regression where `_design/` was not optional in ID when using `DesignDocumentManager` methods.
+- [FIX] Issue where `use_index` was specified as an array instead of a string when only a design
+  document name was provided.
+- [FIX] Issue where empty array was passed for `use_index` option when `FindByIndexOptions.useIndex()`
+  was not used.
 - [FIX] Incorrect method names in overview documentation example for connecting to Cloudant service.
 
 # 2.4.2 (2016-04-07)

--- a/cloudant-client/src/main/java/com/cloudant/client/api/Database.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/Database.java
@@ -1188,7 +1188,7 @@ public class Database {
         }
         if (options.getUseIndex() != null) {
             indexObject.add("use_index", getGson().fromJson(options.getUseIndex(),
-                    JsonArray.class));
+                    JsonElement.class));
         }
 
         return indexObject;

--- a/cloudant-client/src/main/java/com/cloudant/client/api/model/FindByIndexOptions.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/model/FindByIndexOptions.java
@@ -14,8 +14,11 @@
 
 package com.cloudant.client.api.model;
 
+import static com.cloudant.client.org.lightcouch.internal.CouchDbUtil.assertNotNull;
+
 import com.cloudant.client.api.Database;
 import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
 import com.google.gson.JsonPrimitive;
 
 import java.util.ArrayList;
@@ -48,7 +51,8 @@ public class FindByIndexOptions {
     private List<IndexField> sort = new ArrayList<IndexField>();
     private List<String> fields = new ArrayList<String>();
     private Integer readQuorum;
-    private JsonArray useIndex = new JsonArray();
+    // Either a string for design document only or an array of ["designDoc", "indexName"]
+    private JsonElement useIndex = null;
 
     /**
      * @param limit limit the number of results return
@@ -84,6 +88,7 @@ public class FindByIndexOptions {
      * @return this to set additional options
      */
     public FindByIndexOptions sort(IndexField sort) {
+        assertNotNull(sort, "sort");
         this.sort.add(sort);
         return this;
     }
@@ -96,6 +101,7 @@ public class FindByIndexOptions {
      * @return this to set additional options
      */
     public FindByIndexOptions fields(String field) {
+        assertNotNull(field, "field");
         this.fields.add(field);
         return this;
     }
@@ -107,8 +113,8 @@ public class FindByIndexOptions {
      * @return this to set additional options
      */
     public FindByIndexOptions useIndex(String designDocument) {
-        JsonPrimitive jsonDesign = new JsonPrimitive(designDocument);
-        this.useIndex.add(jsonDesign);
+        assertNotNull(designDocument, "designDocument");
+        this.useIndex = new JsonPrimitive(designDocument);
         return this;
     }
 
@@ -120,10 +126,12 @@ public class FindByIndexOptions {
      * @return this to set additional options
      */
     public FindByIndexOptions useIndex(String designDocument, String indexName) {
-        JsonPrimitive jsonDesign = new JsonPrimitive(designDocument);
-        JsonPrimitive jsonIndex = new JsonPrimitive(indexName);
-        this.useIndex.add(jsonDesign);
-        this.useIndex.add(jsonIndex);
+        assertNotNull(designDocument, "designDocument");
+        assertNotNull(indexName, "indexName");
+        JsonArray index = new JsonArray();
+        index.add(new JsonPrimitive(designDocument));
+        index.add(new JsonPrimitive(indexName));
+        this.useIndex = index;
         return this;
     }
 
@@ -148,6 +156,6 @@ public class FindByIndexOptions {
     }
 
     public String getUseIndex() {
-        return useIndex.toString();
+        return (useIndex != null) ? useIndex.toString() : null;
     }
 }


### PR DESCRIPTION
## What

Fixed regressions introduced in 2.2.0 where:

1. `use_index=[]` being added to requests using `FindByIndexOptions` when `useIndex()` had not been called.
1. `use_index` being specified as an array when it should have been a string for the design document only case.

## How

Changed to use `JsonElement` instead of `JsonArray` to support both
string and array use cases.

Stopped adding to the array if `useIndex` is called more than once,
replace the property instead.

Added the `use_index` option to the request only in cases where
`useIndex` was called instead of adding an empty array.

## Testing

Added 2 new tests to check the type of the use_index property:
-useIndexDesignDocJsonTypeIsString
-useIndexDesignDocAndIndexNameJsonTypeIsArray

Added a new test to check that the use_index property is not
specified if the option was not used:
-useIndexNotSpecified

Added a test to validate that the use_index property is replaced
if the method is called multiple times on the same FindByIndexOptions:
-useIndexReplaced

## Reviewers

reviewer @mikerhodes
reviewer @rhyshort
## Issues
Fixes #243 
