### PR TITLE
Closed streams and documented the need to close

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
   A default instance is available using 3 retries and starting with a 250 ms backoff:
   `Replay429Interceptor.WITH_DEFAULTS`. To replicate the backoff of version 2.5.0 create an instance
    using `new Replay429Interceptor(10, 250l)`.
+- [FIX] Fixed places where streams where not closed and could cause connections to leak.
 
 # 2.5.0 (2016-05-24)
 - [NEW] Handle HTTP status code `429 Too Many Requests` with blocking backoff and retries.

--- a/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/CouchDbClient.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/CouchDbClient.java
@@ -302,7 +302,8 @@ public class CouchDbClient {
     }
 
     /**
-     * Performs a HTTP GET request.
+     * <p>Performs a HTTP GET request.</p>
+     * <p>The stream <b>must</b> be closed after use.</p>
      *
      * @return Input stream with response
      */
@@ -327,7 +328,8 @@ public class CouchDbClient {
     }
 
     /**
-     * Performs a HTTP HEAD request.
+     * <p>Performs a HTTP HEAD request.</p>
+     * <p>The stream <b>must</b> be closed after use.</p>
      *
      * @return {@link Response}
      */
@@ -337,8 +339,9 @@ public class CouchDbClient {
     }
 
     /**
-     * Performs a HTTP PUT request, saves or updates a document.
-     * This defaults to "application/json" content type.
+     * <p>Performs a HTTP PUT request, saves or updates a document.
+     * This defaults to "application/json" content type.</p>
+     * <p>The stream <b>must</b> be closed after use.</p>
      *
      * @return Input stream with response
      */
@@ -347,7 +350,8 @@ public class CouchDbClient {
     }
 
     /**
-     * Performs a HTTP PUT request with content type, saves or updates a document.
+     * <p>Performs a HTTP PUT request with content type, saves or updates a document.</p>
+     * <p>The stream <b>must</b> be closed after use.</p>
      *
      * @return Input stream with response
      */
@@ -412,7 +416,8 @@ public class CouchDbClient {
     }
 
     /**
-     * Performs a HTTP POST request with JSON request body.
+     * <p>Performs a HTTP POST request with JSON request body.</p>
+     * <p>The stream <b>must</b> be closed after use.</p>
      *
      * @return Input stream with response
      */
@@ -549,7 +554,8 @@ public class CouchDbClient {
     }
 
     /**
-     * Execute the HttpConnection request and return the InputStream if there were no errors.
+     * <p>Execute the HttpConnection request and return the InputStream if there were no errors.</p>
+     * <p>The stream <b>must</b> be closed after use.</p>
      *
      * @param connection the request HttpConnection
      * @return InputStream from the HttpConnection response

--- a/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/internal/CouchDbUtil.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/internal/CouchDbUtil.java
@@ -30,6 +30,7 @@ import com.google.gson.JsonParser;
 import org.apache.commons.io.IOUtils;
 
 import java.io.Closeable;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
@@ -39,7 +40,6 @@ import java.net.URI;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Scanner;
 import java.util.UUID;
 
 /**
@@ -127,12 +127,13 @@ final public class CouchDbUtil {
     }
 
     public static String streamToString(InputStream in) {
-        Scanner s = new Scanner(in, "UTF-8");
-        s.useDelimiter("\\A");
-        String str = s.hasNext() ? s.next() : null;
-        close(in);
-        s.close();// mdb
-        return str;
+        try {
+            return IOUtils.toString(in, "UTF-8");
+        } catch (IOException e) {
+            throw new RuntimeException("Error reading stream.", e);
+        } finally {
+            close(in);
+        }
     }
 
     /**
@@ -202,13 +203,17 @@ final public class CouchDbUtil {
      */
     public static <T> List<T> getResponseList(InputStream response, Gson gson,
                                               Type typeofT) throws CouchDbException {
+        Reader reader = null;
         try {
-            Reader reader = new InputStreamReader(response, "UTF-8");
+            reader = new InputStreamReader(response, "UTF-8");
             return gson.fromJson(reader, typeofT);
         } catch (UnsupportedEncodingException e) {
             // This should never happen as every implementation of the java platform is required
             // to support UTF-8.
             throw new RuntimeException(e);
+        }  finally {
+            close(reader);
+            close(response);
         }
     }
 
