### PR TITLE
Fixed deserialization of query design documents

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
 - [NEW] Added an optional `SettableViewParameters.STALE_NO` constant for the default omitted case of
   the stale parameter on a view request.
 - [NEW] Added `descending` option for changes feed.
+- [FIX] `JsonSyntaxException` when deserializing Cloudant query language generated design
+  documents into the `DesignDocument` class.
 
 # 2.4.3 (2016-05-05)
 - [IMPROVED] Reduced the length of the User-Agent header string.

--- a/cloudant-client/src/test/resources/design-files/query_design_doc.js
+++ b/cloudant-client/src/test/resources/design-files/query_design_doc.js
@@ -1,0 +1,17 @@
+{
+ "_id": "_design/testQuery",
+ "language": "query",
+ "views": {
+  "testView": {
+   "map": {"fields": {"Person_dob": "asc"}},
+   "reduce": "_count",
+   "options": {
+    "def": {
+     "fields": [
+      "Person_dob"
+     ]
+    }
+   }
+  }
+ }
+}


### PR DESCRIPTION
## What
Fixed deserialization of query design documents

## How

Replaced `String` map/reduce fields with `JsonElement` in `DesignDocument.MapReduce` to allow for either a JSON string or JSON object to be stored as a map function.
Default for `JsonElement.toString()` is to enclose JSON string with `"` (i.e. escaped quotes `\"`) in the Java string. Added logic to remove these leading and trailing quotes from JSON string map/reduce functions (i.e. javascript language case) to maintain backwards compatibility with existing behaviour. 
Updated CHANGES.md.

## Testing

Added tests for serializing and deserializing map functions of string and object types for the javascript and query language design documents.

## Reviewers
reviewer @rhyshort
reviewer @emlaver
## Issues
Fixes #239 (part 1), part 2 was done in #242 