### PR TITLE
Moved isOkUsable check into own class

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# Unreleased
+- [FIX] Another `NoClassDefFoundError: com.squareup.okhttp.Authenticator` for version 2.6.1 if the
+  optional okhttp dependency was not included.
+
 # 2.6.1 (2016-09-15)
 - [FIX] `NoClassDefFoundError: com.squareup.okhttp.Authenticator` for version 2.6.0 if the optional
   okhttp dependency was not included.

--- a/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/CouchDbClient.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/CouchDbClient.java
@@ -24,7 +24,6 @@ import static com.cloudant.client.org.lightcouch.internal.CouchDbUtil.getRespons
 import com.cloudant.client.internal.DatabaseURIHelper;
 import com.cloudant.client.internal.URIBase;
 import com.cloudant.client.internal.util.DeserializationTypes;
-import com.cloudant.client.org.lightcouch.internal.CouchDbUtil;
 import com.cloudant.client.org.lightcouch.internal.GsonHelper;
 import com.cloudant.http.Http;
 import com.cloudant.http.HttpConnection;
@@ -32,6 +31,7 @@ import com.cloudant.http.HttpConnectionRequestInterceptor;
 import com.cloudant.http.HttpConnectionResponseInterceptor;
 import com.cloudant.http.interceptors.HttpConnectionInterceptorException;
 import com.cloudant.http.internal.DefaultHttpUrlConnectionFactory;
+import com.cloudant.http.internal.ok.OkHelper;
 import com.cloudant.http.internal.ok.OkHttpClientHttpUrlConnectionFactory;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -92,7 +92,7 @@ public class CouchDbClient {
 
         // If OkHttp is available then use it for connection pooling, otherwise default to the
         // JVM built-in pooling for HttpUrlConnection
-        if (OkHttpClientHttpUrlConnectionFactory.isOkUsable()) {
+        if (OkHelper.isOkUsable()) {
             log.config("Using OkHttp");
             OkHttpClientHttpUrlConnectionFactory factory = new
                     OkHttpClientHttpUrlConnectionFactory();

--- a/cloudant-client/src/test/java/com/cloudant/tests/HttpProxyTest.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/HttpProxyTest.java
@@ -21,7 +21,7 @@ import static org.junit.Assert.assertTrue;
 import com.cloudant.client.api.ClientBuilder;
 import com.cloudant.client.api.CloudantClient;
 import com.cloudant.http.Http;
-import com.cloudant.http.internal.ok.OkHttpClientHttpUrlConnectionFactory;
+import com.cloudant.http.internal.ok.OkHelper;
 import com.cloudant.tests.util.MockWebServerResources;
 import com.squareup.okhttp.mockwebserver.Dispatcher;
 import com.squareup.okhttp.mockwebserver.MockResponse;
@@ -89,11 +89,11 @@ public class HttpProxyTest {
     public void changeHttpConnectionFactory() throws Exception {
         if (!okUsable) {
             // New up the mock that will stop okhttp's factory being used
-            new HttpTest.OkFactoryBlocker();
+            new HttpTest.OkHelperMock();
         }
         // Verify that we are getting the behaviour we expect.
         assertEquals("The OK usable value was not what was expected for the test parameter.",
-                okUsable, OkHttpClientHttpUrlConnectionFactory.isOkUsable());
+                okUsable, OkHelper.isOkUsable());
     }
 
     @Parameterized.Parameter(1)

--- a/cloudant-http/src/main/java/com/cloudant/http/internal/DefaultHttpUrlConnectionFactory.java
+++ b/cloudant-http/src/main/java/com/cloudant/http/internal/DefaultHttpUrlConnectionFactory.java
@@ -54,7 +54,7 @@ public class DefaultHttpUrlConnectionFactory implements HttpConnection.HttpUrlCo
     }
 
     @Override
-    public void setProxyAuthentication(final PasswordAuthentication proxyAuthentication) {
+    public void setProxyAuthentication(PasswordAuthentication proxyAuthentication) {
         // Currently a no-op.
         // HttpURLConnection doesn't allow the setting of an Authenticator per instance and it would
         // be irresponsible to set the default Authenticator because it applies globally and we

--- a/cloudant-http/src/main/java/com/cloudant/http/internal/ok/OkHelper.java
+++ b/cloudant-http/src/main/java/com/cloudant/http/internal/ok/OkHelper.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2016 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.http.internal.ok;
+
+/**
+ * This class should only reflectively try to load the OkUrlFactory and then provide a boolean
+ * answer to {@link #isOkUsable()}. Addition of other methods is not advised as it may cause loading
+ * of okhttp classes that break the optional dependency relationship.
+ */
+public class OkHelper {
+
+    private final static boolean okUsable;
+
+    static {
+        Class<?> okFactoryClass;
+        try {
+            okFactoryClass = Class.forName("com.squareup.okhttp.OkUrlFactory");
+        } catch (Throwable t) {
+            okFactoryClass = null;
+        }
+        okUsable = (okFactoryClass != null);
+    }
+
+    public static boolean isOkUsable() {
+        return okUsable;
+    }
+
+}

--- a/cloudant-http/src/main/java/com/cloudant/http/internal/ok/OkHttpClientHttpUrlConnectionFactory.java
+++ b/cloudant-http/src/main/java/com/cloudant/http/internal/ok/OkHttpClientHttpUrlConnectionFactory.java
@@ -38,23 +38,6 @@ public class OkHttpClientHttpUrlConnectionFactory extends DefaultHttpUrlConnecti
     private final OkHttpClient client;
     private final OkUrlFactory factory;
 
-    private final static boolean okUsable;
-
-    static {
-        Class<?> okFactoryClass;
-        try {
-            okFactoryClass = Class.forName("com.squareup.okhttp.OkUrlFactory");
-        } catch (Throwable t) {
-            okFactoryClass = null;
-        }
-        okUsable = (okFactoryClass != null);
-    }
-
-    public static boolean isOkUsable() {
-        return okUsable;
-    }
-
-
     public OkHttpClientHttpUrlConnectionFactory() {
         client = new OkHttpClient();
         client.setConnectionSpecs(Arrays.asList(
@@ -81,7 +64,7 @@ public class OkHttpClientHttpUrlConnectionFactory extends DefaultHttpUrlConnecti
     }
 
     @Override
-    public void setProxyAuthentication(final PasswordAuthentication proxyAuthentication) {
+    public void setProxyAuthentication(PasswordAuthentication proxyAuthentication) {
         client.setAuthenticator(new ProxyAuthenticator(Credentials.basic(proxyAuthentication
                 .getUserName(), new String(proxyAuthentication.getPassword()))));
     }


### PR DESCRIPTION
## What

Moved `isOkUsable` check into own class to avoid further okhttp `NoClassDefFound` issues.

## How

The complexity of the `OkHttpClientHttpUrlConnectionFactory` increased to
the point where it was challenging to continue maintaining it without
inadvertently loading okhttp classes. Such loads prevents okhttp being
optional.
Added a new `OkHelper` class that has only the `isOkUsable` check.

## Testing

Fixed the test mocks to match.
Added a new test that uses a special `URLClassLoader` with a reflective
load of `OkHelper` to ensure that okhttp classes aren't accidentally loaded
by the helper.
The 2.6.1 release that should have fixed this problem did not because whilst the manual test of the fix did not include okhttp directly it did use the mock web server which pulled in okhttp. This new test gives us a check that is protected from the test classpath.

## Issues

Fixes #294