### PR TITLE
Fixed NPE in AllDocsResponse.getIdsAndRevs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# Unreleased
+- [FIX] `NullPointerException` when calling `AllDocsResponse.getIdsAndRevs` for a request with
+  multiple non-existent keys (IDs).
+
 # 2.6.2 (2016-09-20)
 - [FIX] `NoClassDefFoundError: com.squareup.okhttp.Authenticator` for version 2.6.1 if the optional
   okhttp dependency was not included.

--- a/cloudant-client/src/main/java/com/cloudant/client/internal/views/AllDocsRequestResponse.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/internal/views/AllDocsRequestResponse.java
@@ -54,7 +54,10 @@ public class AllDocsRequestResponse implements AllDocsRequest, AllDocsResponse {
     public Map<String, String> getIdsAndRevs() {
         Map<String, String> docIdsAndRevs = new HashMap<String, String>();
         for (ViewResponse.Row<String, Revision> row : response.getRows()) {
-            docIdsAndRevs.put(row.getKey(), row.getValue().get());
+            Revision rev = row.getValue();
+            if (rev != null) {
+                docIdsAndRevs.put(row.getKey(), rev.get());
+            }
         }
         return docIdsAndRevs;
     }

--- a/cloudant-client/src/test/java/com/cloudant/tests/ViewsTest.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/ViewsTest.java
@@ -1126,4 +1126,22 @@ public class ViewsTest {
         assertTrue("There request URL should match the pattern " + p.toString(), p.matcher
                 (request.getPath()).matches());
     }
+
+    /**
+     * <p>
+     * Test added for https://github.com/cloudant/java-cloudant/issues/297
+     * </p>
+     * <p>
+     * When _all_docs is used an array of rows is returned containing an entry for each key
+     * specified. If the document doesn't exist an "error" : "not_found" entry is present in the row
+     * instead of the expected "value" property. Trying to use the value results in a NPE.
+     * </p>
+     *
+     * @throws Exception
+     */
+    @Test
+    public void getIdsAndRevsForTwoNonExistentKeysWithAllDocs() throws Exception {
+        db.getAllDocsRequestBuilder().keys(new String[]{"a", "b"}).build().getResponse()
+                .getIdsAndRevs();
+    }
 }


### PR DESCRIPTION
## What

Fixed NPE in `AllDocsResponse.getIdsAndRevs`.

## How

Added check for a `null` for `row.getValue()` before adding id/rev to result map.
Updated CHANGES.md.

## Testing

Added test `com.cloudant.tests.ViewsTest#getIdsAndRevsForTwoNonExistentKeysWithAllDocs`

## Issues

Fixes #297 