### PR TITLE
270 dns log

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@
 - [FIX] `java.lang.StringIndexOutOfBoundsException` when trying to parse `Set-Cookie` headers.
 - [FIX] `NullPointerException` in `CookieInterceptor` when no body was present on response.
 - [UPGRADED] Upgraded GSON to 2.7
+- [IMPROVED] Added warning messages for JVM DNS cache configuration settings that could impede
+  client operation during cluster failover.
 
 # 2.5.1 (2016-07-19)
 - [IMPROVED] Made the 429 response code backoff optional and configurable. To enable the backoff add


### PR DESCRIPTION
## What

Added log warnings for long JVM DNS cache TTLs.

## How

Added warning level log messages if the TTL is too high or can't be checked.
* If permission is denied to read the configuration property log a warning.
* If the property can be read and parsed, but is longer than 30 s log a warning.
* If the value is the default setting and a `SecurityManager` is active then log a warning because the TTL is infinite if unconfigured with a `SecurityManager`.

## Testing

Added tests to validate log output:
dnsNoWarningLessThan30
dnsNoWarning0
dnsWarningForever
dnsNoWarning30
dnsWarning31
dnsWarningPermissionDenied
dnsWarningDefaultWithSecurityManager

## Issues

Fixes #270 
