### PR TITLE
Fixed 403 null reason deserialization

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@
 - [FIX] Documentation that suggested calling `database("dbname", false)` would immediately throw a
   `NoDocumentException` if the database did not exist. The exception is not thrown until the first
   operation on the `Database` instance.
+- [FIX] `ClassCastException` when the server responded `403` with a `null` reason in the JSON.
 
 # 2.4.3 (2016-05-05)
 - [IMPROVED] Reduced the length of the User-Agent header string.

--- a/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/CouchDbClient.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/CouchDbClient.java
@@ -475,10 +475,8 @@ public class CouchDbClient {
                     try {
                         JsonObject errorResponse = new Gson().fromJson(e.error, JsonObject
                                 .class);
-                        exception.error = errorResponse.getAsJsonPrimitive
-                                ("error").getAsString();
-                        exception.reason = errorResponse.getAsJsonPrimitive
-                                ("reason").getAsString();
+                        exception.error = getAsString(errorResponse, "error");
+                        exception.reason = getAsString(errorResponse, "reason");
                     } catch (JsonParseException jpe) {
                         exception.error = e.error;
                     }

--- a/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/internal/CouchDbUtil.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/internal/CouchDbUtil.java
@@ -93,10 +93,17 @@ final public class CouchDbUtil {
     }
 
     /**
-     * @return A JSON element as a String, or null if not found.
+     * @return A JSON element as a String, or null if there is no member with that name or the
+     * value was a JSON null.
      */
     public static String getAsString(JsonObject j, String e) {
-        return (j.get(e) == null) ? null : j.get(e).getAsString();
+        if (j != null && e != null) {
+            JsonElement element = j.get(e);
+            if (element != null && !element.isJsonNull()) {
+                return element.getAsString();
+            }
+        }
+        return null;
     }
 
     /**


### PR DESCRIPTION
## What

Fixed `ClassCastException` for `{"reason": null}` `403` responses.

## How

Changed exception `error` and `reason` assigns to use `getAsString` utility method.
Added check for `JsonNull` to `getAsString` utility method.

## Testing

Added new tests for 403 with a missing or null `reason` property:
* `handleNonExpiry403NoReason`
* `handleNonExpiry403NullReason`

## Reviewers
reviewer: @brynh
reviewer @emlaver

## Issues
Fixes #256 
