### PR TITLE
277 leaked conns

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 # Unreleased
 - [NEW] Enabled `reduce` and other reduce related parameters to be set when using
   `MultipleRequestBuilder`.
+- [FIX] Consumed response streams in `client.shutdown()` and `CookieInterceptor` to prevent
+  connection leaks.
 
 # 2.5.1 (2016-07-19)
 - [IMPROVED] Made the 429 response code backoff optional and configurable. To enable the backoff add

--- a/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/CouchDbClient.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/CouchDbClient.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2011 lightcouch.org
- * Copyright (c) 2015 IBM Corp. All rights reserved.
+ * Copyright © 2015, 2016 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -24,6 +24,7 @@ import static com.cloudant.client.org.lightcouch.internal.CouchDbUtil.getRespons
 import com.cloudant.client.internal.DatabaseURIHelper;
 import com.cloudant.client.internal.URIBase;
 import com.cloudant.client.internal.util.DeserializationTypes;
+import com.cloudant.client.org.lightcouch.internal.CouchDbUtil;
 import com.cloudant.client.org.lightcouch.internal.GsonHelper;
 import com.cloudant.http.Http;
 import com.cloudant.http.HttpConnection;
@@ -143,9 +144,11 @@ public class CouchDbClient {
      */
     public void shutdown() {
         // Delete the cookie _session if there is one
-        execute(Http.DELETE(new URIBase(clientUri).path("_session")
+        Response response = executeToResponse(Http.DELETE(new URIBase(clientUri).path("_session")
                 .build()));
-
+        if (!response.isOk()) {
+            log.warning("Error deleting session on client shutdown.");
+        }
         // The execute method handles non-2xx response codes by throwing a CouchDbException.
     }
 

--- a/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/Response.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/Response.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2011 lightcouch.org
- * Copyright (c) 2015 IBM Corp. All rights reserved.
+ * Copyright © 2015, 2016 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -26,6 +26,7 @@ package com.cloudant.client.org.lightcouch;
  * @since 0.0.2
  */
 public class Response {
+    private boolean ok;
     private String id;
     private String rev;
 
@@ -74,5 +75,9 @@ public class Response {
 
     void setStatusCode(int code) {
         this.code = code;
+    }
+
+    boolean isOk() {
+        return ok;
     }
 }

--- a/cloudant-client/src/test/java/com/cloudant/tests/AttachmentsTest.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/AttachmentsTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2011 lightcouch.org
- * Copyright (c) 2015 IBM Corp. All rights reserved.
+ * Copyright © 2015, 2016 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -34,6 +34,7 @@ import com.cloudant.tests.util.DatabaseResource;
 import com.cloudant.tests.util.Utils;
 
 import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.io.IOUtils;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -105,17 +106,15 @@ public class AttachmentsTest {
                 .attachmentUri(response.getId(), "foo.txt"));
         InputStream in = clientResource.get().executeRequest(conn).responseAsInputStream();
 
-        ByteArrayOutputStream bytesOut = new ByteArrayOutputStream();
-        int n;
-        while ((n = in.read()) != -1) {
-            bytesOut.write(n);
+        try {
+
+            ByteArrayOutputStream bytesOut = new ByteArrayOutputStream();
+            IOUtils.copy(in, bytesOut);
+            byte[] bytesFromDB = bytesOut.toByteArray();
+            assertArrayEquals(bytesToDB, bytesFromDB);
+        } finally {
+            in.close();
         }
-        bytesOut.flush();
-        in.close();
-
-        byte[] bytesFromDB = bytesOut.toByteArray();
-
-        assertArrayEquals(bytesToDB, bytesFromDB);
     }
 
     @Test
@@ -136,17 +135,14 @@ public class AttachmentsTest {
                 .attachmentUri(response.getId(), "foo.txt"));
         InputStream in = clientResource.get().executeRequest(conn).responseAsInputStream();
 
-        ByteArrayOutputStream bytesOut = new ByteArrayOutputStream();
-        int n;
-        while ((n = in.read()) != -1) {
-            bytesOut.write(n);
+        try {
+            ByteArrayOutputStream bytesOut = new ByteArrayOutputStream();
+            IOUtils.copy(in, bytesOut);
+            byte[] bytesFromDB = bytesOut.toByteArray();
+            assertArrayEquals(bytesToDB, bytesFromDB);
+        } finally {
+            in.close();
         }
-        bytesOut.flush();
-        in.close();
-
-        byte[] bytesFromDB = bytesOut.toByteArray();
-
-        assertArrayEquals(bytesToDB, bytesFromDB);
     }
 
     @Test
@@ -174,18 +170,14 @@ public class AttachmentsTest {
                 .attachmentUri(response.getId(), attResponse.getRev(), "foo.txt"));
         InputStream in = clientResource.get().executeRequest(conn).responseAsInputStream();
 
-        ByteArrayOutputStream bytesOut = new ByteArrayOutputStream();
-        int n;
-        while ((n = in.read()) != -1) {
-            bytesOut.write(n);
+        try {
+            ByteArrayOutputStream bytesOut = new ByteArrayOutputStream();
+            IOUtils.copy(in, bytesOut);
+            byte[] bytesFromDB = bytesOut.toByteArray();
+            assertArrayEquals(bytesToDB, bytesFromDB);
+        } finally {
+            in.close();
         }
-        bytesOut.flush();
-        in.close();
-
-        byte[] bytesFromDB = bytesOut.toByteArray();
-
-        assertArrayEquals(bytesToDB, bytesFromDB);
-
     }
 
     @Test
@@ -202,17 +194,14 @@ public class AttachmentsTest {
                 .attachmentUri(response.getId(), "foo.txt"));
         InputStream in = clientResource.get().executeRequest(conn).responseAsInputStream();
 
-        ByteArrayOutputStream bytesOut = new ByteArrayOutputStream();
-        int n;
-        while ((n = in.read()) != -1) {
-            bytesOut.write(n);
+        try {
+            ByteArrayOutputStream bytesOut = new ByteArrayOutputStream();
+            IOUtils.copy(in, bytesOut);
+            byte[] bytesFromDB = bytesOut.toByteArray();
+            assertArrayEquals(bytesToDB, bytesFromDB);
+        } finally {
+            in.close();
         }
-        bytesOut.flush();
-        in.close();
-
-        byte[] bytesFromDB = bytesOut.toByteArray();
-
-        assertArrayEquals(bytesToDB, bytesFromDB);
     }
 
     @Test
@@ -232,17 +221,14 @@ public class AttachmentsTest {
                 .attachmentUri(response.getId(), "foo.txt"));
         InputStream in = clientResource.get().executeRequest(conn).responseAsInputStream();
 
-        ByteArrayOutputStream bytesOut = new ByteArrayOutputStream();
-        int n;
-        while ((n = in.read()) != -1) {
-            bytesOut.write(n);
+        try {
+            ByteArrayOutputStream bytesOut = new ByteArrayOutputStream();
+            IOUtils.copy(in, bytesOut);
+            byte[] bytesFromDB = bytesOut.toByteArray();
+            assertArrayEquals(bytesToDB, bytesFromDB);
+        } finally {
+            in.close();
         }
-        bytesOut.flush();
-        in.close();
-
-        byte[] bytesFromDB = bytesOut.toByteArray();
-
-        assertArrayEquals(bytesToDB, bytesFromDB);
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/cloudant-client/src/test/java/com/cloudant/tests/CloudantClientTests.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/CloudantClientTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 IBM Corp. All rights reserved.
+ * Copyright © 2015, 2016 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -136,7 +136,9 @@ public class CloudantClientTests {
             //instantiating the client performs a single post request
             CloudantClient client = CloudantClientHelper.newMockWebServerClientBuilder(server)
                     .build();
-            client.executeRequest(createPost(client.getBaseUri(), null, "application/json"));
+            String response = client.executeRequest(createPost(client.getBaseUri(), null,
+                    "application/json")).responseAsString();
+            assertTrue("There should be no response body on the mock response", response.isEmpty());
 
             //assert that the request had the expected header
             String userAgentHeader = server.takeRequest(10, TimeUnit.SECONDS)

--- a/cloudant-client/src/test/java/com/cloudant/tests/HttpProxyTest.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/HttpProxyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 IBM Corp. All rights reserved.
+ * Copyright © 2015, 2016 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -58,7 +58,8 @@ public class HttpProxyTest {
                 .proxyPassword(mockProxyPass)
                 .build();
 
-        client.executeRequest(Http.GET(client.getBaseUri()));
+        String response = client.executeRequest(Http.GET(client.getBaseUri())).responseAsString();
+        assertTrue("There should be no response body on the mock response", response.isEmpty());
         //if it wasn't a 20x then an exception should have been thrown by now
 
         RecordedRequest request = server.takeRequest(10, TimeUnit.SECONDS);

--- a/cloudant-client/src/test/java/com/cloudant/tests/LoggingTest.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/LoggingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 IBM Corp. All rights reserved.
+ * Copyright © 2016 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -84,7 +84,7 @@ public class LoggingTest {
     @Test
     public void httpLoggingEnabled() throws Exception {
         logger = setupLogger(HttpConnection.class, Level.ALL);
-        client.executeRequest(Http.GET(client.getBaseUri()));
+        client.executeRequest(Http.GET(client.getBaseUri())).responseAsString();
         assertTrue("There should be at least 1 log entry", handler.logEntries.size() > 0);
     }
 
@@ -100,7 +100,8 @@ public class LoggingTest {
         logger = setupLogger(HttpConnection.class, Level.FINE);
 
         // Make a request to testdb
-        client.executeRequest(Http.GET(new URL(client.getBaseUri().toString() + "/testdb")));
+        client.executeRequest(Http.GET(new URL(client.getBaseUri().toString() + "/testdb")))
+                .responseAsString();
 
         // Check there were two log messages one for request and one for response
         assertEquals("There should be 2 log messages", 2, handler.logEntries.size());
@@ -112,7 +113,7 @@ public class LoggingTest {
         int logsize = handler.logEntries.size();
 
         // Make a second request to a different URL and check that nothing else was logged
-        client.executeRequest(Http.GET(client.getBaseUri()));
+        client.executeRequest(Http.GET(client.getBaseUri())).responseAsString();
         assertEquals("There should have been no more log entries", logsize, handler.logEntries
                 .size());
     }
@@ -124,7 +125,7 @@ public class LoggingTest {
         logger = setupLogger(HttpConnection.class, Level.FINE);
 
         // Make a GET request
-        client.executeRequest(Http.GET(client.getBaseUri()));
+        client.executeRequest(Http.GET(client.getBaseUri())).responseAsString();
 
         // Check there were two log messages one for request and one for response
         assertEquals("There should be 2 log messages", 2, handler.logEntries.size());
@@ -136,7 +137,8 @@ public class LoggingTest {
         int logsize = handler.logEntries.size();
 
         // Make a PUT request to a different URL and check that nothing else was logged
-        client.executeRequest(Http.PUT(client.getBaseUri(), "text/plain").setRequestBody(""));
+        client.executeRequest(Http.PUT(client.getBaseUri(), "text/plain").setRequestBody(""))
+                .responseAsString();
         assertEquals("There should have been no more log entries", logsize, handler.logEntries
                 .size());
     }
@@ -147,7 +149,7 @@ public class LoggingTest {
         logger = setupLogger(HttpConnection.class, Level.FINE);
 
         // Make a GET request
-        client.executeRequest(Http.GET(client.getBaseUri()));
+        client.executeRequest(Http.GET(client.getBaseUri())).responseAsString();
 
         // Check there were two log messages one for request and one for response
         assertEquals("There should be 2 log messages", 2, handler.logEntries.size());
@@ -156,7 +158,8 @@ public class LoggingTest {
         assertHttpMessage("GET .* response 200 OK", 1);
 
         // Make a PUT request to a different URL and check that new messages are logged
-        client.executeRequest(Http.PUT(client.getBaseUri(), "text/plain").setRequestBody(""));
+        client.executeRequest(Http.PUT(client.getBaseUri(), "text/plain").setRequestBody(""))
+                .responseAsString();
 
         assertEquals("There should now be 4 log messages", 4, handler.logEntries.size());
         // Check the messages were the ones we expected

--- a/cloudant-client/src/test/java/com/cloudant/tests/ResponseTest.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/ResponseTest.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright © 2016 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
 package com.cloudant.tests;
 
 import static org.junit.Assert.assertEquals;
@@ -150,12 +163,13 @@ public class ResponseTest {
         try {
             // Make a good request, which will set up the session etc
             HttpConnection d = c.executeRequest(Http.GET(c.getBaseUri()));
+            d.responseAsString();
             assertTrue("The first request should succeed", d.getConnection().getResponseCode() / 100 == 2);
 
             // Enable the bad headers and expect the exception on the next request
             badHeaderEnabled.set(true);
-            c.executeRequest(Http.GET(c.getBaseUri()));
-            fail("A CouchDbException should be thrown");
+            String response = c.executeRequest(Http.GET(c.getBaseUri())).responseAsString();
+            fail("A CouchDbException should be thrown, but had response " + response);
         } catch (CouchDbException e) {
             //we expect a CouchDbException
 


### PR DESCRIPTION
## What

Consumed and closed response streams to avoid leaking connections.

## How

Made `CookieInterceptor` consume error streams in 4xx response cases.

Made `DELETE _session` request in `client.shutdown()` consume the response stream.

## Testing

Fixed tests that were not closing connection streams:
* `AttachmentsTest`
* `CloudantClientTests`
* `HttpProxyTest`
* `HttpTest`
* `LoggingTest`
* `ResponseTest`

Fixed `HttpTest.cookieInterceptorURLEncoding` test to use `mockWebServer` field instead of starting and stopping an additional instance.

No more instances of leaked connection message seen in logs.

## Issues

Fixes #277 