### PR TITLE
Added STALE_NO constant for default view parameter

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 # Unreleased
 - [NEW] Handle HTTP status code `429 Too Many Requests` with blocking backoff and retries.
 - [NEW] Added `DesignDocumentManager.list()` to return all design documents defined in a database.
+- [NEW] Added an optional `SettableViewParameters.STALE_NO` constant for the default omitted case of
+  the stale parameter on a view request.
 
 # 2.4.3 (2016-05-05)
 - [IMPROVED] Reduced the length of the User-Agent header string.

--- a/cloudant-client/src/main/java/com/cloudant/client/api/views/SettableViewParameters.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/views/SettableViewParameters.java
@@ -28,6 +28,12 @@ package com.cloudant.client.api.views;
 public interface SettableViewParameters {
 
     /**
+     * Convenience constant defined as null to omit the value for a stale parameter, resulting in
+     * the server default case, i.e. not allowing stale documents.
+     * {@link com.cloudant.client.api.views.SettableViewParameters.Common#stale(String)}
+     */
+    String STALE_NO = null;
+    /**
      * Constant for the value "ok" for use with
      * {@link com.cloudant.client.api.views.SettableViewParameters.Common#stale(String)}
      * <P>


### PR DESCRIPTION
## What

Added STALE_NO constant for default view parameter

## How

Added a constant to represent the default omitted stale parameter case
(i.e. it has a `null` value and can be passed into the `stale()` method).

## Testing

Added new test `ViewsTest#staleParameterValues` for the various stale parameter cases.

## Reviewers
reviewer @rhyshort
reviewer @emlaver

## Issues
#194 

