### PR TITLE
258 db create

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,11 @@
   the request for example to be used by a filter function.
 - [FIX] `JsonSyntaxException` when deserializing Cloudant query language generated design
   documents into the `DesignDocument` class.
+- [FIX] `PreconditionFailedException` was never thrown when calling `createDB("dbname")` when the
+  database already existed.
+- [FIX] Documentation that suggested calling `database("dbname", false)` would immediately throw a
+  `NoDocumentException` if the database did not exist. The exception is not thrown until the first
+  operation on the `Database` instance.
 
 # 2.4.3 (2016-05-05)
 - [IMPROVED] Reduced the length of the User-Agent header string.

--- a/cloudant-client/src/main/java/com/cloudant/client/api/CloudantClient.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/CloudantClient.java
@@ -200,12 +200,16 @@ public class CloudantClient {
 
     /**
      * Get a database reference for the database with the specified name.
+     * <P>
+     * Note that if create is {@code false} and the database does not exist an instance will be
+     * returned, but the first operation on that instance will throw a
+     * {@link com.cloudant.client.org.lightcouch.NoDocumentException} because the database does not
+     * exist.
+     * </P>
      *
      * @param name   name of database to access
      * @param create flag indicating whether to create the database if it does not exist
      * @return Database object
-     * @throws com.cloudant.client.org.lightcouch.NoDocumentException if the database does not
-     *                                                                exist and create was false
      * @see <a target="_blank" href="https://docs.cloudant.com/database.html#read">Databases -
      * read</a>
      */

--- a/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/CouchDatabaseBase.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/CouchDatabaseBase.java
@@ -59,7 +59,13 @@ public abstract class CouchDatabaseBase {
         this.clientUri = couchDbClient.getBaseUri();
         this.dbUri = new DatabaseURIHelper(clientUri, name).getDatabaseUri();
         if (create) {
-            create();
+            try {
+                couchDbClient.createDB(dbName);
+            } catch (PreconditionFailedException e) {
+                // The PreconditionFailedException is thrown if the database already existed.
+                // To preserve the behaviour of the previous version, suppress this type of exception.
+                // All other CouchDbExceptions will be thrown.
+            }
         }
     }
 
@@ -424,21 +430,6 @@ public abstract class CouchDatabaseBase {
      */
     public String getDbName() {
         return dbName;
-    }
-
-
-    private void create() {
-        InputStream putresp = null;
-        try {
-            putresp = couchDbClient.put(new DatabaseURIHelper(clientUri, dbName).build());
-            log.info(String.format("Created Database: '%s'", dbName));
-        } catch (PreconditionFailedException e) {
-            // The PreconditionFailedException is thrown if the database already existed.
-            // To preserve the behaviour of the previous version, suppress this type of exception.
-            // All other CouchDbExceptions will be thrown.
-        } finally {
-            close(putresp);
-        }
     }
 
     // helper

--- a/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/CouchDbClient.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/CouchDbClient.java
@@ -198,16 +198,9 @@ public class CouchDbClient {
      */
     public void createDB(String dbName) {
         assertNotEmpty(dbName, "dbName");
-        InputStream is = null;
         final URI uri = new DatabaseURIHelper(getBaseUri(), dbName).getDatabaseUri();
-        try {
-            is = get(uri);
-        } catch (NoDocumentException e) { // db doesn't exist
-            is = put(uri);
-            log.info(String.format("Created Database: '%s'", dbName));
-        } finally {
-            close(is);
-        }
+        executeToResponse(Http.PUT(uri, "application/json"));
+        log.info(String.format("Created Database: '%s'", dbName));
     }
 
     /**

--- a/cloudant-client/src/test/java/com/cloudant/tests/CloudantClientTests.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/CloudantClientTests.java
@@ -28,6 +28,7 @@ import com.cloudant.client.api.model.Membership;
 import com.cloudant.client.api.model.Task;
 import com.cloudant.client.org.lightcouch.CouchDbException;
 import com.cloudant.client.org.lightcouch.NoDocumentException;
+import com.cloudant.client.org.lightcouch.PreconditionFailedException;
 import com.cloudant.http.interceptors.BasicAuthInterceptor;
 import com.cloudant.library.LibraryVersion;
 import com.cloudant.test.main.RequiresCloudant;
@@ -174,8 +175,30 @@ public class CloudantClientTests {
             //create a DB for this test
             account.createDB(dbName);
 
-            //do a get with create true for the already existing DB
+            // Get a database instance using create true for the already existing DB
             account.database(dbName, true);
+        } finally {
+            //clean up the DB created by this test
+            account.deleteDB(dbName);
+        }
+    }
+
+    /**
+     * Validate that a PreconditionFailedException is thrown when using the createDB method to
+     * create a database that already exists.
+     */
+    @Test(expected = PreconditionFailedException.class)
+    @Category(RequiresDB.class)
+    public void existingDatabaseCreateDBException() {
+        String id = Utils.generateUUID();
+        String dbName = "existing" + id;
+        try {
+            //create a DB for this test
+            account.createDB(dbName);
+
+            //do a get with create true for the already existing DB
+            account.createDB(dbName);
+
         } finally {
             //clean up the DB created by this test
             account.deleteDB(dbName);


### PR DESCRIPTION
## What

Fixed database create behaviour and documentation.

## How

Fixed documentation for `CloudantClient.database` database creation.
Consolidated database create behaviour into a single method.
Removed unnecessary `GET` from `createDB` method that was preventing the documented `PreconditionFailedException` from propagating to`CloudantClient.createDB`.
Added new test for validating the `PreconditionFailedException` is thrown.

## Testing
Added new test for validating the `PreconditionFailedException` is thrown when using `createDB` and the database does not exist.

## Reviewers

reviewer @emlaver
reviewer @rhyshort adding you as you already looked at this anyway

## Issues
Fixes #258 
