### PR TITLE
Added functionality to remove attachment from a document by attachment name.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
   `MultipleRequestBuilder`.
 - [FIX] Consumed response streams in `client.shutdown()` and `CookieInterceptor` to prevent
   connection leaks.
+- [NEW] Added functionality to remove attachment from document by attachment name.
 
 # 2.5.1 (2016-07-19)
 - [IMPROVED] Made the 429 response code backoff optional and configurable. To enable the backoff add

--- a/cloudant-client/src/main/java/com/cloudant/client/api/Database.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/Database.java
@@ -1010,6 +1010,61 @@ public class Database {
     }
 
     /**
+     * Removes an attachment from the specified document.
+     * <p>The object must have the correct {@code _id} and {@code _rev} values.</p>
+     * <P>Example usage:</P>
+     * <pre>
+     * {@code
+     * //get a Bar object from the database
+     * Bar bar = db.find(Bar.class, "exampleId");
+     * String attachmentName = "example.jpg";
+     * //now remove the remote Bar attachment
+     * Response response = db.removeAttachment(bar, attachmentName);
+     * }
+     * </pre>
+     *
+     * @param object the document to remove as an object
+     * @param attachmentName the attachment name to remove
+     * @return {@link com.cloudant.client.api.model.Response}
+     * @throws NoDocumentException If the document is not found in the database.
+     * @throws DocumentConflictException If a conflict is detected during the removal.
+     * @see <a target="_blank" href="https://docs.cloudant.com/attachments.html#delete">Documents -
+     * delete</a>
+     */
+    public com.cloudant.client.api.model.Response removeAttachment(Object object, String attachmentName) {
+        Response couchDbResponse = db.removeAttachment(object, attachmentName);
+        com.cloudant.client.api.model.Response response = new com.cloudant.client.api.model
+                .Response(couchDbResponse);
+        return response;
+    }
+
+    /**
+     * Removes the attachment from a document the specified {@code _id} and {@code _rev} and {@code attachmentName}
+     * values.
+     * <P>Example usage:</P>
+     * <pre>
+     * {@code
+     * Response response = db.removeAttachment("exampleId", "1-12345exampleRev", "example.jpg");
+     * }
+     * </pre>
+     *
+     * @param id  the document _id field
+     * @param rev the document _rev field
+     * @param attachmentName the attachment name
+     * @return {@link com.cloudant.client.api.model.Response}
+     * @throws NoDocumentException If the document is not found in the database.
+     * @throws DocumentConflictException if the attachment cannot be removed because of a conflict
+     * @see <a target="_blank" href="https://docs.cloudant.com/attachments.html#delete">Documents -
+     * delete</a>
+     */
+    public com.cloudant.client.api.model.Response removeAttachment(String id, String rev, String attachmentName) {
+        Response couchDbResponse = db.removeAttachment(id, rev, attachmentName);
+        com.cloudant.client.api.model.Response response = new com.cloudant.client.api.model
+                .Response(couchDbResponse);
+        return response;
+    }
+
+    /**
      * Invokes an Update Handler.
      * <P>Example usage:</P>
      * <pre>

--- a/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/CouchDatabaseBase.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/CouchDatabaseBase.java
@@ -348,6 +348,43 @@ public abstract class CouchDatabaseBase {
     }
 
     /**
+     * Removes an attachment from a document.
+     * <p>The object must have the correct <code>_id</code> and <code>_rev</code> and <code>attachmentName</code> values.
+     *
+     * @param object The document to remove attachment as object.
+     * @param attachmentName The attachment name to remove.
+     * @return {@link Response}
+     * @throws NoDocumentException If the document is not found in the database.
+     * @throws DocumentConflictException If a conflict is found during attachment removal.
+     */
+    public Response removeAttachment(Object object, String attachmentName) {
+        assertNotEmpty(object, "object");
+        JsonObject jsonObject = getGson().toJsonTree(object).getAsJsonObject();
+        final String id = getAsString(jsonObject, "_id");
+        final String rev = getAsString(jsonObject, "_rev");
+        return removeAttachment(id, rev, attachmentName);
+    }
+
+    /**
+     * Removes an attachment from a document given both a document <code>_id</code> and
+     * <code>_rev</code> and <code>attachmentName</code> values.
+     *
+     * @param id  The document _id field.
+     * @param rev The document _rev field.
+     * @param attachmentName The document attachment field.
+     * @return {@link Response}
+     * @throws NoDocumentException If the document is not found in the database.
+     * @throws DocumentConflictException If a conflict is found during attachment removal.
+     */
+    public Response removeAttachment(String id, String rev, String attachmentName) {
+        assertNotEmpty(id, "id");
+        assertNotEmpty(rev, "rev");
+        assertNotEmpty(attachmentName, "attachmentName");
+        final URI uri = new DatabaseURIHelper(dbUri).attachmentUri(id, rev, attachmentName);
+        return couchDbClient.delete(uri);
+    }
+
+    /**
      * Invokes an Update Handler.
      * <pre>
      * Params params = new Params()


### PR DESCRIPTION
Thanks for your hard work, please ensure all items are complete before opening.

- [x] You have signed the CLA as per the instructions in [CONTRIBUTING.md](https://github.com/cloudant/java-cloudant/blob/master/CONTRIBUTING.md#contributor-license-agreement)
- [X] You have added tests for any code changes
- [X] You have updated the [CHANGES.md](https://github.com/cloudant/java-cloudant/blob/master/CHANGES.md) 
- [X] You have completed the PR template below:

## What

Added functionality to cloudant-client to remove attachment from a document by attachment name.

## How

Needed ability to remove an attachment from a document by attachment name.

Modeled new functionality after the remove() methods that remove a document from the database. Leveraged functionality already available in the REST API to send a delete request with attachment name and _rev as query parameter (info found at https://docs.cloudant.com/attachments.html#delete).

## Testing

Added tests to com.cloudant.tests.AttachmentTest:

1) Creates a document, adds an attachment, verifies attachment has been added, and then calls the new removeAttachment method. Asserts the bar.getAttachments() is null after removal.

2) Test variant where id is null

3) Test variant where rev is null

4) Test variant where attachmentName is null

## Issues

N/A