@@ -218,12 +223,16 @@ final public class CouchDbUtil {
      */
     public static <T> T getResponse(InputStream response, Class<T> classType, Gson gson) throws
             CouchDbException {
+        Reader reader = null;
         try {
-            InputStreamReader reader = new InputStreamReader(response, "UTF-8");
+            reader = new InputStreamReader(response, "UTF-8");
             return gson.fromJson(reader, classType);
         } catch (UnsupportedEncodingException e) {
             // This should never happen as every implementation of the java platform is required to support UTF-8.
             throw new RuntimeException(e);
+        } finally {
+            close(reader);
+            close(response);
         }
     }
 
@@ -233,12 +242,16 @@ final public class CouchDbUtil {
      */
     public static Map<String, EnumSet<Permissions>> getResponseMap(InputStream response, Gson
             gson, Type typeofT) throws CouchDbException {
+        Reader reader = null;
         try {
-            Reader reader = new InputStreamReader(response, "UTF-8");
+            reader = new InputStreamReader(response, "UTF-8");
             return gson.fromJson(reader, typeofT);
         } catch (UnsupportedEncodingException e) {
             // This should never happen as every implementation of the java platform is required to support UTF-8.
             throw new RuntimeException(e);
+        } finally {
+            close(reader);
+            close(response);
         }
     }
 }

--- a/cloudant-http/src/main/java/com/cloudant/http/HttpConnection.java
+++ b/cloudant-http/src/main/java/com/cloudant/http/HttpConnection.java
@@ -391,15 +391,7 @@ public class HttpConnection {
      * @throws IOException if there was a problem reading data from the server
      */
     public String responseAsString() throws IOException {
-        if (connection == null) {
-            throw new IOException("Attempted to read response from server before calling execute" +
-                    "()");
-        }
-        InputStream is = connection.getInputStream();
-        String string = IOUtils.toString(is);
-        is.close();
-        connection.disconnect();
-        return string;
+        return IOUtils.toString(responseAsBytes(), "UTF-8");
     }
 
     /**
@@ -414,20 +406,21 @@ public class HttpConnection {
      * @throws IOException if there was a problem reading data from the server
      */
     public byte[] responseAsBytes() throws IOException {
-        if (connection == null) {
-            throw new IOException("Attempted to read response from server before calling execute" +
-                    "()");
+        InputStream is = responseAsInputStream();
+        try {
+            return IOUtils.toByteArray(is);
+        } finally {
+            IOUtils.closeQuietly(is);
+            disconnect();
         }
-        InputStream is = connection.getInputStream();
-        byte[] bytes = IOUtils.toByteArray(is);
-        is.close();
-        connection.disconnect();
-        return bytes;
+
     }
 
     /**
      * <p>
-     * Return response body data from server as an InputStream.
+     * Return response body data from server as an InputStream. The InputStream must be closed
+     * after use to avoid leaking resources. Connection re-use may be improved if the entire stream
+     * has been read before closing.
      * </p>
      * <p>
      * <b>Important:</b> you must call <code>execute()</code> before calling this method.


### PR DESCRIPTION
## What

Added calls to close response streams in places they were missing.

## How

There were a couple of places where calls to `CouchDbUtil` were not
closing streams. `CouchDbUtil.getAsString` was already closing the
streams, so it makes sense if the rest of the util functions that use
streams do the same.

Added comments to remind users to close InputStreams in various places,
where the streams are returned outside of our control.

Moved stream closes into `finally` blocks to make sure they are called.
* Closed stream in a `finally` for `streamToString`
* Routed response calls in `HttpConnection` through fewer lines
  and then moved the remaining `close` into a `finally` block to
  make sure it is called.

## Testing

No new tests added. Existing tests continue to pass.

## Issues

Fixes #268
