### PR TITLE
282 proxy auth

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,9 @@
 - [FIX] Consumed response streams in `client.shutdown()` and `CookieInterceptor` to prevent
   connection leaks.
 - [NEW] Added functionality to remove attachment from document by attachment name.
+- [FIX] Issue authenticating with a proxy server when connecting to a HTTPS database server.
+- [FIX] Throw an `IllegalArgumentException` if using an unsupported proxy type.
+- [IMPROVED] Documentation for connecting to and authenticating with proxy servers.
 
 # 2.5.1 (2016-07-19)
 - [IMPROVED] Made the 429 response code backoff optional and configurable. To enable the backoff add

--- a/cloudant-client/build.gradle
+++ b/cloudant-client/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     testCompile group: 'junit', name: 'junit', version: '4.12'
     testCompile group: 'com.squareup.okhttp', name: 'mockwebserver', version: '2.7.5'
     testCompile group: 'org.jmockit', name: 'jmockit', version: '1.25'
+    testCompile group: 'org.littleshoot', name: 'littleproxy', version: '1.1.0'
 }
 
 javadoc {

--- a/cloudant-client/overview.html
+++ b/cloudant-client/overview.html
@@ -66,6 +66,7 @@ There is no need to add a head/title as that is provided by Javadoc.
             <LI><a href="#J2EE">J2EE</a></LI>
             <LI><a href="#Logging">Logging</a></LI>
             <LI><a href="#Replays">Replays</a></LI>
+            <LI><a href="#Proxies">Proxies</a></LI>
         </OL>
     <LI><a href="#Project">Project</a></LI>
 </OL>
@@ -545,7 +546,7 @@ library to query a view.
 <OL>
     <LI>Configuring using a properties file (see also this heavily commented example
         <a href="{@docroot}logging.properties" target="_blank">logging.properties</a> file).
-    </P>
+        </P>
         <pre>
             {@code
             # "handlers" specifies a comma separated list of log Handler
@@ -631,6 +632,95 @@ library to query a view.
     response then the expected {@link com.cloudant.client.org.lightcouch.TooManyRequestsException}
     is thrown as would be the case if no interceptor was configured.
 </P>
+
+<h2 id="Proxies">Proxies</h2>
+
+<P>
+    This table provides a summary of the proxy configuration options.
+</P>
+<table border=true>
+    <tr>
+        <th>Server type</th>
+        <th rowspan="2">HTTP</th>
+        <th rowspan="2">HTTPS</th>
+    </tr>
+    <tr>
+        <th>Proxy type</th>
+    </tr>
+    <tr>
+        <th>HTTP (no authentication)</th>
+        <td>
+        <pre>
+        {@code
+          ClientBuilder.url("http://myserver.example")
+            .proxyURL(new URL("http://myproxy.example"))
+        }
+        </pre>
+        </td>
+        <td>
+      <pre>
+      {@code
+        ClientBuilder.url("https://myserver.example") // or .account("exampleAccount")
+          .proxyURL(new URL("http://myproxy.example"))
+      }
+      </pre>
+        </td>
+    </tr>
+    <tr>
+        <th>HTTP (authentication)</th>
+        <td>
+          <pre>
+          {@code
+            ClientBuilder.url("http://myserver.example")
+              .proxyURL(new URL("http://myproxy.example"))
+              .proxyUser("exampleProxyUser")
+              .proxyPassword("exampleProxyPass")
+          }
+          </pre>
+        </td>
+        <td>
+            <p>Default HttpURLConnection:</p>
+      <pre>
+      {@code
+        ClientBuilder.url("https://myserver.example") // or .account("exampleAccount")
+          .proxyURL(new URL("http://myproxy.example"))
+
+        // Configure the JVM Authenticator
+        // The library does not do this automatically because it applies JVM wide
+        Authenticator.setDefault(new Authenticator() {
+
+            protected PasswordAuthentication getPasswordAuthentication() {
+                return new PasswordAuthentication("exampleProxyUser", "exampleProxyPassword".toCharArray());
+            }
+        });
+      }
+      </pre>
+            <p>Using okhttp:</p>
+      <pre>
+      {@code
+        ClientBuilder.url("https://myserver.example") // or .account("exampleAccount")
+          .proxyURL(new URL("http://myproxy.example"))
+          .proxyUser("exampleProxyUser")
+          .proxyPassword("exampleProxyPass")
+      }
+      </pre>
+        </td>
+    </tr>
+    <tr>
+        <th>HTTPS</th>
+        <td colspan="2">SSL proxies are not supported by the {@link java.net.Proxy}. This means that
+            <strong>proxy authentication always happens in the clear</strong>. Note that client
+            requests to a HTTPS server are always encrypted because a SSL tunnel is established
+            through a HTTP proxy.
+        </td>
+    </tr>
+    <tr>
+        <th>SOCKS</th>
+        <td colspan="2">SOCKS proxies are not supported internally by the {@code CloudantClient}. It
+            may be possible to use a JVM or system level proxy configuration, but this is untested.
+        </td>
+    </tr>
+</table>
 
 <h1 id="Project">Project</h1>
 

--- a/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/CouchDbClient.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/CouchDbClient.java
@@ -113,6 +113,9 @@ public class CouchDbClient {
         //set the proxy if it has been configured
         if (props.getProxyURL() != null) {
             factory.setProxy(props.getProxyURL());
+            if (props.getProxyAuthentication() != null) {
+                factory.setProxyAuthentication(props.getProxyAuthentication());
+            }
         }
 
         this.requestInterceptors = new ArrayList<HttpConnectionRequestInterceptor>();

--- a/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/CouchDbProperties.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/CouchDbProperties.java
@@ -18,6 +18,7 @@ package com.cloudant.client.org.lightcouch;
 import com.cloudant.http.HttpConnectionRequestInterceptor;
 import com.cloudant.http.HttpConnectionResponseInterceptor;
 
+import java.net.PasswordAuthentication;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -36,7 +37,9 @@ public class CouchDbProperties {
 
     //default to 6 connections
     private int maxConnections = 6;
+
     private URL proxyURL;
+    private PasswordAuthentication proxyAuthentication = null;
 
     private List<HttpConnectionRequestInterceptor> requestInterceptors = new ArrayList
             <HttpConnectionRequestInterceptor>();
@@ -86,6 +89,15 @@ public class CouchDbProperties {
     public CouchDbProperties addResponseInterceptors(HttpConnectionResponseInterceptor
                                                              responseInterceptors) {
         this.responseInterceptors.addAll(Arrays.asList(responseInterceptors));
+        return this;
+    }
+
+    public PasswordAuthentication getProxyAuthentication() {
+        return proxyAuthentication;
+    }
+
+    public CouchDbProperties setProxyAuthentication(PasswordAuthentication authentication) {
+        this.proxyAuthentication = authentication;
         return this;
     }
 }

--- a/cloudant-client/src/test/java/com/cloudant/tests/HttpProxyTest.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/HttpProxyTest.java
@@ -18,67 +18,239 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import com.cloudant.client.api.ClientBuilder;
 import com.cloudant.client.api.CloudantClient;
 import com.cloudant.http.Http;
-import com.cloudant.http.interceptors.ProxyAuthInterceptor;
+import com.cloudant.http.internal.ok.OkHttpClientHttpUrlConnectionFactory;
+import com.cloudant.tests.util.MockWebServerResources;
+import com.squareup.okhttp.mockwebserver.Dispatcher;
 import com.squareup.okhttp.mockwebserver.MockResponse;
 import com.squareup.okhttp.mockwebserver.MockWebServer;
 import com.squareup.okhttp.mockwebserver.RecordedRequest;
 
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.littleshoot.proxy.HttpProxyServer;
+import org.littleshoot.proxy.HttpProxyServerBootstrap;
+import org.littleshoot.proxy.ProxyAuthenticator;
+import org.littleshoot.proxy.SslEngineSource;
+import org.littleshoot.proxy.impl.DefaultHttpProxyServer;
 
+import java.net.Authenticator;
+import java.net.InetSocketAddress;
+import java.net.PasswordAuthentication;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
+import javax.net.ssl.SSLEngine;
+
+
+@RunWith(Parameterized.class)
 public class HttpProxyTest {
+
+    @Parameterized.Parameters(name = "okhttp: {0}; secure proxy: {1}; https server: {2}; proxy " +
+            "auth: {3}")
+    public static List<Object[]> combinations() {
+        boolean[] tf = new boolean[]{true, false};
+        List<Object[]> combos = new ArrayList<Object[]>();
+        for (boolean okUsable : tf) {
+            for (boolean secureProxy : new boolean[]{false}) {
+                // AFAICT there is no way to instruct HttpURLConnection to connect via SSL to a
+                // proxy server - so for now we just test an unencrypted proxy.
+                // Note this is independent of the SSL tunnelling to an https server and influences
+                // only requests between client and proxy. With an https server client requests are
+                // tunnelled directly to the https server, other than the original HTTP CONNECT
+                // request. The reason for using a SSL proxy would be to encrypt proxy auth creds
+                // but it appears this scenario is not readily supported.
+                for (boolean httpsServer : tf) {
+                    for (boolean proxyAuth : tf) {
+                        combos.add(new Object[]{okUsable, secureProxy, httpsServer, proxyAuth});
+                    }
+                }
+            }
+        }
+        return combos;
+    }
+
+    /**
+     * A parameter governing whether to allow okhttp or not. This lets us exercise both
+     * HttpURLConnection types in these tests.
+     */
+    @Parameterized.Parameter(0)
+    public boolean okUsable;
+
+    @Before
+    public void changeHttpConnectionFactory() throws Exception {
+        if (!okUsable) {
+            // New up the mock that will stop okhttp's factory being used
+            new HttpTest.OkFactoryBlocker();
+        }
+        // Verify that we are getting the behaviour we expect.
+        assertEquals("The OK usable value was not what was expected for the test parameter.",
+                okUsable, OkHttpClientHttpUrlConnectionFactory.isOkUsable());
+    }
+
+    @Parameterized.Parameter(1)
+    public boolean secureProxy;
+
+    @Parameterized.Parameter(2)
+    public boolean useHttpsServer;
+
+    @Parameterized.Parameter(3)
+    public boolean useProxyAuth;
 
     @Rule
     public MockWebServer server = new MockWebServer();
 
+    HttpProxyServer proxy;
+    String mockProxyUser = "alpha";
+    String mockProxyPass = "alphaPass";
+
     /**
-     * This test validates that proxy configuration is correctly used.
-     * It does not test the actual function of a proxy, just that the URL and authentication
-     * headers are set as expected.
+     * Enables https on the mock web server receiving our requests if useHttpsServer is true.
+     *
+     * @throws Exception
+     */
+    @Before
+    public void setupMockServerSSLIfNeeded() throws Exception {
+        if (useHttpsServer) {
+            server.useHttps(MockWebServerResources.getSSLSocketFactory(), false);
+        }
+    }
+
+    /**
+     * Starts a littleproxy instance that will proxy the requests. Applies appropriate configuration
+     * options to the proxy based on the test parameters.
+     *
+     * @throws Exception
+     */
+    @Before
+    public void setupAndStartProxy() throws Exception {
+
+        HttpProxyServerBootstrap proxyBoostrap = DefaultHttpProxyServer.bootstrap()
+                .withAllowLocalOnly(true) // only run on localhost
+                .withAuthenticateSslClients(false); // we aren't checking client certs
+
+        if (useProxyAuth) {
+            // check the proxy user and password
+            ProxyAuthenticator pa = new ProxyAuthenticator() {
+                @Override
+                public boolean authenticate(String userName, String password) {
+                    return (mockProxyUser.equals(userName) && mockProxyPass.equals(password));
+                }
+
+                @Override
+                public String getRealm() {
+                    return null;
+                }
+            };
+            proxyBoostrap.withProxyAuthenticator(pa);
+        }
+
+        if (secureProxy) {
+            proxyBoostrap.withSslEngineSource(new SslEngineSource() {
+                @Override
+                public SSLEngine newSslEngine() {
+                    return MockWebServerResources.getSSLContext().createSSLEngine();
+                }
+
+                @Override
+                public SSLEngine newSslEngine(String peerHost, int peerPort) {
+                    return MockWebServerResources.getSSLContext().createSSLEngine(peerHost,
+                            peerPort);
+                }
+            });
+        }
+
+        // Start the proxy server
+        proxy = proxyBoostrap.start();
+    }
+
+    /**
+     * Shutdown the proxy server at the end of the test.
+     *
+     * @throws Exception
+     */
+    @After
+    public void shutdownProxy() throws Exception {
+        proxy.stop();
+    }
+
+    /**
+     * The Proxy-Authorization header that we add to requests gets encrypted in the case of a SSL
+     * tunnel connection to a HTTPS server. The default HttpURLConnection does not add the header
+     * to the CONNECT request so in that case we require an Authenticator to provide credentials
+     * to the proxy server. The client code does not set an Authenticator automatically because
+     * it is a global default so it must be set by the application developer or system
+     * administrators in accordance with their environment. For the purposes of this test we can
+     * add and remove the Authenticator before and after testing.
+     */
+    @Before
+    public void setAuthenticatorIfNeeded() {
+        // If we are not using okhttp and we have an https server and a proxy that needs auth then
+        // we need to set the default Authenticator
+        if (useProxyAuth && useHttpsServer && !okUsable) {
+            Authenticator.setDefault(new Authenticator() {
+                @Override
+                protected PasswordAuthentication getPasswordAuthentication() {
+                    return new PasswordAuthentication(mockProxyUser, mockProxyPass.toCharArray());
+                }
+            });
+        }
+    }
+
+    /**
+     * Reset the Authenticator after the test.
+     *
+     * @see #setAuthenticatorIfNeeded()
+     */
+    @After
+    public void resetAuthenticator() {
+        // If we are not using okhttp and we have an https server and a proxy that needs auth then
+        // we need to set the default Authenticator
+        if (useProxyAuth && useHttpsServer && !okUsable) {
+            Authenticator.setDefault(null);
+        }
+    }
+
+    /**
+     * This test validates that a request can successfully traverse a proxy to our mock server.
      */
     @Test
-    public void proxyConfiguration() throws Exception {
+    public void proxiedRequest() throws Exception {
 
         //mock a 200 OK
-        server.enqueue(new MockResponse());
+        server.setDispatcher(new Dispatcher() {
+            @Override
+            public MockResponse dispatch(RecordedRequest request) throws InterruptedException {
+                return new MockResponse();
+            }
+        });
 
-        //instantiating the client performs a single post request
-        //create a client with a bogus address (TEST-NET)
-        String mockProxyUser = "alpha";
-        String mockProxyPass = "alphaPass";
-        CloudantClient client = CloudantClientHelper.newTestAddressClient()
-                .proxyURL(server.url("/").url())
-                .proxyUser(mockProxyUser)
-                .proxyPassword(mockProxyPass)
-                .build();
+        InetSocketAddress address = proxy.getListenAddress();
+        URL proxyUrl = new URL((secureProxy) ? "https" : "http", address.getHostName(), address
+                .getPort(), "/");
+        ClientBuilder builder = CloudantClientHelper.newMockWebServerClientBuilder(server)
+                .proxyURL(proxyUrl);
+        if (useProxyAuth) {
+            builder.proxyUser(mockProxyUser).proxyPassword(mockProxyPass);
+        }
+
+        // We don't use SSL authentication for this test
+        CloudantClient client = builder.disableSSLAuthentication().build();
 
         String response = client.executeRequest(Http.GET(client.getBaseUri())).responseAsString();
+
         assertTrue("There should be no response body on the mock response", response.isEmpty());
         //if it wasn't a 20x then an exception should have been thrown by now
 
         RecordedRequest request = server.takeRequest(10, TimeUnit.SECONDS);
-        String proxyAuthHeader = request.getHeader("Proxy-Authorization");
-        assertNotNull("The Proxy-Authorization header should be present", proxyAuthHeader);
-
-        Matcher m = Pattern.compile("Basic (.*)", Pattern
-                .CASE_INSENSITIVE).matcher(proxyAuthHeader);
-        assertTrue("The Proxy-Authorization header should match the pattern", m.matches());
-        assertEquals("There should be 1 group for the value", 1, m.groupCount());
-
-        //create an interceptor with the same creds so we can easily get the expected value
-        final String encodedCreds = new ProxyAuthInterceptor(mockProxyUser, mockProxyPass) {
-            String getEncodedCreds() {
-                return encodedAuth;
-            }
-        }.getEncodedCreds();
-
-        assertEquals("The encoded credentials should match the expected value",
-                encodedCreds, m.group(1));
+        assertNotNull(request);
     }
 }

--- a/cloudant-client/src/test/java/com/cloudant/tests/HttpTest.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/HttpTest.java
@@ -862,4 +862,21 @@ public class HttpTest {
         assertEquals("There should be 5 request attempts", 5, mockWebServer
                 .getRequestCount());
     }
+
+    /**
+     * Test that an IllegalArgumentException is thrown if an https proxy address is used. SSL proxies
+     * are not supported. HTTP proxies can tunnel SSL connections to HTTPS servers.
+     *
+     * @throws Exception
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void httpsProxyIllegalArgumentException() throws Exception {
+
+        // Get a client pointing to an https proxy
+        CloudantClient client = CloudantClientHelper.newMockWebServerClientBuilder(mockWebServer)
+                .proxyURL(new URL("https://192.0.2.0")).build();
+
+        String response = client.executeRequest(Http.GET(client.getBaseUri())).responseAsString();
+        fail("There should be an IllegalStateException for an https proxy.");
+    }
 }

--- a/cloudant-client/src/test/java/com/cloudant/tests/util/MockWebServerResources.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/util/MockWebServerResources.java
@@ -54,7 +54,10 @@ public class MockWebServerResources {
     private static String KEYSTORE_PASSWORD = "password";
     private static String KEY_PASSWORD = "password";
 
-    public static SSLSocketFactory getSSLSocketFactory() {
+    private static SSLContext sslContext = null;
+
+    public static SSLContext getSSLContext() {
+        if (sslContext != null) return sslContext;
         try {
             KeyStore keystore = KeyStore.getInstance("JKS");
             keystore.load(new FileInputStream(KEYSTORE_FILE), KEYSTORE_PASSWORD
@@ -62,13 +65,17 @@ public class MockWebServerResources {
             KeyManagerFactory kmf = KeyManagerFactory.getInstance(KeyManagerFactory
                     .getDefaultAlgorithm());
             kmf.init(keystore, KEY_PASSWORD.toCharArray());
-            SSLContext sslContext = SSLContext.getInstance("TLS");
+            sslContext = SSLContext.getInstance("TLS");
             sslContext.init(kmf.getKeyManagers(), null, null);
-            return sslContext.getSocketFactory();
+            return sslContext;
         } catch (Exception e) {
             logger.log(Level.SEVERE, "Error initializing test SSLSocketFactory", e);
             return null;
         }
+    }
+
+    public static SSLSocketFactory getSSLSocketFactory() {
+        return (getSSLContext() != null) ? getSSLContext().getSocketFactory() : null;
     }
 
     /**

--- a/cloudant-http/src/main/java/com/cloudant/http/HttpConnection.java
+++ b/cloudant-http/src/main/java/com/cloudant/http/HttpConnection.java
@@ -22,6 +22,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.HttpURLConnection;
+import java.net.PasswordAuthentication;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -479,6 +480,14 @@ public class HttpConnection {
          * @param proxyUrl the URL of the HTTP proxy to use for this connection
          */
         void setProxy(URL proxyUrl);
+
+        /**
+         * Set an authenticator to be used to provide credentials for the connection to the
+         * proxy server defined by the URL passed to {@link #setProxy(URL)}.
+         *
+         * @param proxyAuthentication the password authentication to use for the proxy connection
+         */
+        void setProxyAuthentication(PasswordAuthentication proxyAuthentication);
     }
 
     /**

--- a/cloudant-http/src/main/java/com/cloudant/http/interceptors/ProxyAuthInterceptor.java
+++ b/cloudant-http/src/main/java/com/cloudant/http/interceptors/ProxyAuthInterceptor.java
@@ -16,8 +16,10 @@ package com.cloudant.http.interceptors;
 
 public class ProxyAuthInterceptor extends BasicAuthInterceptor {
 
+    public static final String PROXY_AUTH_HEADER = "Proxy-Authorization";
+
     public ProxyAuthInterceptor(String proxyUser, String proxyPassword) {
-        super(proxyUser + ":" + proxyPassword, "Proxy-Authorization");
+        super(proxyUser + ":" + proxyPassword, PROXY_AUTH_HEADER);
     }
 
 }

--- a/cloudant-http/src/main/java/com/cloudant/http/internal/DefaultHttpUrlConnectionFactory.java
+++ b/cloudant-http/src/main/java/com/cloudant/http/internal/DefaultHttpUrlConnectionFactory.java
@@ -19,8 +19,10 @@ import com.cloudant.http.HttpConnection;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.InetSocketAddress;
+import java.net.PasswordAuthentication;
 import java.net.Proxy;
 import java.net.URL;
+import java.util.Locale;
 import java.util.logging.Logger;
 
 public class DefaultHttpUrlConnectionFactory implements HttpConnection.HttpUrlConnectionFactory {
@@ -41,13 +43,21 @@ public class DefaultHttpUrlConnectionFactory implements HttpConnection.HttpUrlCo
 
     @Override
     public void setProxy(URL proxyUrl) {
-        if ("http".equals(proxyUrl.getProtocol()) || "https".equals(proxyUrl.getProtocol
-                ())) {
+        if ("http".equals(proxyUrl.getProtocol())) {
             proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(proxyUrl.getHost(),
                     proxyUrl.getPort()));
             logger.config(String.format("Configured HTTP proxy url %s", proxyUrl));
         } else {
-            throw new IllegalArgumentException("Only HTTP type proxies are supported");
+            throw new IllegalArgumentException(String.format(Locale.ENGLISH, "The proxy URL %s " +
+                    "is invalid. Only HTTP type proxies are supported.", proxyUrl));
         }
+    }
+
+    @Override
+    public void setProxyAuthentication(final PasswordAuthentication proxyAuthentication) {
+        // Currently a no-op.
+        // HttpURLConnection doesn't allow the setting of an Authenticator per instance and it would
+        // be irresponsible to set the default Authenticator because it applies globally and we
+        // might disrupt other applications in the JVM.
     }
 }


### PR DESCRIPTION
## What

Fixed and documented proxy authentication.

## How

Added proxy authenticator for okhttp case.
Added documentation for `HttpURLConnection` case.
Added throw of `IllegalArgumentException` for https proxy URLs.
Added general proxy documentation and caveats to proxy methods
on `ClientBuilder`.

## Testing
 	
Changed `HttpProxyTest` to use a real proxy server.

Added parameterized combinations to HttpProxyTest:
- HTTP and HTTPS servers
- okhttp or default HttpURLConnection
- using proxy auth or not

Added additional test for `IllegalArgumentException` if an attempt is made to use an https proxy to the `HttpTest` class.

## Issues

#282 
