### PR TITLE
235 changes params

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
 - [NEW] Added an optional `SettableViewParameters.STALE_NO` constant for the default omitted case of
   the stale parameter on a view request.
 - [NEW] Added `descending` option for changes feed.
+- [NEW] Added `parameter` option for changes feed to allow specifying a custom query parameter on
+  the request for example to be used by a filter function.
 - [FIX] `JsonSyntaxException` when deserializing Cloudant query language generated design
   documents into the `DesignDocument` class.
 

--- a/cloudant-client/src/main/java/com/cloudant/client/api/Changes.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/Changes.java
@@ -241,6 +241,19 @@ public class Changes {
         return this;
     }
 
+    /**
+     * Add a custom query parameter to the _changes request. Useful for specifying extra parameters
+     * to a filter function for example.
+     *
+     * @param name the name of the query parameter
+     * @param value the value of the query parameter
+     * @return this Changes instance
+     */
+    public Changes parameter(String name, String value) {
+        this.databaseHelper.query(name, value);
+        return this;
+    }
+
     // Helper
 
     /**

--- a/cloudant-client/src/main/java/com/cloudant/client/api/Changes.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/Changes.java
@@ -235,6 +235,7 @@ public class Changes {
     /**
      * @param descending {@code true} to return changes in descending order
      * @return this Changes instance
+     * @since 2.5.0
      */
     public Changes descending(boolean descending) {
         this.databaseHelper.query("descending", descending);
@@ -245,9 +246,10 @@ public class Changes {
      * Add a custom query parameter to the _changes request. Useful for specifying extra parameters
      * to a filter function for example.
      *
-     * @param name the name of the query parameter
+     * @param name  the name of the query parameter
      * @param value the value of the query parameter
      * @return this Changes instance
+     * @since 2.5.0
      */
     public Changes parameter(String name, String value) {
         this.databaseHelper.query(name, value);

--- a/cloudant-client/src/main/java/com/cloudant/client/api/DesignDocumentManager.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/DesignDocumentManager.java
@@ -213,6 +213,7 @@ public class DesignDocumentManager {
      *
      * @return a list of the design documents from the database
      * @throws IOException if there was an error communicating with the server
+     * @since 2.5.0
      */
     public List<DesignDocument> list() throws IOException {
         return db.getAllDocsRequestBuilder()

--- a/cloudant-client/src/main/java/com/cloudant/client/api/views/SettableViewParameters.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/views/SettableViewParameters.java
@@ -31,6 +31,8 @@ public interface SettableViewParameters {
      * Convenience constant defined as null to omit the value for a stale parameter, resulting in
      * the server default case, i.e. not allowing stale documents.
      * {@link com.cloudant.client.api.views.SettableViewParameters.Common#stale(String)}
+     *
+     * @since 2.5.0
      */
     String STALE_NO = null;
     /**

--- a/cloudant-client/src/test/java/com/cloudant/tests/ChangeNotificationsTest.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/ChangeNotificationsTest.java
@@ -133,4 +133,22 @@ public class ChangeNotificationsTest {
                 .contains("descending=true"));
     }
 
+    /**
+     * Test that a custom parameter can be added to a changes request.
+     */
+    @Test
+    public void changesCustomParameter() throws Exception {
+        CloudantClient client = CloudantClientHelper.newMockWebServerClientBuilder(mockWebServer)
+                .build();
+        Database db = client.database("notreal", false);
+        // Mock up an empty set of changes
+        mockWebServer.enqueue(new MockResponse().setBody("{\"results\": []}"));
+        db.changes().filter("myFilter").parameter("myParam", "paramValue").getChanges();
+        RecordedRequest request = mockWebServer.takeRequest(1, TimeUnit.SECONDS);
+        assertNotNull("There should be a changes request", request);
+        assertTrue("There should be a filter parameter on the request", request.getPath()
+                .contains("filter=myFilter"));
+        assertTrue("There should be a custom parameter on the request", request.getPath()
+                .contains("myParam=paramValue"));
+    }
 }


### PR DESCRIPTION
## What

Added custom query parameter for changes

## How

Added `Changes.parameter(String, String)` method for adding a custom query parameter.
Apply the arguments of that method to the changes request.
Updated `CHANGES.md`.

## Testing

Added test for custom parameter `ChangeNotificationsTest#changesCustomParameter` that validates the custom parameter is added to a URL.

## Reviewers

reviewer @rhyshort 

## Issues
Fixes #235
