### PR TITLE
Added list method to DesignDocumentManager

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 # Unreleased
 - [NEW] Handle HTTP status code `429 Too Many Requests` with blocking backoff and retries.
+- [NEW] Added `DesignDocumentManager.list()` to return all design documents defined in a database.
 
 # 2.4.3 (2016-05-05)
 - [IMPROVED] Reduced the length of the User-Agent header string.

--- a/cloudant-client/src/main/java/com/cloudant/client/api/DesignDocumentManager.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/DesignDocumentManager.java
@@ -30,6 +30,7 @@ import org.apache.commons.io.FileUtils;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
@@ -205,6 +206,22 @@ public class DesignDocumentManager {
         assertNotEmpty(designDocument, "DesignDocument");
         ensureDesignPrefixObject(designDocument);
         return db.remove(designDocument);
+    }
+
+    /**
+     * Performs a query to retrieve all the design documents defined in the database.
+     *
+     * @return a list of the design documents from the database
+     * @throws IOException if there was an error communicating with the server
+     */
+    public List<DesignDocument> list() throws IOException {
+        return db.getAllDocsRequestBuilder()
+                .startKey("_design/")
+                .endKey("_design0")
+                .inclusiveEnd(false)
+                .includeDocs(true)
+                .build()
+                .getResponse().getDocsAs(DesignDocument.class);
     }
 
     /**

--- a/cloudant-client/src/test/java/com/cloudant/tests/DesignDocumentsTest.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/DesignDocumentsTest.java
@@ -46,6 +46,8 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 import java.io.File;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -370,5 +372,34 @@ public class DesignDocumentsTest {
         // Queue a mock response with no "ETag" header
         mockWebServer.enqueue(new MockResponse());
         database.getDesignDocumentManager().remove("example");
+    }
+
+    /**
+     * Test the {@link DesignDocumentManager#list()} function. Assert that the returned list of
+     * design documents matches that expected.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void listDesignDocuments() throws Exception {
+        // Put all the design docs from the directory
+        List<DesignDocument> designDocs = DesignDocumentManager.fromDirectory(rootDesignDir);
+
+        // Sort the list lexicographically so that the order matches that returned by the list
+        // function, as elements need to be in the same order for list.equals().
+        Collections.sort(designDocs, new Comparator<DesignDocument>() {
+            @Override
+            public int compare(DesignDocument doc1, DesignDocument doc2) {
+                return doc1.getId().compareTo(doc2.getId());
+            }
+        });
+
+        for (DesignDocument doc : designDocs) {
+            // Put each design document and set the revision for equality comparison later
+            doc.setRevision(designManager.put(doc).getRev());
+        }
+
+        assertEquals("The retrieved list of design documents should match the expected list",
+                designDocs, designManager.list());
     }
 }


### PR DESCRIPTION
## What
Added list method to DesignDocumentManager.

## How

Added `list()` method to `DesignDocumentManager` that performs and all docs request using a start key of `_design/` and an exclusive end key of  `_design0` with doc content included to retrieve all the design documents. They are deserialized using the `getDocsAs(DesignDocument.class)` on the all docs response.
Updated CHANGES.md.

## Testing

Added test `com.cloudant.tests.DesignDocumentsTest#listDesignDocuments()` to exercise `DesignDocumentManager.list()`.

## Reviewers
reviewer @rhyshort
reviewer @emlaver

## Issues
#193 