### PR TITLE
294 opt okhttp

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# Unreleased
+- [FIX] `NoClassDefFoundError: com.squareup.okhttp.Authenticator` for version 2.6.0 if the optional
+  okhttp dependency was not included.
+
 # 2.6.0 (2016-09-12)
 - [NEW] Enabled `reduce` and other reduce related parameters to be set when using
   `MultipleRequestBuilder`.

--- a/cloudant-client/src/main/java/com/cloudant/client/api/ClientBuilder.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/ClientBuilder.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright © 2015, 2016 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
 package com.cloudant.client.api;
 
 import com.cloudant.client.api.views.Key;

--- a/cloudant-http/src/main/java/com/cloudant/http/internal/ok/OkHttpClientHttpUrlConnectionFactory.java
+++ b/cloudant-http/src/main/java/com/cloudant/http/internal/ok/OkHttpClientHttpUrlConnectionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 IBM Corp. All rights reserved.
+ * Copyright © 2015, 2016 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -14,20 +14,15 @@
 
 package com.cloudant.http.internal.ok;
 
-import com.cloudant.http.interceptors.ProxyAuthInterceptor;
 import com.cloudant.http.internal.DefaultHttpUrlConnectionFactory;
-import com.squareup.okhttp.Authenticator;
 import com.squareup.okhttp.ConnectionSpec;
 import com.squareup.okhttp.Credentials;
 import com.squareup.okhttp.OkHttpClient;
 import com.squareup.okhttp.OkUrlFactory;
-import com.squareup.okhttp.Request;
-import com.squareup.okhttp.Response;
 
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.PasswordAuthentication;
-import java.net.Proxy;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.logging.Logger;
@@ -93,32 +88,6 @@ public class OkHttpClientHttpUrlConnectionFactory extends DefaultHttpUrlConnecti
 
     public OkHttpClient getOkHttpClient() {
         return client;
-    }
-
-    private static class ProxyAuthenticator implements Authenticator {
-
-        private final String creds;
-
-        ProxyAuthenticator(String creds) {
-            this.creds = creds;
-        }
-
-        @Override
-        public Request authenticate(Proxy proxy, Response response) throws IOException {
-            // Don't interfere with normal auth, this is just for proxies.
-            return null;
-        }
-
-        @Override
-        public Request authenticateProxy(Proxy proxy, Response response) throws IOException {
-            if (creds.equals(response.request().header("Proxy-Authorization"))) {
-                // If the proxy creds have already been tried then give up
-                return null;
-            } else {
-                return response.request().newBuilder().addHeader(ProxyAuthInterceptor
-                        .PROXY_AUTH_HEADER, creds).build();
-            }
-        }
     }
 
 }

--- a/cloudant-http/src/main/java/com/cloudant/http/internal/ok/ProxyAuthenticator.java
+++ b/cloudant-http/src/main/java/com/cloudant/http/internal/ok/ProxyAuthenticator.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2016 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.http.internal.ok;
+
+import com.cloudant.http.interceptors.ProxyAuthInterceptor;
+import com.squareup.okhttp.Authenticator;
+import com.squareup.okhttp.Request;
+import com.squareup.okhttp.Response;
+
+import java.io.IOException;
+import java.net.Proxy;
+
+class ProxyAuthenticator implements Authenticator {
+
+    private final String creds;
+
+    ProxyAuthenticator(String creds) {
+        this.creds = creds;
+    }
+
+    @Override
+    public Request authenticate(Proxy proxy, Response response) throws IOException {
+        // Don't interfere with normal auth, this is just for proxies.
+        return null;
+    }
+
+    @Override
+    public Request authenticateProxy(Proxy proxy, Response response) throws IOException {
+        if (creds.equals(response.request().header("Proxy-Authorization"))) {
+            // If the proxy creds have already been tried then give up
+            return null;
+        } else {
+            return response.request().newBuilder().addHeader(ProxyAuthInterceptor
+                    .PROXY_AUTH_HEADER, creds).build();
+        }
+    }
+}


### PR DESCRIPTION
## What

Fixed class structure that caused early loading of optional okhttp class.

## How

Moved the `ProxyAuthenticator` from a static internal class to a top level class.

## Testing

No new tests.

## Issues

Fixes #294
