### PR TITLE
Add a method to GET standalone attachments

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 # Unreleased
+- [NEW] Add additional method to `GET` standalone attachments.
 - [FIXED] Issue with "+" (plus) not being regarded as a reserved character in URI path components.
 - [FIXED] Issue with double encoding of restricted URL characters in credentials when using
    `ClientBuilder.url()`.

--- a/cloudant-client/src/main/java/com/cloudant/client/api/Database.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/Database.java
@@ -944,6 +944,33 @@ public class Database {
     }
 
     /**
+     * Reads an attachment from the database.
+     *
+     * The stream must be closed after usage, otherwise http connection leaks will occur.
+     *
+     * @param docId the document id
+     * @param attachmentName the attachment name
+     * @return the attachment in the form of an {@code InputStream}.
+     */
+    public InputStream getAttachment(String docId, String attachmentName) {
+        return getAttachment(docId, attachmentName, null);
+    }
+
+    /**
+     * Reads an attachment from the database.
+     *
+     * The stream must be closed after usage, otherwise http connection leaks will occur.
+     *
+     * @param docId the document id
+     * @param attachmentName the attachment name
+     * @param revId the document revision id or {@code null}
+     * @return the attachment in the form of an {@code InputStream}.
+     */
+    public InputStream getAttachment(String docId, String attachmentName, String revId) {
+        return db.getAttachment(docId, attachmentName, revId);
+    }
+
+    /**
      * Creates an attachment from the specified InputStream and a new document with a generated
      * document ID.
      * <P>Example usage:</P>

--- a/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/CouchDatabaseBase.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/CouchDatabaseBase.java
@@ -299,6 +299,39 @@ public abstract class CouchDatabaseBase {
     }
 
     /**
+     * Reads an attachment from the database.
+     *
+     * The stream must be closed after usage, otherwise http connection leaks will occur.
+     *
+     * @param docId the document id
+     * @param attachmentName the attachment name
+     * @param revId the document revision id or {@code null}
+     * @return the attachment in the form of an {@code InputStream}.
+     */
+    public InputStream getAttachment(String docId, String attachmentName, String revId) {
+        final URI uri = new DatabaseURIHelper(dbUri).attachmentUri(docId, revId, attachmentName);
+        return getAttachment(uri);
+    }
+
+    /**
+     * Reads an attachment from the database.
+     *
+     * The stream must be closed after usage, otherwise http connection leaks will occur.
+     *
+     * @param uri the attachment URI
+     * @return the attachment in the form of an {@code InputStream}.
+     */
+    private InputStream getAttachment(URI uri) {
+        HttpConnection connection = Http.GET(uri);
+        couchDbClient.execute(connection);
+        try {
+            return connection.responseAsInputStream();
+        } catch (IOException e) {
+            throw new CouchDbException("Error retrieving response input stream.", e);
+        }
+    }
+
+    /**
      * Saves an attachment to a new document with a generated <tt>UUID</tt> as the document id.
      * <p>To retrieve an attachment, see {@link #find(String)}.
      *


### PR DESCRIPTION
## What
Add a method to `GET` standalone attachments.

## How
Reads an attachment from the database, returning an `InputStream`.

## Testing
Updates unit tests.

## Issues
Fixes #331.
