### PR TITLE
Preserve path for cookie authentication.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,8 +3,8 @@
 - [FIX] `NullPointerException` when calling `AllDocsResponse.getIdsAndRevs` for a request with
   multiple non-existent keys (IDs).
 - [IMPROVED] Preserved path elements from `URL`s used to construct a `ClientBuilder`.
-This allows, for example, a `CloudantClient`connection to use a gateway with a `URL` like
- `https://testproxy.example.net:443/cloudant/mydb`.
+  This allows, for example, a `CloudantClient`connection to use a gateway with a
+  `URL` like `https://testproxy.example.net:443/cloudant/mydb`.
 - [FIX] Fixed issue where DesignDocumentManager did not close a `FileInputStream`.
 
 # 2.6.2 (2016-09-20)

--- a/cloudant-client/src/main/java/com/cloudant/client/api/ClientBuilder.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/ClientBuilder.java
@@ -228,7 +228,7 @@ public class ClientBuilder {
             //make interceptor if both username and password are not null
 
             //Create cookie interceptor and set in HttpConnection interceptors
-            CookieInterceptor cookieInterceptor = new CookieInterceptor(username, password);
+            CookieInterceptor cookieInterceptor = new CookieInterceptor(username, password, this.url.toString());
 
             props.addRequestInterceptors(cookieInterceptor);
             props.addResponseInterceptors(cookieInterceptor);


### PR DESCRIPTION
## What

Preserve path for cookie authentication.

## How

Modify the constructor for `CookieInterceptor` to take the URL that the client was constructed with
to use as the base URL. 

## Testing

New test `testCookieAuthWithPath` in `HTTPTest`

## Issues

Fixes #320 
