### PR TITLE
325 url creds

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,6 @@
-# unreleased
+# Unreleased
+- [FIXED] Issue with double encoding of restricted URL characters in credentials when using
+   `ClientBuilder.url()`.
 - [NEW] Added `bluemix` method to the client builder allowing service credentials to be passed using
   the CloudFoundry VCAP_SERVICES environment variable.
 

--- a/cloudant-client/src/main/java/com/cloudant/client/api/ClientBuilder.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/ClientBuilder.java
@@ -34,10 +34,12 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonParseException;
 
+import java.io.UnsupportedEncodingException;
 import java.net.Authenticator;
 import java.net.MalformedURLException;
 import java.net.PasswordAuthentication;
 import java.net.URL;
+import java.net.URLDecoder;
 import java.security.Security;
 import java.util.ArrayList;
 import java.util.List;
@@ -194,12 +196,17 @@ public class ClientBuilder {
         }
         if (url.getUserInfo() != null) {
             //Get username and password and replace credential variables
-            this.username = url.getUserInfo().substring(0, url
-                    .getUserInfo()
-                    .indexOf(":"));
-            this.password = url.getUserInfo().substring(url
-                    .getUserInfo()
-                    .indexOf(":") + 1);
+            try {
+                this.username = URLDecoder.decode(url.getUserInfo().substring(0, url
+                        .getUserInfo()
+                        .indexOf(":")), "UTF-8");
+                this.password = URLDecoder.decode(url.getUserInfo().substring(url
+                        .getUserInfo()
+                        .indexOf(":") + 1), "UTF-8");
+            } catch (UnsupportedEncodingException e) {
+                // Should never happen UTF-8 is required in JVM
+                throw new RuntimeException(e);
+            }
         }
         
         // Check if a path exists and sanitize it by removing whitespace and any trailing /

--- a/cloudant-http/src/main/java/com/cloudant/http/interceptors/CookieInterceptor.java
+++ b/cloudant-http/src/main/java/com/cloudant/http/interceptors/CookieInterceptor.java
@@ -62,9 +62,11 @@ public class CookieInterceptor implements HttpConnectionRequestInterceptor,
     private final URL sessionURL;
 
     /**
-     * Constructs a cookie interceptor.
-     * @param username The username to use when getting the cookie
-     * @param password The password to use when getting the cookie
+     * Constructs a cookie interceptor. Credentials should be supplied not URL encoded, this class
+     * will perform the necessary URL encoding.
+     *
+     * @param username The username to use when getting the cookie (not URL encoded)
+     * @param password The password to use when getting the cookie (not URL encoded)
      * @param baseURL  The base URL to use when constructing an `_session` request.
      */
     public CookieInterceptor(String username, String password, String baseURL) {


### PR DESCRIPTION
## What

Prevented double encoding of URL user info when using `ClientBuilder.url()`.

## How

Added URL decoding to creds extracted from URL.
Clarified documentation on `CookieInterceptor` WRT to URL encoding of credentials.
Updated `CHANGES.md`.

## Testing

Added special character credentials tests
* Made `MockWebServer` available for all `CloudantClientTests`.
* Added new tests:
    - testUserInfoWithSpecials()
    - testUserInfoInUrlWithSpecials()

## Issues

Fixes #325 
