### PR TITLE
Added functionality to remove attachment from a document by attachment name.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
   `MultipleRequestBuilder`.
 - [FIX] Consumed response streams in `client.shutdown()` and `CookieInterceptor` to prevent
   connection leaks.
+- [NEW] Added functionality to remove attachment from document by attachment name.
 
 # 2.5.1 (2016-07-19)
 - [IMPROVED] Made the 429 response code backoff optional and configurable. To enable the backoff add

--- a/cloudant-client/src/main/java/com/cloudant/client/api/Database.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/Database.java
@@ -1010,6 +1010,59 @@ public class Database {
     }
 
     /**
+     * Removes an attachment from the specified document.
+     * <p>The object must have the correct {@code _id} and {@code _rev} values.</p>
+     * <P>Example usage:</P>
+     * <pre>
+     * {@code
+     * //get a Bar object from the database
+     * Bar bar = db.find(Bar.class, "exampleId");
+     * String attachmentName = "example.jpg";
+     * //now remove the remote Bar
+     * Response response = db.removeAttachment(bar, attachmentName);
+     * }
+     * </pre>
+     *
+     * @param object the document to remove as an object
+     * @param attachmentName the attachment name to remove
+     * @return {@link com.cloudant.client.api.model.Response}
+     * @throws NoDocumentException If the document is not found in the database.
+     * @see <a target="_blank" href="https://docs.cloudant.com/attachments.html#delete">Documents -
+     * delete</a>
+     */
+    public com.cloudant.client.api.model.Response removeAttachment(Object object, String attachmentName) {
+        Response couchDbResponse = db.removeAttachment(object, attachmentName);
+        com.cloudant.client.api.model.Response response = new com.cloudant.client.api.model
+                .Response(couchDbResponse);
+        return response;
+    }
+
+    /**
+     * Removes the attachment from a document the specified {@code _id} and {@code _rev} and {@code attachmentName}
+     * values.
+     * <P>Example usage:</P>
+     * <pre>
+     * {@code
+     * Response response = db.removeAttachment("exampleId", "1-12345exampleRev", "example.jpg");
+     * }
+     * </pre>
+     *
+     * @param id  the document _id field
+     * @param rev the document _rev field
+     * @param attachmentName the attachment name
+     * @return {@link com.cloudant.client.api.model.Response}
+     * @throws DocumentConflictException if the attachment cannot be saved because of a conflict
+     * @see <a target="_blank" href="https://docs.cloudant.com/attachments.html#delete">Documents -
+     * delete</a>
+     */
+    public com.cloudant.client.api.model.Response removeAttachment(String id, String rev, String attachmentName) {
+        Response couchDbResponse = db.removeAttachment(id, rev, attachmentName);
+        com.cloudant.client.api.model.Response response = new com.cloudant.client.api.model
+                .Response(couchDbResponse);
+        return response;
+    }
+
+    /**
      * Invokes an Update Handler.
      * <P>Example usage:</P>
      * <pre>

--- a/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/CouchDatabaseBase.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/CouchDatabaseBase.java
@@ -348,6 +348,41 @@ public abstract class CouchDatabaseBase {
     }
 
     /**
+     * Removes an attachment from a document.
+     * <p>The object must have the correct <code>_id</code> and <code>_rev</code> and <code>attachmentName</code> values.
+     *
+     * @param object The document to remove attachment as object.
+     * @param attachmentName The attachment name to remove.
+     * @return {@link Response}
+     * @throws NoDocumentException If the document is not found in the database.
+     */
+    public Response removeAttachment(Object object, String attachmentName) {
+        assertNotEmpty(object, "object");
+        JsonObject jsonObject = getGson().toJsonTree(object).getAsJsonObject();
+        final String id = getAsString(jsonObject, "_id");
+        final String rev = getAsString(jsonObject, "_rev");
+        return removeAttachment(id, rev, attachmentName);
+    }
+
+    /**
+     * Removes an attachment from a document given both a document <code>_id</code> and
+     * <code>_rev</code> and <code>attachmentName</code> values.
+     *
+     * @param id  The document _id field.
+     * @param rev The document _rev field.
+     * @param attachmentName The document attachment field.
+     * @return {@link Response}
+     * @throws DocumentConflictException
+     */
+    public Response removeAttachment(String id, String rev, String attachmentName) {
+        assertNotEmpty(id, "id");
+        assertNotEmpty(rev, "rev");
+        assertNotEmpty(attachmentName, "attachmentName");
+        final URI uri = new DatabaseURIHelper(dbUri).attachmentUri(id, rev, attachmentName);
+        return couchDbClient.delete(uri);
+    }
+
+    /**
      * Invokes an Update Handler.
      * <pre>
      * Params params = new Params()

--- a/cloudant-client/src/test/java/com/cloudant/tests/AttachmentsTest.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/AttachmentsTest.java
@@ -14,11 +14,13 @@
  */
 package com.cloudant.tests;
 
+import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertThat;
 
 import com.cloudant.client.api.Database;
 import com.cloudant.client.api.model.Attachment;
@@ -251,5 +253,26 @@ public class AttachmentsTest {
         byte[] bytesToDB = "binary data".getBytes();
         ByteArrayInputStream bytesIn = new ByteArrayInputStream(bytesToDB);
         Response response = db.saveAttachment(bytesIn, "foo.txt", "text/plain", docId, "");
+    }
+
+    @Test
+    public void removeAttachment() {
+        String attachmentName = "txt_1.txt";
+        Attachment attachment1 = new Attachment("VGhpcyBpcyBhIGJhc2U2NCBlbmNvZGVkIHRleHQ=",
+                "text/plain");
+
+        Bar bar = new Bar(); // Bar extends Document
+        bar.addAttachment(attachmentName, attachment1);
+
+        Response response = db.save(bar);
+
+        Bar bar2 = db.find(Bar.class, response.getId(), new Params().attachments());
+        String base64Data = bar2.getAttachments().get("txt_1.txt").getData();
+        assertNotNull(base64Data);
+
+        response = db.removeAttachment(bar2, attachmentName);
+
+        Bar bar3 = db.find(Bar.class, response.getId(), new Params().attachments());
+        assertNull(bar3.getAttachments());
     }
 }


### PR DESCRIPTION
Thanks for your hard work, please ensure all items are complete before opening.

- [x] You have signed the CLA as per the instructions in [CONTRIBUTING.md](https://github.com/cloudant/java-cloudant/blob/master/CONTRIBUTING.md#contributor-license-agreement)
- [X] You have added tests for any code changes
- [X] You have updated the [CHANGES.md](https://github.com/cloudant/java-cloudant/blob/master/CHANGES.md) 
- [X] You have completed the PR template below:

## What

Added functionality to cloudant-client to remove attachment from a document by attachment name.

## How

Needed ability to remove an attachment from a document by attachment name.

Modeled new functionality after the remove() methods that remove a document from the database. Leveraged functionality already available in the REST API to sent a delete request with attachment name and _rev as query parameter (info found at https://docs.cloudant.com/attachments.html#delete).

## Testing

Added test to com.cloudant.tests.AttachmentTest that creates a document, adds an attachment, verifies attachment has been added, and then calls the new removeAttachment method. Asserts the bar.getAttachments() is null after removal.

## Issues

N/A