### PR TITLE
Updated doc and test for CVE-2016-5597

### DIFF
--- a/cloudant-client/overview.html
+++ b/cloudant-client/overview.html
@@ -685,12 +685,22 @@ library to query a view.
         ClientBuilder.url("https://myserver.example") // or .account("exampleAccount")
           .proxyURL(new URL("http://myproxy.example"))
 
-        // Configure the JVM Authenticator
-        // The library does not do this automatically because it applies JVM wide
+        // Configure the JVM Authenticator:
+        // The library does not do this automatically because it applies JVM wide.
+        // This is an example Authenticator. You should ensure that your Authenticator class does
+        // not provide any other credentials to your proxy as they will be in the clear. For newer
+        // JVM versions you may need to set the property jdk.http.auth.tunneling.disabledSchemes
+        // to an appropriate value to allow proxy Basic authentication with HTTPS tunneling.
+        // See CVE-2016-5597 and the documentation for jdk.http.auth.tunneling.disabledSchemes for
+        // more information.
         Authenticator.setDefault(new Authenticator() {
 
             protected PasswordAuthentication getPasswordAuthentication() {
+              if (getRequestorType() == RequestorType.PROXY) {
                 return new PasswordAuthentication("exampleProxyUser", "exampleProxyPassword".toCharArray());
+              } else {
+                  return null;
+              }
             }
         });
       }

--- a/cloudant-client/src/test/java/com/cloudant/tests/HttpProxyTest.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/HttpProxyTest.java
@@ -112,7 +112,12 @@ public class HttpProxyTest {
     String mockProxyUser = "alpha";
     String mockProxyPass = "alphaPass";
 
-    String defaultDisabledList = "";
+    // Unfortunately getting the System property jdk.http.auth.tunneling.disabledSchemes doesn't
+    // actually give us the default value (it returns null so the property being unset enables some
+    // default behaviour). It is not possible to unset the value after we have set it so the best we
+    // can do is set it back to a value we think is appropirate. According to release notes for the
+    // fix for CVE-2016-5597 the Basic scheme is disabled so we'll reset to that value.
+    private final String defaultDisabledList = "Basic";
 
     /**
      * Enables https on the mock web server receiving our requests if useHttpsServer is true.
@@ -198,8 +203,8 @@ public class HttpProxyTest {
         // If we are not using okhttp and we have an https server and a proxy that needs auth then
         // we need to set the default Authenticator
         if (useProxyAuth && useHttpsServer && !okUsable) {
-            // Allow https tunnelling through http proxy
-            defaultDisabledList = System.getProperty("jdk.http.auth.tunneling.disabledSchemes", "");
+            // Allow https tunnelling through http proxy for the duration of the test
+            System.setProperty("jdk.http.auth.tunneling.disabledSchemes", "");
             Authenticator.setDefault(new Authenticator() {
                 @Override
                 protected PasswordAuthentication getPasswordAuthentication() {
@@ -224,9 +229,9 @@ public class HttpProxyTest {
         // we need to set the default Authenticator
         if (useProxyAuth && useHttpsServer && !okUsable) {
             Authenticator.setDefault(null);
+            // Reset the disabled schemes property
+            System.setProperty("jdk.http.auth.tunneling.disabledSchemes", defaultDisabledList);
         }
-        // Reset the disabled schemes property
-        System.setProperty("jdk.http.auth.tunneling.disabledSchemes", defaultDisabledList);
     }
 
     /**


### PR DESCRIPTION
## What

Updated doc and test for CVE-2016-5597.

## How

* Updated doc to mention `jdk.http.auth.tunneling.disabledSchemes` property and the CVE.

## Testing

`HttpProxyTest.proxiedRequest`

* Updated test to use `jdk.http.auth.tunneling.disabledSchemes` property.
* Updated test `Authenticator` to only send creds to a proxy.

Test now passes locally on the most recent JVM.

## Issues

Fixes #314 
