### PR TITLE
Changed CookieInterceptor to use CookieManager

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
 - [FIX] Issue authenticating with a proxy server when connecting to a HTTPS database server.
 - [FIX] Throw an `IllegalArgumentException` if using an unsupported proxy type.
 - [IMPROVED] Documentation for connecting to and authenticating with proxy servers.
+- [FIX] `java.lang.StringIndexOutOfBoundsException` when trying to parse `Set-Cookie` headers.
 
 # 2.5.1 (2016-07-19)
 - [IMPROVED] Made the 429 response code backoff optional and configurable. To enable the backoff add

--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,10 @@ subprojects {
             }
         }
         testLogging {
+            // Get full exceptions for test failures
             exceptionFormat = 'full'
+            // Log all tests, not just failures. Include test output.
+            events "passed", "skipped", "failed", "standardOut", "standardError"
         }
     }
 


### PR DESCRIPTION
## What

Changed `CookieInterceptor` to use `java.net.CookieManager`

## How

The previous `CookieInterceptor` code failed to account for the possibility of multiple `Set-Cookie` headers being present in a response. It also failed to account for the possibility of multiple cookie values within a single header. Finally and most obviously from #287 it failed to check that the string parsing it was doing was safe. To avoid having to write code for all these scenarios it seemed preferable to use the `java.net.CookieManager` instead, which should be spec compliant.

* Removed our existing cookie/header parsing and used an instance of `java.net.CookieManager` instead.
* Refactored methods and error handling to work with `CookieManager` changes.
* Made the `shouldAttemptCookieRequest` atomic as it is potentially accessed by multiple `HttpConnection` instances.

## Testing

Added tests:
* HttpTest#badCredsDisablesCookie - to check that a 401 when requesting a
cookie stops any further attempts.
* HttpTest#cookieAppliedToDifferentURL - to validate that the cookie is
successfully applied to a different request URL.

Updated the `OK_COOKIE` to better match CouchDB.
Fixed assertions impacted by cookie change (optional " not present in a `CookieManager` handled cookie).

## Issues

Fixes #287 
Also fixes #273 