### PR TITLE
290 cookie error npe

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
 - [FIX] Throw an `IllegalArgumentException` if using an unsupported proxy type.
 - [IMPROVED] Documentation for connecting to and authenticating with proxy servers.
 - [FIX] `java.lang.StringIndexOutOfBoundsException` when trying to parse `Set-Cookie` headers.
+- [FIX] `NullPointerException` in `CookieInterceptor` when no body was present on response.
 
 # 2.5.1 (2016-07-19)
 - [IMPROVED] Made the 429 response code backoff optional and configurable. To enable the backoff add

--- a/cloudant-client/src/test/java/com/cloudant/tests/HttpTest.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/HttpTest.java
@@ -998,14 +998,17 @@ public class HttpTest {
     }
 
     /**
-     * Test that having no body and hence no error stream correctly results in the 403 causing
-     * a CouchDbException with no NPEs.
+     * Test that having no body and hence no error stream on a 403 response correctly results in the
+     * 403 causing a CouchDbException with no NPEs.
      *
      * @throws Exception
      */
     @Test(expected=CouchDbException.class)
     public void noErrorStream403() throws Exception {
+
+        // Respond with a cookie init to the first request to _session
         mockWebServer.enqueue(MockWebServerResources.OK_COOKIE);
+        // Respond to the executeRequest GET of / with a 403 with no body
         mockWebServer.enqueue(new MockResponse().setResponseCode(403));
         CloudantClient c = CloudantClientHelper.newMockWebServerClientBuilder(mockWebServer)
                 .username("a")
@@ -1017,17 +1020,23 @@ public class HttpTest {
     }
 
     /**
-     * Test that having no body and hence no error stream correctly results in a 401 cookie renewal.
-     * Without a NPE.
+     * Test that having no body and hence no error stream on a 401 response correctly results in a
+     * 401 cookie renewal without a NPE.
      *
      * @throws Exception
      */
     @Test
     public void noErrorStream401() throws Exception {
+
+        // Respond with a cookie init to the first request to _session
         mockWebServer.enqueue(MockWebServerResources.OK_COOKIE);
+        // Respond to the executeRequest GET of / with a 401 with no body
         mockWebServer.enqueue(new MockResponse().setResponseCode(401));
+        // 401 triggers a renewal so respond with a new cookie for renewal request to _session
         mockWebServer.enqueue(MockWebServerResources.OK_COOKIE);
+        // Finally respond 200 OK with body of "TEST" to the replay of GET to /
         mockWebServer.enqueue(new MockResponse().setBody("TEST"));
+        
         CloudantClient c = CloudantClientHelper.newMockWebServerClientBuilder(mockWebServer)
                 .username("a")
                 .password("b")

--- a/cloudant-client/src/test/java/com/cloudant/tests/HttpTest.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/HttpTest.java
@@ -996,4 +996,44 @@ public class HttpTest {
         assertEquals("The third request should have been for /", "/",
                 MockWebServerResources.takeRequestWithTimeout(mockWebServer).getPath());
     }
+
+    /**
+     * Test that having no body and hence no error stream correctly results in the 403 causing
+     * a CouchDbException with no NPEs.
+     *
+     * @throws Exception
+     */
+    @Test(expected=CouchDbException.class)
+    public void noErrorStream403() throws Exception {
+        mockWebServer.enqueue(MockWebServerResources.OK_COOKIE);
+        mockWebServer.enqueue(new MockResponse().setResponseCode(403));
+        CloudantClient c = CloudantClientHelper.newMockWebServerClientBuilder(mockWebServer)
+                .username("a")
+                .password("b")
+                .build();
+
+        String response = c.executeRequest(Http.GET(c.getBaseUri())).responseAsString();
+        fail("There should be an exception, but received response " + response);
+    }
+
+    /**
+     * Test that having no body and hence no error stream correctly results in a 401 cookie renewal.
+     * Without a NPE.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void noErrorStream401() throws Exception {
+        mockWebServer.enqueue(MockWebServerResources.OK_COOKIE);
+        mockWebServer.enqueue(new MockResponse().setResponseCode(401));
+        mockWebServer.enqueue(MockWebServerResources.OK_COOKIE);
+        mockWebServer.enqueue(new MockResponse().setBody("TEST"));
+        CloudantClient c = CloudantClientHelper.newMockWebServerClientBuilder(mockWebServer)
+                .username("a")
+                .password("b")
+                .build();
+
+        String response = c.executeRequest(Http.GET(c.getBaseUri())).responseAsString();
+        assertEquals("The expected response body should be received", "TEST", response);
+    }
 }


### PR DESCRIPTION
## What

Prevent NPE when intercepting response with no body.

## How

* Added a `null` check for the error stream.
* Stopped converting the stream to a string if it was `null`.
* Added `null` check and reversed condition for `errorString.matches` to avoid NPE if the `errorString` was `null`.
* Changed value of  `toThrow.deserialize` to be `false` if the `errorString` was `null` in the case where a non-expiry 403 needs propagating.

## Testing

Added new tests, which failed with NPE before fix and now pass:
* `noErrorStream403`
* `noErrorStream401`

Note that the NPE does not happen when using okhttp, but our parameterized tests exercise both options anyway.

## Issues

Fixes #290 
