### PR TITLE
60008 http 429 backoff

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+# Unreleased
+- [NEW] Handle HTTP status code `429 Too Many Requests` with blocking backoff and retries.
+
 # 2.4.3 (2016-05-05)
 - [IMPROVED] Reduced the length of the User-Agent header string.
 - [IMPROVED] Use a more efficient HEAD request for getting revision information when using

--- a/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/CouchDbClient.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/CouchDbClient.java
@@ -511,6 +511,12 @@ public class CouchDbClient {
                     case HttpURLConnection.HTTP_PRECON_FAILED: //412
                         ex = new PreconditionFailedException(response);
                         break;
+                    case 429:
+                        // The RequestLimitInterceptor will check for 429 and retry with a doubling
+                        // duration wait. If the default 10 retries are exceeded before the request
+                        // succeeds we end up here and throw a TooManyRequestsException.
+                        ex = new TooManyRequestsException(response);
+                        break;
                     default:
                         ex = new CouchDbException(response, code);
                         break;

--- a/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/TooManyRequestsException.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/TooManyRequestsException.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2016 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.client.org.lightcouch;
+
+/**
+ * <P>
+ * CouchDbException class for HTTP 429 too many requests status code
+ * </P>
+ * <P>
+ * This exception is thrown when a 429 response is received and the client is not going to make
+ * any additional attempts.
+ * </P>
+ */
+public class TooManyRequestsException extends CouchDbException {
+    public TooManyRequestsException(String message) {
+        super(message, 429);
+    }
+}

--- a/cloudant-client/src/test/java/com/cloudant/tests/CloudantClientTests.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/CloudantClientTests.java
@@ -34,7 +34,7 @@ import com.cloudant.test.main.RequiresCloudant;
 import com.cloudant.test.main.RequiresCloudantService;
 import com.cloudant.test.main.RequiresDB;
 import com.cloudant.tests.util.CloudantClientResource;
-import com.cloudant.tests.util.MockWebServerResource;
+import com.cloudant.tests.util.MockWebServerResources;
 import com.cloudant.tests.util.TestLog;
 import com.cloudant.tests.util.Utils;
 import com.squareup.okhttp.mockwebserver.MockResponse;
@@ -247,7 +247,7 @@ public class CloudantClientTests {
 
         //start a simple http server
         MockWebServer server = new MockWebServer();
-        server.setDispatcher(new MockWebServerResource.SleepingDispatcher(READ_TIMEOUT * 2,
+        server.setDispatcher(new MockWebServerResources.SleepingDispatcher(READ_TIMEOUT * 2,
                 TimeUnit.MILLISECONDS));
 
         try {

--- a/cloudant-client/src/test/java/com/cloudant/tests/DesignDocumentsTest.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/DesignDocumentsTest.java
@@ -32,7 +32,7 @@ import com.cloudant.test.main.RequiresCloudant;
 import com.cloudant.test.main.RequiresDB;
 import com.cloudant.tests.util.CloudantClientResource;
 import com.cloudant.tests.util.DatabaseResource;
-import com.cloudant.tests.util.MockWebServerResource;
+import com.cloudant.tests.util.MockWebServerResources;
 import com.cloudant.tests.util.Utils;
 import com.google.gson.JsonObject;
 import com.squareup.okhttp.mockwebserver.MockResponse;
@@ -341,7 +341,7 @@ public class DesignDocumentsTest {
         CloudantClient mockClient = CloudantClientHelper.newMockWebServerClientBuilder
                 (mockWebServer).readTimeout(50, TimeUnit.MILLISECONDS).build();
         // Cause a read timeout to generate an IOException
-        mockWebServer.setDispatcher(new MockWebServerResource.SleepingDispatcher(100, TimeUnit
+        mockWebServer.setDispatcher(new MockWebServerResources.SleepingDispatcher(100, TimeUnit
                 .MILLISECONDS) {
             @Override
             public MockResponse dispatch(RecordedRequest request) throws InterruptedException {

--- a/cloudant-client/src/test/java/com/cloudant/tests/HttpProxyTest.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/HttpProxyTest.java
@@ -21,12 +21,10 @@ import static org.junit.Assert.assertTrue;
 import com.cloudant.client.api.CloudantClient;
 import com.cloudant.http.Http;
 import com.cloudant.http.interceptors.ProxyAuthInterceptor;
-import com.cloudant.tests.util.MockWebServerResource;
 import com.squareup.okhttp.mockwebserver.MockResponse;
 import com.squareup.okhttp.mockwebserver.MockWebServer;
 import com.squareup.okhttp.mockwebserver.RecordedRequest;
 
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -37,14 +35,7 @@ import java.util.regex.Pattern;
 public class HttpProxyTest {
 
     @Rule
-    public MockWebServerResource serverResource = new MockWebServerResource();
-    public MockWebServer server;
-
-    @Before
-    public void setup() {
-        server = serverResource.getServer();
-    }
-
+    public MockWebServer server = new MockWebServer();
 
     /**
      * This test validates that proxy configuration is correctly used.

--- a/cloudant-client/src/test/java/com/cloudant/tests/HttpTest.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/HttpTest.java
@@ -19,7 +19,7 @@ import com.cloudant.http.interceptors.CookieInterceptor;
 import com.cloudant.test.main.RequiresCloudant;
 import com.cloudant.tests.util.CloudantClientResource;
 import com.cloudant.tests.util.DatabaseResource;
-import com.cloudant.tests.util.MockWebServerResource;
+import com.cloudant.tests.util.MockWebServerResources;
 import com.cloudant.tests.util.Utils;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
@@ -53,8 +53,7 @@ public class HttpTest {
     @ClassRule
     public static RuleChain chain = RuleChain.outerRule(clientResource).around(dbResource);
     @Rule
-    public MockWebServerResource mwr = new MockWebServerResource();
-    public MockWebServer mockWebServer = mwr.getServer();
+    public MockWebServer mockWebServer = new MockWebServer();
 
     /*
      * Basic test that we can write a document body by POSTing to a known database
@@ -194,7 +193,7 @@ public class HttpTest {
 
         MockWebServer server = new MockWebServer();
         //expect a cookie request then a GET
-        server.enqueue(MockWebServerResource.OK_COOKIE);
+        server.enqueue(MockWebServerResources.OK_COOKIE);
         server.enqueue(new MockResponse());
 
         server.start();
@@ -238,10 +237,10 @@ public class HttpTest {
         // GET request -> 403
         // _session for new cookie
         // GET replay -> 200
-        mockWebServer.enqueue(MockWebServerResource.OK_COOKIE);
+        mockWebServer.enqueue(MockWebServerResources.OK_COOKIE);
         mockWebServer.enqueue(new MockResponse().setResponseCode(403).setBody
                 ("{\"error\":\"credentials_expired\", \"reason\":\"Session expired\"}\r\n"));
-        mockWebServer.enqueue(MockWebServerResource.OK_COOKIE);
+        mockWebServer.enqueue(MockWebServerResources.OK_COOKIE);
         mockWebServer.enqueue(new MockResponse());
 
         CloudantClient c = CloudantClientHelper.newMockWebServerClientBuilder(mockWebServer)
@@ -277,7 +276,7 @@ public class HttpTest {
         // GET request -> 403
         // _session for new cookie
         // GET replay -> 200
-        mockWebServer.enqueue(MockWebServerResource.OK_COOKIE);
+        mockWebServer.enqueue(MockWebServerResources.OK_COOKIE);
         mockWebServer.enqueue(new MockResponse().setResponseCode(200).addHeader("Set-Cookie",
                 String.format(Locale.ENGLISH, "%s;", renewalCookieValue))
                 .setBody("{\"hello\":\"world\"}\r\n"));
@@ -321,7 +320,7 @@ public class HttpTest {
         // Request sequence
         // _session request to get Cookie
         // GET request -> 403 (CouchDbException)
-        mockWebServer.enqueue(MockWebServerResource.OK_COOKIE);
+        mockWebServer.enqueue(MockWebServerResources.OK_COOKIE);
         mockWebServer.enqueue(new MockResponse().setResponseCode(403).setBody
                 ("{\"error\":\"403_not_expired_test\", \"reason\":\"example reason\"}\r\n"));
 
@@ -478,10 +477,10 @@ public class HttpTest {
     @Test
     public void testCookieRenewOnPost() throws Exception {
 
-        mockWebServer.enqueue(MockWebServerResource.OK_COOKIE);
+        mockWebServer.enqueue(MockWebServerResources.OK_COOKIE);
         mockWebServer.enqueue(new MockResponse().setResponseCode(403).setBody
                 ("{\"error\":\"credentials_expired\", \"reason\":\"Session expired\"}\r\n"));
-        mockWebServer.enqueue(MockWebServerResource.OK_COOKIE);
+        mockWebServer.enqueue(MockWebServerResources.OK_COOKIE);
         mockWebServer.enqueue(new MockResponse());
 
         CloudantClient c = CloudantClientHelper.newMockWebServerClientBuilder(mockWebServer)

--- a/cloudant-client/src/test/java/com/cloudant/tests/SslAuthenticationTest.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/SslAuthenticationTest.java
@@ -22,7 +22,7 @@ import com.cloudant.client.api.CloudantClient;
 import com.cloudant.client.org.lightcouch.CouchDbException;
 import com.cloudant.test.main.RequiresCloudantService;
 import com.cloudant.tests.util.CloudantClientResource;
-import com.cloudant.tests.util.MockWebServerResource;
+import com.cloudant.tests.util.MockWebServerResources;
 import com.squareup.okhttp.mockwebserver.MockResponse;
 import com.squareup.okhttp.mockwebserver.MockWebServer;
 
@@ -42,13 +42,11 @@ public class SslAuthenticationTest {
     private static CloudantClient dbClient = dbClientResource.get();
 
     @Rule
-    public MockWebServerResource mockServerResource = new MockWebServerResource(true);
-
-    private MockWebServer server;
+    public MockWebServer server = new MockWebServer();
 
     @Before
     public void getMockWebServer() {
-        server = mockServerResource.getServer();
+        server.useHttps(MockWebServerResources.getSSLSocketFactory(), false);
     }
 
     /**
@@ -177,7 +175,7 @@ public class SslAuthenticationTest {
     public void localSSLAuthenticationDisabledWithCookieAuth() throws Exception {
 
         // Mock up an OK cookie response then an OK response for the getAllDbs()
-        server.enqueue(MockWebServerResource.OK_COOKIE);
+        server.enqueue(MockWebServerResources.OK_COOKIE);
         server.enqueue(new MockResponse()); //OK 200
 
         // Use a username and password to enable the cookie auth interceptor
@@ -197,7 +195,7 @@ public class SslAuthenticationTest {
     public void localSSLAuthenticationEnabledWithCookieAuth() throws Exception {
 
         // Mock up an OK cookie response then an OK response for the getAllDbs()
-        server.enqueue(MockWebServerResource.OK_COOKIE);
+        server.enqueue(MockWebServerResources.OK_COOKIE);
         server.enqueue(new MockResponse()); //OK 200
 
         // Use a username and password to enable the cookie auth interceptor

--- a/cloudant-client/src/test/java/com/cloudant/tests/util/MockWebServerResources.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/util/MockWebServerResources.java
@@ -16,13 +16,9 @@ package com.cloudant.tests.util;
 
 import com.squareup.okhttp.mockwebserver.Dispatcher;
 import com.squareup.okhttp.mockwebserver.MockResponse;
-import com.squareup.okhttp.mockwebserver.MockWebServer;
 import com.squareup.okhttp.mockwebserver.RecordedRequest;
 
-import org.junit.rules.ExternalResource;
-
 import java.io.FileInputStream;
-import java.io.IOException;
 import java.security.KeyStore;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
@@ -32,7 +28,7 @@ import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSocketFactory;
 
-public class MockWebServerResource extends ExternalResource {
+public class MockWebServerResources {
 
     /**
      * A mock cookie response that is OK
@@ -43,42 +39,12 @@ public class MockWebServerResource extends ExternalResource {
                     "AuthSession=\"a2ltc3RlYmVsOjUxMzRBQTUzOtiY2_IDUIdsTJEVNEjObAbyhrgz\";")
             .setBody("{\"ok\":true,\"name\":\"mockUser\",\"roles\":[]}");
 
-    private static final Logger logger = Logger.getLogger(MockWebServerResource.class.getName());
+    private static final Logger logger = Logger.getLogger(MockWebServerResources.class.getName());
 
     //Keystore information for https
     private static String KEYSTORE_FILE = "src/test/resources/SslAuthenticationTest.keystore";
     private static String KEYSTORE_PASSWORD = "password";
     private static String KEY_PASSWORD = "password";
-
-    private final MockWebServer mockWebServer = new MockWebServer();
-
-    public MockWebServerResource() {
-        this(false);
-    }
-
-    public MockWebServerResource(boolean useHttps) {
-        if (useHttps) {
-            mockWebServer.useHttps(getSSLSocketFactory(), false);
-        }
-    }
-
-    @Override
-    protected void before() throws Throwable {
-        mockWebServer.start();
-    }
-
-    @Override
-    protected void after() {
-        try {
-            mockWebServer.shutdown();
-        } catch (IOException e) {
-            logger.log(Level.SEVERE, "IOExeption during mock server shutdown", e);
-        }
-    }
-
-    public MockWebServer getServer() {
-        return mockWebServer;
-    }
 
     public static SSLSocketFactory getSSLSocketFactory() {
         try {
@@ -92,7 +58,7 @@ public class MockWebServerResource extends ExternalResource {
             sslContext.init(kmf.getKeyManagers(), null, null);
             return sslContext.getSocketFactory();
         } catch (Exception e) {
-            logger.log(Level.SEVERE, "Error initializing SimpleHttpsServer", e);
+            logger.log(Level.SEVERE, "Error initializing test SSLSocketFactory", e);
             return null;
         }
     }

--- a/cloudant-http/src/main/java/com/cloudant/http/interceptors/HttpConnectionInterceptorException.java
+++ b/cloudant-http/src/main/java/com/cloudant/http/interceptors/HttpConnectionInterceptorException.java
@@ -20,6 +20,12 @@ public class HttpConnectionInterceptorException extends RuntimeException {
     public final String error;
     public final String reason;
 
+    HttpConnectionInterceptorException(Throwable cause) {
+        this.initCause(cause);
+        this.error = null;
+        this.reason = null;
+    }
+
     HttpConnectionInterceptorException(String error) {
         this(error, null);
     }

--- a/cloudant-http/src/main/java/com/cloudant/http/interceptors/RequestLimitInterceptor.java
+++ b/cloudant-http/src/main/java/com/cloudant/http/interceptors/RequestLimitInterceptor.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2016 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.http.interceptors;
+
+import com.cloudant.http.HttpConnectionInterceptorContext;
+import com.cloudant.http.HttpConnectionResponseInterceptor;
+
+import org.apache.commons.io.IOUtils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
+
+public class RequestLimitInterceptor implements HttpConnectionResponseInterceptor {
+
+    private static final Logger logger = Logger.getLogger(RequestLimitInterceptor.class.getName());
+    // Initial backoff time is 250 ms.
+    // Note: not final to allow modification via reflection for faster tests.
+    private static int initialSleep = 250;
+    private int exp = 0;
+
+    @Override
+    public HttpConnectionInterceptorContext interceptResponse(HttpConnectionInterceptorContext
+                                                                      context) {
+        try {
+            HttpURLConnection urlConnection = context.connection.getConnection();
+            int code = urlConnection.getResponseCode();
+            if (429 == code && context.connection.getNumberOfRetriesRemaining() >= 1) {
+                // Too many requests, we need to backoff before retrying
+
+                // If the response includes a Retry-After then that is when we will retry, otherwise
+                // we use a doubling sleep
+                long sleepTime = 0l;
+                String retryAfter = urlConnection.getHeaderField("Retry-After");
+                if (retryAfter != null) {
+                    // See https://tools.ietf.org/html/rfc6585#section-4
+                    // Whilst not specified for 429 for 3xx or 503 responses the Retry-After header
+                    // is expressed as an integer number of seconds or a date in one of the 3 HTTP
+                    // date formats https://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.3
+                    // Cloudant servers should give us an integer number of seconds, so don't worry
+                    // about parsing dates for now.
+                    sleepTime = Long.parseLong(retryAfter) * 1000;
+                } else {
+                    // Calculate the backoff time, 2^n * initial sleep
+                    sleepTime = initialSleep * (int) Math.pow(2, exp);
+                }
+                // Read the reasons and log a warning
+                InputStream errorStream = urlConnection.getErrorStream();
+                try {
+                    String errorString = IOUtils.toString(errorStream, "UTF-8");
+                    logger.warning(errorString + " will retry in " +
+                            sleepTime + " ms");
+
+                } finally {
+                    errorStream.close();
+                }
+
+
+                logger.fine("Too many requests backing off for " + sleepTime + " ms.");
+
+                // Sleep the thread for the appropriate backoff time
+                try {
+                    TimeUnit.MILLISECONDS.sleep(sleepTime);
+                } catch (InterruptedException e) {
+                    logger.fine("Interrupted during 429 backoff wait.");
+                    // If the thread was interrupted we'll just continue and try again a bit earlier
+                    // than planned.
+                }
+
+                // Get ready to replay the request after the backoff time
+                context.replayRequest = true;
+                exp++;
+                return context;
+            } else {
+                return context;
+            }
+        } catch (IOException e) {
+            throw new HttpConnectionInterceptorException(e);
+        }
+    }
+}


### PR DESCRIPTION
## What

Added handling for `429 Too many requests` server responses.

## How

* cloudant-http
    * Expose the current number of retries from `HttpConnection`.
    * Added cause constructor to `HttpConnectionInterceptorException`.
    * Added unwrapping of `IOException` from interceptor thrown `HttpConnectionInterceptorException`s.
    * Create a `RequestLimitInterceptor` that checks for `429` status codes and sleeps before replaying the request.
    * The sleep duration is a doubling backoff starting at 0.25 s and doubling with each retry (up to 10 tries by default) unless a `Retry-After` header was specified by the server in which case that is parsed (as seconds) and used as the duration.
    * Whilst it would be nice to reschedule the request rather than sleeping the current `HttpConnection` approach does not have an executor to support that.
    * Added an instance of the `RequestLimitInterceptor` to all `HttpConnection`s.

* cloudant-client
    * Added a `TooManyRequestsException` to be thrown if a `429` is received and there are no retries remaining

## Testing

* Removed `MockWebServerResource` wrapping of `MockWebServer` since `MockWebServer` is usable as a JUnit rule anyway. Renamed to `MockWebServerResources` for the remaining utilities.
* Configured a reduced starting backoff time (1 ms) to speed up testing.
* Added new `HttpTest` class tests:
    * test429Backoff - test that a request is replayed in response to a 429.
    * test429BackoffMaxDefault - test the default number of retries and backoff duration.
    * test429BackoffMaxConfigured - test a configured number of retries.
    * test429BackoffRetryAfter - test backoff duration specified in `Retry-After` response header is honoured.

## Reviewers

reviewer @brynh 
reviewer @rhyshort

## Issues

Internal case 60008.
