### PR TITLE
Added parameterised testing for both HttpURLConnection types

### DIFF
--- a/cloudant-client/build.gradle
+++ b/cloudant-client/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     //test dependencies
     testCompile group: 'junit', name: 'junit', version: '4.12'
     testCompile group: 'com.squareup.okhttp', name: 'mockwebserver', version: '2.7.5'
+    testCompile group: 'org.jmockit', name: 'jmockit', version: '1.25'
 }
 
 javadoc {
@@ -49,6 +50,17 @@ gradle.projectsEvaluated {
             String moduleVers = configurations.linkableJavadoc.resolvedConfiguration.firstLevelModuleDependencies.first().moduleVersion;
             options.linksOffline("http://static.javadoc.io/com.cloudant/$moduleName/$moduleVers","../$moduleName/build/docs/javadoc");
         }
+    }
+}
+
+tasks.withType(Test) {
+    def jMockit
+    doFirst {
+        // Do this when the task runs, not before because it will freeze the testCompile config.
+        jMockit = project.configurations.testCompile.find {
+            it.name.startsWith("jmockit-")
+        }
+        jvmArgs "-javaagent:${jMockit}"
     }
 }
 


### PR DESCRIPTION
## What

Always test both HttpURLConnection implementations with a parameterized test.

## How

Parameterised the `HttpTest` class to test using both `HttpURLConnection`
implementations.
Added JMockit to allow a `MockUp` of `OkHttpClientHttpUrlConnectionFactory` so it is possible to force the default `HttpURLConnection` even when okhttp is on the classpath.

## Testing

These are test changes, the tests pass for both implementations.

