### PR TITLE
Include URL in the CouchDbException exception message

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 # Unreleased
+- [FIXED] Add URL to `CouchDbException` exception message (where applicable) for easier debugging.
 - [NEW] Add additional method to `GET` standalone attachments.
 - [FIXED] Issue with "+" (plus) not being regarded as a reserved character in URI path components.
 - [FIXED] Issue with double encoding of restricted URL characters in credentials when using

--- a/cloudant-client/.gitignore
+++ b/cloudant-client/.gitignore
@@ -1,1 +1,2 @@
 /build
+/bin/

--- a/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/CouchDbClient.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/CouchDbClient.java
@@ -554,10 +554,13 @@ public class CouchDbClient {
                         close(es);
                     }
                 }
+                ex.setUrl(connection.url.toString());
                 throw ex;
             }
         } catch (IOException ioe) {
-            throw new CouchDbException("Error retrieving server response", ioe);
+            CouchDbException ex = new CouchDbException("Error retrieving server response", ioe);
+            ex.setUrl(connection.url.toString());
+            throw ex;
         }
     }
 

--- a/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/CouchDbException.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/CouchDbException.java
@@ -39,6 +39,7 @@ public class CouchDbException extends RuntimeException {
     }
 
     private int statusCode;
+    private String url = null;
     protected String error = null;
     protected String reason = null;
 
@@ -74,9 +75,23 @@ public class CouchDbException extends RuntimeException {
 
     @Override
     public String getMessage() {
-        //improve the message with status code, error and reason if we have them
-        return ((getStatusCode() > 0) ? getStatusCode() + " " : "") + super.getMessage()
-                + ((error != null) ? ": " + getError() : "")
-                + ((reason != null) ? ": " + getReason() : "");
+        String msg = super.getMessage();
+        // trim trailing full stop
+        msg = (msg.endsWith(".")) ? msg.substring(0, msg.length() - 1) : msg;
+
+        // include the status code, URL, error and reason (if available)
+        return ((getStatusCode() > 0) ? getStatusCode() + " " : "") + msg
+                + ((url != null) ? " at " + url : "") + "."
+                + ((error != null) ? " Error: " + getError() + ".": "")
+                + ((reason != null) ? " Reason: " + getReason() + ".": "");
+    }
+
+    /**
+     * Set the URL that resulted in this exception being thrown.
+     *
+     * @param url the {@link String} representation of a URL
+     */
+    public void setUrl(String url) {
+        this.url = url;
     }
 }


### PR DESCRIPTION
## What
Include URL in the `CouchDbException` exception message (where applicable).

## How
Add a private `url` attribute to `CouchDbException`. The URL can be set via a setter or through an additional constructor. `.getMessage()` now includes the URL (if defined).

## Testing
No additional tests.

## Issues
Fixes #304.