### PR TITLE
226 error resp

### DIFF
--- a/cloudant-client/src/main/java/com/cloudant/client/api/Database.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/Database.java
@@ -171,19 +171,10 @@ public class Database {
         }
         elem.getAsJsonObject().add(userNameorApikey, jsonPermissions);
 
-        InputStream response = null;
         HttpConnection put = Http.PUT(apiV2DBSecurityURI, "application/json");
         put.setRequestBody(client.getGson().toJson(perms));
-        try {
-            response = client.couchDbClient.executeToInputStream(put);
-            String ok = getAsString(response, "ok");
-            if (!ok.equalsIgnoreCase("true")) {
-                //raise exception
-                throw new CouchDbException("Error setting permissions.");
-            }
-        } finally {
-            close(response);
-        }
+        // CouchDbExceptions will be thrown for non-2XX cases
+        client.couchDbClient.executeToResponse(put);
     }
 
     /**

--- a/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/CouchDbClient.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/CouchDbClient.java
@@ -276,11 +276,10 @@ public class CouchDbClient {
     }
 
     /**
-     * Executes a HTTP request.
-     * <p><b>Note</b>: The stream must be closed after use to release the connection.
+     * Executes a HTTP request and parses the JSON response into a Response instance.
      *
      * @param connection The HTTP request to execute.
-     * @return Class type of object T (i.e. {@link Response}
+     * @return Response object of the deserialized JSON response
      */
     public Response executeToResponse(HttpConnection connection) {
         InputStream is = null;

--- a/cloudant-client/src/test/java/com/cloudant/tests/util/MockWebServerResources.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/util/MockWebServerResources.java
@@ -39,6 +39,12 @@ public class MockWebServerResources {
                     "AuthSession=\"a2ltc3RlYmVsOjUxMzRBQTUzOtiY2_IDUIdsTJEVNEjObAbyhrgz\";")
             .setBody("{\"ok\":true,\"name\":\"mockUser\",\"roles\":[]}");
 
+    public static final MockResponse JSON_OK = new MockResponse().setResponseCode(200).setBody
+            ("{\"ok\":true}");
+
+    public static final MockResponse PERMISSIONS = new MockResponse().setResponseCode(200)
+            .setBody("{\"_id\":\"security\", \"cloudant\":{\"user\": [\"_reader\"]}}");
+
     private static final Logger logger = Logger.getLogger(MockWebServerResources.class.getName());
 
     //Keystore information for https


### PR DESCRIPTION
## What

Ensured error information is included in setPermissions exceptions.

## How

The issue #226 was opened as a result of a PR comment around the throwing of a `CouchDbException` from the `setPermissions` method without including `error` or `reason` information. Investigation of the code paths involved revealed that the branch that threw that exception should have been unreachable anyway because if `ok` was not `true` in the response JSON then a `CouchDbException` would have been thrown already by the `executeToInputStream` method from a non-2XX response code. So the changes here are primarily removing that unnecessary path and adding some tests.

* Simplified `Database.setPermissions()` error handling by removing unreachable exception path.

## Testing

* Added new test `com.cloudant.tests.DatabaseTest#permissionsParsing` to check ok/error states of setPermissions.

## Reviewers

reviewer @emlaver
## Issues
#226 
