### PR TITLE
Updated to okhttp3

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 # Unreleased
+- [UPGRADED] Optional okhttp dependency to version 3.4.2.
 - [FIX] `NullPointerException` when calling `AllDocsResponse.getIdsAndRevs` for a request with
   multiple non-existent keys (IDs).
 - [IMPROVED] Preserved path elements from `URL`s used to construct a `ClientBuilder`.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Gradle with [optional `okhttp-urlconnection` dependency](#optional-okhttp-depend
 ```groovy
 dependencies {
     compile group: 'com.cloudant', name: 'cloudant-client', version: '2.6.2'
-    compile group: 'com.squareup.okhttp', name: 'okhttp-urlconnection', version: '2.7.5'
+    compile group: 'com.squareup.okhttp3', name: 'okhttp-urlconnection', version: '3.4.2'
 }
 ```
 
@@ -53,9 +53,9 @@ Maven with [optional `okhttp-urlconnection` dependency](#optional-okhttp-depende
 </dependency>
 
 <dependency>
-  <groupId>com.squareup.okhttp</groupId>
+  <groupId>com.squareup.okhttp3</groupId>
   <artifactId>okhttp-urlconnection</artifactId>
-  <version>2.7.5</version>
+  <version>3.4.2</version>
 </dependency>
 ~~~
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 IBM Corp. All rights reserved.
+ * Copyright © 2016 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at

--- a/cloudant-client/build.gradle
+++ b/cloudant-client/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 IBM Corp. All rights reserved.
+ * Copyright © 2016 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -26,7 +26,7 @@ dependencies {
     linkableJavadoc project(':cloudant-http')
     //test dependencies
     testCompile group: 'junit', name: 'junit', version: '4.12'
-    testCompile group: 'com.squareup.okhttp', name: 'mockwebserver', version: '2.7.5'
+    testCompile group: 'com.squareup.okhttp3', name: 'mockwebserver', version: '3.4.2'
     testCompile group: 'org.jmockit', name: 'jmockit', version: '1.25'
     testCompile group: 'org.littleshoot', name: 'littleproxy', version: '1.1.0'
 }

--- a/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/CouchDbClient.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/CouchDbClient.java
@@ -39,9 +39,10 @@ import com.google.gson.InstanceCreator;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
 import com.google.gson.JsonParser;
-import com.squareup.okhttp.ConnectionPool;
 
 import org.apache.commons.io.IOUtils;
+
+import okhttp3.ConnectionPool;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -101,8 +102,9 @@ public class CouchDbClient {
                 log.config("Setting max connections to " + maxConns);
                 //keep connections open for as long as possible, anything over 2.5 minutes will be
                 //longer than the server so we'll use a 3 minute timeout
-                ConnectionPool pool = new ConnectionPool(maxConns, TimeUnit.MINUTES.toMillis(3));
-                factory.getOkHttpClient().setConnectionPool(pool);
+                ConnectionPool pool = new ConnectionPool(maxConns, 3l, TimeUnit
+                        .MINUTES);
+                factory.getOkHttpClientBuilder().connectionPool(pool);
             }
             this.factory = factory;
         } else {

--- a/cloudant-client/src/test/java/com/cloudant/tests/ChangeNotificationsTest.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/ChangeNotificationsTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2011 lightcouch.org
- * Copyright (c) 2015 IBM Corp. All rights reserved.
+ * Copyright © 2015, 2016 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -31,15 +31,16 @@ import com.cloudant.test.main.RequiresDB;
 import com.cloudant.tests.util.CloudantClientResource;
 import com.cloudant.tests.util.DatabaseResource;
 import com.google.gson.JsonObject;
-import com.squareup.okhttp.mockwebserver.MockResponse;
-import com.squareup.okhttp.mockwebserver.MockWebServer;
-import com.squareup.okhttp.mockwebserver.RecordedRequest;
 
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
 
 import java.util.List;
 import java.util.concurrent.TimeUnit;

--- a/cloudant-client/src/test/java/com/cloudant/tests/CloudantClientHelper.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/CloudantClientHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 IBM Corp. All rights reserved.
+ * Copyright © 2015, 2016 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -16,7 +16,7 @@ package com.cloudant.tests;
 
 import com.cloudant.client.api.ClientBuilder;
 import com.cloudant.client.api.CloudantClient;
-import com.squareup.okhttp.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.MockWebServer;
 
 import java.net.MalformedURLException;
 import java.net.URL;

--- a/cloudant-client/src/test/java/com/cloudant/tests/CloudantClientTests.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/CloudantClientTests.java
@@ -38,15 +38,16 @@ import com.cloudant.tests.util.CloudantClientResource;
 import com.cloudant.tests.util.MockWebServerResources;
 import com.cloudant.tests.util.TestLog;
 import com.cloudant.tests.util.Utils;
-import com.squareup.okhttp.mockwebserver.Dispatcher;
-import com.squareup.okhttp.mockwebserver.MockResponse;
-import com.squareup.okhttp.mockwebserver.MockWebServer;
-import com.squareup.okhttp.mockwebserver.RecordedRequest;
 
 import org.apache.commons.io.IOUtils;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+
+import okhttp3.mockwebserver.Dispatcher;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
 
 import java.io.IOException;
 import java.lang.reflect.Field;
@@ -115,7 +116,6 @@ public class CloudantClientTests {
     @Test
     public void testUserAgentHeaderString() {
         String userAgentHeader = new LibraryVersion().getUserAgentString();
-        System.out.println(userAgentHeader);
         assertTrue("The value of the User-Agent header: " + userAgentHeader + " should match the " +
                         "format: " + userAgentFormat,
                 userAgentHeader.matches(userAgentRegex));
@@ -379,7 +379,7 @@ public class CloudantClientTests {
         // Test passes if there are no exceptions
         client.getAllDbs();
     }
-    
+
     @Test
     public void gatewayStyleURL() throws Exception {
 

--- a/cloudant-client/src/test/java/com/cloudant/tests/DatabaseTest.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/DatabaseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 IBM Corp. All rights reserved.
+ * Copyright © 2015, 2016 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -32,14 +32,15 @@ import com.cloudant.tests.util.CloudantClientResource;
 import com.cloudant.tests.util.DatabaseResource;
 import com.cloudant.tests.util.MockWebServerResources;
 import com.google.gson.GsonBuilder;
-import com.squareup.okhttp.mockwebserver.MockResponse;
-import com.squareup.okhttp.mockwebserver.MockWebServer;
 
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.RuleChain;
+
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
 
 import java.net.MalformedURLException;
 import java.util.EnumSet;

--- a/cloudant-client/src/test/java/com/cloudant/tests/DesignDocumentsTest.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/DesignDocumentsTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2011 lightcouch.org
- * Copyright (c) 2015 IBM Corp. All rights reserved.
+ * Copyright © 2015, 2016 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -37,15 +37,16 @@ import com.cloudant.tests.util.DatabaseResource;
 import com.cloudant.tests.util.MockWebServerResources;
 import com.cloudant.tests.util.Utils;
 import com.google.gson.JsonObject;
-import com.squareup.okhttp.mockwebserver.MockResponse;
-import com.squareup.okhttp.mockwebserver.MockWebServer;
-import com.squareup.okhttp.mockwebserver.RecordedRequest;
 
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
 
 import java.io.File;
 import java.util.Collections;

--- a/cloudant-client/src/test/java/com/cloudant/tests/HttpProxyTest.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/HttpProxyTest.java
@@ -14,31 +14,30 @@
 
 package com.cloudant.tests;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import com.cloudant.client.api.ClientBuilder;
 import com.cloudant.client.api.CloudantClient;
 import com.cloudant.http.Http;
-import com.cloudant.http.internal.ok.OkHelper;
 import com.cloudant.tests.util.MockWebServerResources;
-import com.squareup.okhttp.mockwebserver.Dispatcher;
-import com.squareup.okhttp.mockwebserver.MockResponse;
-import com.squareup.okhttp.mockwebserver.MockWebServer;
-import com.squareup.okhttp.mockwebserver.RecordedRequest;
+import com.cloudant.tests.util.HttpFactoryParameterizedTest;
 
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.littleshoot.proxy.HttpProxyServer;
 import org.littleshoot.proxy.HttpProxyServerBootstrap;
 import org.littleshoot.proxy.ProxyAuthenticator;
 import org.littleshoot.proxy.SslEngineSource;
 import org.littleshoot.proxy.impl.DefaultHttpProxyServer;
+
+import okhttp3.mockwebserver.Dispatcher;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
 
 import java.net.Authenticator;
 import java.net.InetSocketAddress;
@@ -51,8 +50,7 @@ import java.util.concurrent.TimeUnit;
 import javax.net.ssl.SSLEngine;
 
 
-@RunWith(Parameterized.class)
-public class HttpProxyTest {
+public class HttpProxyTest extends HttpFactoryParameterizedTest {
 
     @Parameterized.Parameters(name = "okhttp: {0}; secure proxy: {1}; https server: {2}; proxy " +
             "auth: {3}")
@@ -78,23 +76,7 @@ public class HttpProxyTest {
         return combos;
     }
 
-    /**
-     * A parameter governing whether to allow okhttp or not. This lets us exercise both
-     * HttpURLConnection types in these tests.
-     */
-    @Parameterized.Parameter(0)
-    public boolean okUsable;
-
-    @Before
-    public void changeHttpConnectionFactory() throws Exception {
-        if (!okUsable) {
-            // New up the mock that will stop okhttp's factory being used
-            new HttpTest.OkHelperMock();
-        }
-        // Verify that we are getting the behaviour we expect.
-        assertEquals("The OK usable value was not what was expected for the test parameter.",
-                okUsable, OkHelper.isOkUsable());
-    }
+    // Note Parameter(0) okUsable is inherited
 
     @Parameterized.Parameter(1)
     public boolean secureProxy;

--- a/cloudant-client/src/test/java/com/cloudant/tests/HttpTest.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/HttpTest.java
@@ -34,11 +34,11 @@ import com.cloudant.http.HttpConnectionResponseInterceptor;
 import com.cloudant.http.interceptors.BasicAuthInterceptor;
 import com.cloudant.http.interceptors.CookieInterceptor;
 import com.cloudant.http.interceptors.Replay429Interceptor;
-import com.cloudant.http.internal.ok.OkHelper;
 import com.cloudant.test.main.RequiresCloudant;
 import com.cloudant.tests.util.CloudantClientResource;
 import com.cloudant.tests.util.DatabaseResource;
 import com.cloudant.tests.util.MockWebServerResources;
+import com.cloudant.tests.util.HttpFactoryParameterizedTest;
 import com.cloudant.tests.util.TestTimer;
 import com.cloudant.tests.util.Utils;
 import com.google.gson.Gson;
@@ -46,22 +46,18 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
-import com.squareup.okhttp.mockwebserver.Dispatcher;
-import com.squareup.okhttp.mockwebserver.MockResponse;
-import com.squareup.okhttp.mockwebserver.MockWebServer;
-import com.squareup.okhttp.mockwebserver.RecordedRequest;
 
-import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.RuleChain;
-import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import mockit.Mock;
-import mockit.MockUp;
+import okhttp3.mockwebserver.Dispatcher;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -78,8 +74,7 @@ import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 
-@RunWith(Parameterized.class)
-public class HttpTest {
+public class HttpTest extends HttpFactoryParameterizedTest {
 
     private String data = "{\"hello\":\"world\"}";
 
@@ -93,31 +88,6 @@ public class HttpTest {
     @Parameterized.Parameters(name = "Using okhttp: {0}")
     public static Object[] okUsable() {
         return new Object[]{true, false};
-    }
-
-    /**
-     * A parameter governing whether to allow okhttp or not. This lets us exercise both
-     * HttpURLConnection types in these tests.
-     */
-    @Parameterized.Parameter
-    public boolean okUsable;
-
-    static class OkHelperMock extends MockUp<OkHelper> {
-        @Mock
-        public static boolean isOkUsable() {
-            return false;
-        }
-    }
-
-    @Before
-    public void changeHttpConnectionFactory() throws Exception {
-        if (!okUsable) {
-            // New up the mock that will stop okhttp's factory being used
-            new OkHelperMock();
-        }
-        // Verify that we are getting the behaviour we expect.
-        assertEquals("The OK usable value was not what was expected for the test parameter.",
-                okUsable, OkHelper.isOkUsable());
     }
 
     /*

--- a/cloudant-client/src/test/java/com/cloudant/tests/IndexTests.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/IndexTests.java
@@ -35,15 +35,16 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
 import com.google.gson.JsonPrimitive;
-import com.squareup.okhttp.mockwebserver.MockResponse;
-import com.squareup.okhttp.mockwebserver.MockWebServer;
-import com.squareup.okhttp.mockwebserver.RecordedRequest;
 
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.RuleChain;
+
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
 
 import java.util.HashMap;
 import java.util.Iterator;

--- a/cloudant-client/src/test/java/com/cloudant/tests/LoggingTest.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/LoggingTest.java
@@ -22,10 +22,6 @@ import com.cloudant.client.api.ClientBuilder;
 import com.cloudant.client.api.CloudantClient;
 import com.cloudant.http.Http;
 import com.cloudant.http.HttpConnection;
-import com.squareup.okhttp.mockwebserver.Dispatcher;
-import com.squareup.okhttp.mockwebserver.MockResponse;
-import com.squareup.okhttp.mockwebserver.MockWebServer;
-import com.squareup.okhttp.mockwebserver.RecordedRequest;
 
 import org.junit.After;
 import org.junit.Before;
@@ -37,6 +33,11 @@ import mockit.Expectations;
 import mockit.Mocked;
 import mockit.StrictExpectations;
 import mockit.Verifications;
+
+import okhttp3.mockwebserver.Dispatcher;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
 
 import java.io.ByteArrayInputStream;
 import java.net.URL;

--- a/cloudant-client/src/test/java/com/cloudant/tests/SslAuthenticationTest.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/SslAuthenticationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 IBM Corp. All rights reserved.
+ * Copyright © 2015, 2016 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -23,19 +23,22 @@ import com.cloudant.client.org.lightcouch.CouchDbException;
 import com.cloudant.test.main.RequiresCloudantService;
 import com.cloudant.tests.util.CloudantClientResource;
 import com.cloudant.tests.util.MockWebServerResources;
-import com.squareup.okhttp.mockwebserver.MockResponse;
-import com.squareup.okhttp.mockwebserver.MockWebServer;
+import com.cloudant.tests.util.HttpFactoryParameterizedTest;
 
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.runners.Parameterized;
+
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
 
 import javax.net.ssl.SSLHandshakeException;
 import javax.net.ssl.SSLSocketFactory;
 
-public class SslAuthenticationTest {
+public class SslAuthenticationTest extends HttpFactoryParameterizedTest {
 
     @ClassRule
     public static CloudantClientResource dbClientResource = new CloudantClientResource();
@@ -43,6 +46,11 @@ public class SslAuthenticationTest {
 
     @Rule
     public MockWebServer server = new MockWebServer();
+
+    @Parameterized.Parameters(name = "Using okhttp: {0}")
+    public static Object[] okUsable() {
+        return new Object[]{true, false};
+    }
 
     @Before
     public void getMockWebServer() {

--- a/cloudant-client/src/test/java/com/cloudant/tests/ViewsTest.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/ViewsTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2011 lightcouch.org
- * Copyright (c) 2015 IBM Corp. All rights reserved.
+ * Copyright © 2015, 2016 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -44,9 +44,6 @@ import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import com.squareup.okhttp.mockwebserver.MockResponse;
-import com.squareup.okhttp.mockwebserver.MockWebServer;
-import com.squareup.okhttp.mockwebserver.RecordedRequest;
 
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -54,6 +51,10 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.RuleChain;
+
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
 
 import java.io.IOException;
 import java.util.ArrayList;

--- a/cloudant-client/src/test/java/com/cloudant/tests/util/HttpFactoryParameterizedTest.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/util/HttpFactoryParameterizedTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2016 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.tests.util;
+
+import static org.junit.Assert.assertEquals;
+
+import com.cloudant.http.internal.DefaultHttpUrlConnectionFactory;
+import com.cloudant.http.internal.ok.OkHelper;
+
+import org.junit.Before;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import mockit.Mock;
+import mockit.MockUp;
+
+@RunWith(Parameterized.class)
+public abstract class HttpFactoryParameterizedTest {
+
+    /**
+     * A parameter governing whether to allow okhttp or not. This lets us exercise both
+     * HttpURLConnection types in these tests.
+     */
+    @Parameterized.Parameter
+    public boolean okUsable;
+
+    /**
+     * A mock OkHelper that always returns false to force use of the JVM HttpURLConnection
+     * via the {@link DefaultHttpUrlConnectionFactory}
+     */
+    static class OkHelperMock extends MockUp<OkHelper> {
+        @Mock
+        public static boolean isOkUsable() {
+            return false;
+        }
+    }
+
+    @Before
+    public void changeHttpConnectionFactory() throws Exception {
+        if (!okUsable) {
+            // New up the mock that will stop okhttp's factory being used
+            new OkHelperMock();
+        }
+        // Verify that we are getting the behaviour we expect.
+        assertEquals("The OK usable value was not what was expected for the test parameter.",
+                okUsable, OkHelper.isOkUsable());
+    }
+}

--- a/cloudant-client/src/test/java/com/cloudant/tests/util/MockWebServerResources.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/util/MockWebServerResources.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 IBM Corp. All rights reserved.
+ * Copyright © 2015, 2016 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -14,10 +14,10 @@
 
 package com.cloudant.tests.util;
 
-import com.squareup.okhttp.mockwebserver.Dispatcher;
-import com.squareup.okhttp.mockwebserver.MockResponse;
-import com.squareup.okhttp.mockwebserver.MockWebServer;
-import com.squareup.okhttp.mockwebserver.RecordedRequest;
+import okhttp3.mockwebserver.Dispatcher;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
 
 import java.io.FileInputStream;
 import java.security.KeyStore;

--- a/cloudant-http/build.gradle
+++ b/cloudant-http/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 IBM Corp. All rights reserved.
+ * Copyright © 2016 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -15,7 +15,7 @@
 dependencies {
     compile group: 'commons-io', name: 'commons-io', version: '2.4'
     //needed to compile, but optional for consumers of java-cloudant
-    compile(group: 'com.squareup.okhttp', name: 'okhttp-urlconnection', version: '2.7.5') {
+    compile(group: 'com.squareup.okhttp3', name: 'okhttp-urlconnection', version: '3.4.2') {
         ext.optional = true
     }
 }

--- a/cloudant-http/src/main/java/com/cloudant/http/interceptors/SSLCustomizerInterceptor.java
+++ b/cloudant-http/src/main/java/com/cloudant/http/interceptors/SSLCustomizerInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 IBM Corp. All rights reserved.
+ * Copyright © 2015, 2016 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -41,6 +41,8 @@ public class SSLCustomizerInterceptor implements HttpConnectionRequestIntercepto
             AllowAllHostnameVerifier());
 
     private static final Logger LOGGER = Logger.getLogger(SSLCustomizerInterceptor.class.getName());
+    private static final X509Certificate[] EMPTY_ISSUERS = new X509Certificate[0];
+
     private final SSLSocketFactory sslSocketFactory;
     private final HostnameVerifier hostnameVerifier;
 
@@ -102,7 +104,7 @@ public class SSLCustomizerInterceptor implements HttpConnectionRequestIntercepto
                 @Override
                 public X509Certificate[] getAcceptedIssuers() {
                     //trust all issuers
-                    return null;
+                    return EMPTY_ISSUERS;
                 }
             }}, new SecureRandom());
 

--- a/cloudant-http/src/main/java/com/cloudant/http/internal/ok/OkHelper.java
+++ b/cloudant-http/src/main/java/com/cloudant/http/internal/ok/OkHelper.java
@@ -26,7 +26,7 @@ public class OkHelper {
     static {
         Class<?> okFactoryClass;
         try {
-            okFactoryClass = Class.forName("com.squareup.okhttp.OkUrlFactory");
+            okFactoryClass = Class.forName("okhttp3.OkUrlFactory");
         } catch (Throwable t) {
             okFactoryClass = null;
         }

--- a/cloudant-http/src/main/java/com/cloudant/http/internal/ok/OkHttpClientHttpUrlConnectionFactory.java
+++ b/cloudant-http/src/main/java/com/cloudant/http/internal/ok/OkHttpClientHttpUrlConnectionFactory.java
@@ -15,10 +15,11 @@
 package com.cloudant.http.internal.ok;
 
 import com.cloudant.http.internal.DefaultHttpUrlConnectionFactory;
-import com.squareup.okhttp.ConnectionSpec;
-import com.squareup.okhttp.Credentials;
-import com.squareup.okhttp.OkHttpClient;
-import com.squareup.okhttp.OkUrlFactory;
+
+import okhttp3.ConnectionSpec;
+import okhttp3.Credentials;
+import okhttp3.OkHttpClient;
+import okhttp3.OkUrlFactory;
 
 import java.io.IOException;
 import java.net.HttpURLConnection;
@@ -35,12 +36,11 @@ public class OkHttpClientHttpUrlConnectionFactory extends DefaultHttpUrlConnecti
     private static final Logger logger = Logger.getLogger(OkHttpClientHttpUrlConnectionFactory
             .class.getName());
 
-    private final OkHttpClient client;
-    private final OkUrlFactory factory;
+    private final OkHttpClient.Builder clientBuilder = new OkHttpClient().newBuilder();
+    private OkUrlFactory factory = null;
 
     public OkHttpClientHttpUrlConnectionFactory() {
-        client = new OkHttpClient();
-        client.setConnectionSpecs(Arrays.asList(
+        clientBuilder.connectionSpecs(Arrays.asList(
                 new ConnectionSpec[]{
                         ConnectionSpec.CLEARTEXT, // for http
                         new ConnectionSpec.Builder(ConnectionSpec.MODERN_TLS)
@@ -48,29 +48,32 @@ public class OkHttpClientHttpUrlConnectionFactory extends DefaultHttpUrlConnecti
                                 .allEnabledCipherSuites()
                                 .build() // for https
                 }));
-        factory = new OkUrlFactory(client);
     }
 
     @Override
     public HttpURLConnection openConnection(URL url) throws IOException {
+        if (factory == null) {
+            factory = new OkUrlFactory(clientBuilder.build());
+        }
         return factory.open(url);
     }
 
     @Override
     public void setProxy(URL proxyUrl) {
         super.setProxy(proxyUrl);
-        client.setProxy(proxy);
+        clientBuilder.proxy(proxy).build();
         logger.config(String.format("Configured HTTP proxy url %s", proxyUrl));
+    }
+
+    public OkHttpClient.Builder getOkHttpClientBuilder() {
+        return clientBuilder;
     }
 
     @Override
     public void setProxyAuthentication(PasswordAuthentication proxyAuthentication) {
-        client.setAuthenticator(new ProxyAuthenticator(Credentials.basic(proxyAuthentication
-                .getUserName(), new String(proxyAuthentication.getPassword()))));
-    }
-
-    public OkHttpClient getOkHttpClient() {
-        return client;
+        clientBuilder.proxyAuthenticator(new ProxyAuthenticator(Credentials.basic
+                (proxyAuthentication.getUserName(), new String(proxyAuthentication.getPassword())
+                )));
     }
 
 }


### PR DESCRIPTION
## What

Updated optional okhttp dependency version to 3.4.2.

## How

* Changed dependency version to 3.4.2 (including mockwebserver).
* Updated package names.
* Fixed 2.x calls that don’t work in 3.x.
    * Used new okhttp client builder.
    * Updated authenticator.
* Fix SSLInterceptor NPE
    * The spec states returning a non-null (possibly empty) array of issuers and whilst a null works on the default it causes a NPE in some implementations. Whilst I can’t find doc that clearly states it behaviour suggests that the empty array is a special case that doesn’t mean trust none, but trust all.
* Updated `CHANGES.md`.

## Testing

* Parameterised SSL tests for both HTTP implementation types to ensure that we get SSL coverage of both implementations and don't regress one or the other.
* Added `HttpFactoryParameterizedTest` to simplify tests that need both `HttpURLConnection` implementations.
