### PR TITLE
Reduced the length of the User-Agent string

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 # Unreleased
+- [IMPROVED] Reduced the length of the User-Agent header string.
 - [IMPROVED] Use a more efficient HEAD request for getting revision information when using
   `DesignDocumentManager.remove(String id)`.
 - [FIX] Regression where `_design/` was not optional in ID when using `DesignDocumentManager` methods.

--- a/cloudant-client/src/main/java/com/cloudant/library/LibraryVersion.java
+++ b/cloudant-client/src/main/java/com/cloudant/library/LibraryVersion.java
@@ -54,15 +54,13 @@ public class LibraryVersion implements Version {
                 }
             }
         }
-        USER_AGENT = String.format("%s/%s [Java %s; %s; %s (%s; %s; %s)]",
+        USER_AGENT = String.format("%s/%s/%s/%s/%s/%s",
                 ua,
                 version,
-                System.getProperty("java.vendor"),
                 System.getProperty("java.version"),
-                System.getProperty("java.runtime.version"),
-                System.getProperty("os.arch"),
+                System.getProperty("java.vendor"),
                 System.getProperty("os.name"),
-                System.getProperty("os.version"));
+                System.getProperty("os.arch"));
     }
 
     @Override

--- a/cloudant-client/src/test/java/com/cloudant/tests/CloudantClientTests.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/CloudantClientTests.java
@@ -101,19 +101,22 @@ public class CloudantClientTests {
         assertNotNull(membership);
     }
 
-    private final String userAgentRegex = "java-cloudant/[^\\s]+ " +
-            "\\[Java [^;]*;[^;]*;" +
-            "[^;]* \\([^;]*;[^;]*;[^;]*\\)\\]";
+    // java-cloudant/n.n.n or java-cloudant/unknown followed by 4 groups of /anything
+    private final String userAgentRegex = "java-cloudant/(?:(?:\\d+.\\d+.\\d+)|(?:unknown))" +
+            "(?:/{1}[^/]+){4}";
+    private final String userAgentFormat = "java-cloudant/version/jvm.version/jvm.vendor/os" +
+            ".name/os.arch";
 
     /**
      * Assert that the User-Agent header is of the expected form.
      */
     @Test
     public void testUserAgentHeaderString() {
-        assertTrue("The value of the User-Agent header should match the format " +
-                "\"java-cloudant/version [Java jvm.vendor; jvm" +
-                ".version; jvm.runtime.version (os.arch; os.name; os.version)]\"", new LibraryVersion().getUserAgentString().matches
-                (userAgentRegex));
+        String userAgentHeader = new LibraryVersion().getUserAgentString();
+        System.out.println(userAgentHeader);
+        assertTrue("The value of the User-Agent header: " + userAgentHeader + " should match the " +
+                        "format: " + userAgentFormat,
+                userAgentHeader.matches(userAgentRegex));
     }
 
     /**
@@ -139,11 +142,8 @@ public class CloudantClientTests {
                     .getHeader("User-Agent");
             assertNotNull("The User-Agent header should be present on the request",
                     userAgentHeader);
-            assertTrue("The value of the User-Agent header value on the request should match the " +
-                    "format " +
-                    "\"java-cloudant/version [Java jvm" +
-                    ".vendor; jvm" +
-                    ".version; jvm.runtime.version (os.arch; os.name; os.version)]\"",
+            assertTrue("The value of the User-Agent header " + userAgentHeader + " on the request" +
+                            " should match the format " + userAgentFormat,
                     userAgentHeader.matches(userAgentRegex));
         } finally {
             server.shutdown();


### PR DESCRIPTION
## What

Removed very specific platform version information and reduced length of User-Agent string.

## How

Removed java.runtime.version & os.version property values.
Removed unnecessary “Java” word - we know where the Java info is in the string without it.
Re-ordered the properties so that java.version, is followed by vendor and os name is followed by arch.
Used single `/` separators instead of more complex groupings of `;[]()`.

## Testing

Updated test checks to match new form.

## Reviewers
reviewer @rhyshort
reviewer @alfinkel

## Issues

See case 64095.