### PR TITLE
305 client build url with path

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,9 +1,9 @@
 # Unreleased
 - [FIX] `NullPointerException` when calling `AllDocsResponse.getIdsAndRevs` for a request with
   multiple non-existent keys (IDs).
-- [IMPROVED] Changed `ClientBuilder.ClientBuilder(URL url)` logic to allow cloudant working with URL
-  with not empty path part. Like this: <https://testproxy.samplehost.net:443/cloudant/mydb>. It allow
-  connect to Cloudant by gateways (the IBM DataPower Gateway for example).
+- [IMPROVED] Preserved path elements from `URL`s used to construct a `ClientBuilder`. 
+This allows, for example, a `CloudantClient`connection to use a gateway with a `URL` like
+ `https://testproxy.example.net:443/cloudant/mydb`.
 
 # 2.6.2 (2016-09-20)
 - [FIX] `NoClassDefFoundError: com.squareup.okhttp.Authenticator` for version 2.6.1 if the optional

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 # Unreleased
 - [FIX] `NullPointerException` when calling `AllDocsResponse.getIdsAndRevs` for a request with
   multiple non-existent keys (IDs).
+- [IMPROVED] Changed `ClientBuilder.ClientBuilder(URL url)` logic to allow cloudant working with URL
+  with not empty path part. Like this: <https://testproxy.samplehost.net:443/cloudant/mydb>. It allow
+  connect to Cloudant by gateways (the IBM DataPower Gateway for example).
 
 # 2.6.2 (2016-09-20)
 - [FIX] `NoClassDefFoundError: com.squareup.okhttp.Authenticator` for version 2.6.1 if the optional

--- a/cloudant-client/src/main/java/com/cloudant/client/api/ClientBuilder.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/ClientBuilder.java
@@ -200,7 +200,9 @@ public class ClientBuilder {
                     + urlHost
                     + ":"
                     + urlPort;
+            //add url path if it exist in source url
             if(!urlPath.trim().equals("")) {
+                //removing last slash if it exist in source url
                 urlPath = urlPath.substring(urlPath.length() - 1).equals("/") ?
                         urlPath.substring(0, urlPath.length() - 1) : urlPath;
                 tmpUrl += urlPath;

--- a/cloudant-client/src/main/java/com/cloudant/client/api/ClientBuilder.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/ClientBuilder.java
@@ -178,7 +178,6 @@ public class ClientBuilder {
         logger.config("URL: " + url);
         String urlProtocol = url.getProtocol();
         String urlHost = url.getHost();
-        String urlPath = url.getPath();
         //Check if port exists
         int urlPort = url.getPort();
         if (urlPort < 0) {
@@ -193,21 +192,19 @@ public class ClientBuilder {
                     .getUserInfo()
                     .indexOf(":") + 1);
         }
+        
+        // Check if a path exists and sanitize it by removing whitespace and any trailing /
+        String urlPath = url.getPath().trim();
+        urlPath = urlPath.endsWith("/") ? urlPath.substring(0, urlPath.length() - 1) : urlPath;
+
         try {
-            //Remove user credentials from url
-            String tmpUrl = urlProtocol
+            // Reconstruct URL without user credentials
+            this.url = new URL(urlProtocol
                     + "://"
                     + urlHost
                     + ":"
-                    + urlPort;
-            //add url path if it exist in source url
-            if(!urlPath.trim().equals("")) {
-                //removing last slash if it exist in source url
-                urlPath = urlPath.substring(urlPath.length() - 1).equals("/") ?
-                        urlPath.substring(0, urlPath.length() - 1) : urlPath;
-                tmpUrl += urlPath;
-            }
-            this.url = new URL(tmpUrl);
+                    + urlPort
+                    + urlPath);
         } catch (MalformedURLException e) {
             throw new RuntimeException(e);
         }

--- a/cloudant-client/src/main/java/com/cloudant/client/api/ClientBuilder.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/ClientBuilder.java
@@ -201,6 +201,8 @@ public class ClientBuilder {
                     + ":"
                     + urlPort;
             if(!urlPath.trim().equals("")) {
+                urlPath = urlPath.substring(urlPath.length() - 1).equals("/") ?
+                        urlPath.substring(0, urlPath.length() - 1) : urlPath;
                 tmpUrl += urlPath;
             }
             this.url = new URL(tmpUrl);

--- a/cloudant-client/src/main/java/com/cloudant/client/api/ClientBuilder.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/ClientBuilder.java
@@ -178,7 +178,7 @@ public class ClientBuilder {
         logger.config("URL: " + url);
         String urlProtocol = url.getProtocol();
         String urlHost = url.getHost();
-
+        String urlPath = url.getPath();
         //Check if port exists
         int urlPort = url.getPort();
         if (urlPort < 0) {
@@ -193,14 +193,17 @@ public class ClientBuilder {
                     .getUserInfo()
                     .indexOf(":") + 1);
         }
-
         try {
             //Remove user credentials from url
-            this.url = new URL(urlProtocol
+            String tmpUrl = urlProtocol
                     + "://"
                     + urlHost
                     + ":"
-                    + urlPort);
+                    + urlPort;
+            if(!urlPath.trim().equals("")) {
+                tmpUrl += urlPath;
+            }
+            this.url = new URL(tmpUrl);
         } catch (MalformedURLException e) {
             throw new RuntimeException(e);
         }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,0 @@
-systemProp.test.couch.username=b69f48f2-8986-4865-a2ca-179874528d9a-bluemix
-systemProp.test.couch.password=7bac2478ce14d576cd13a0f127e2fdad13f6c2694ca07691f2a7d8847d5c02e7
-systemProp.test.couch.host=b69f48f2-8986-4865-a2ca-179874528d9a-bluemix.cloudant.com
-systemProp.test.couch.port=80
-systemProp.test.couch.http=http

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,5 @@
+systemProp.test.couch.username=b69f48f2-8986-4865-a2ca-179874528d9a-bluemix
+systemProp.test.couch.password=7bac2478ce14d576cd13a0f127e2fdad13f6c2694ca07691f2a7d8847d5c02e7
+systemProp.test.couch.host=b69f48f2-8986-4865-a2ca-179874528d9a-bluemix.cloudant.com
+systemProp.test.couch.port=80
+systemProp.test.couch.http=http

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-bin.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Jul 19 15:28:44 BST 2016
+#Thu Oct 06 15:51:02 MSK 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip


### PR DESCRIPTION
## What

Added URL path during creation Cloudant URL since the path is important to connect Cloudant with a gateway.

## How

Added URL path during URL creation in `ClientBuilder.ClientBuilder()` method. Check if urlPath exist in the URL provided to API and add it to resulting URL.

## Testing

You can connect to Cloudant with URL with not empty path part now. Like following: <https://testproxy.samplehost.net:443/cloudant/mydb>.

## Issues

Fixes #305 The ClientBuilder.ClientBuilder(URL url) function removes url's path