### PR TITLE
 Regard "+" as reserved character in URI path components

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 # Unreleased
+- [FIXED] Issue with "+" (plus) not being regarded as a reserved character in URI path components.
 - [FIXED] Issue with double encoding of restricted URL characters in credentials when using
    `ClientBuilder.url()`.
 - [NEW] Added `bluemix` method to the client builder allowing service credentials to be passed using

--- a/cloudant-client/src/main/java/com/cloudant/client/internal/HierarchicalUriComponents.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/internal/HierarchicalUriComponents.java
@@ -118,12 +118,30 @@ public class HierarchicalUriComponents {
         PATH {
             @Override
             public boolean isAllowed(int c) {
+                if ('+' == c) {
+                    // CouchDB breaks RFC 3986 compliance by regarding the plus sign ("+") as a
+                    // reserved character in the URI path component (see
+                    // https://issues.apache.org/jira/browse/COUCHDB-1580). In order to conform with
+                    // the CouchDB API, isAllowed("+") must return false.
+                    return false;
+                }
+
+                // These are the RFC 3986 allowed characters for a path.
                 return isPchar(c) || '/' == c;
             }
         },
         PATH_SEGMENT {
             @Override
             public boolean isAllowed(int c) {
+                if ('+' == c) {
+                    // CouchDB breaks RFC 3986 compliance by regarding the plus sign ("+") as a
+                    // reserved character in the URI path component (see
+                    // https://issues.apache.org/jira/browse/COUCHDB-1580). In order to conform with
+                    // the CouchDB API, isAllowed("+") must return false.
+                    return false;
+                }
+
+                // These are the RFC 3986 allowed characters for a path segment.
                 return isPchar(c);
             }
         },

--- a/cloudant-client/src/test/java/com/cloudant/tests/HierarchicalUriComponentsTest.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/HierarchicalUriComponentsTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.tests;
+
+import static org.junit.Assert.assertEquals;
+
+import com.cloudant.client.internal.HierarchicalUriComponents;
+
+import org.junit.Test;
+
+import java.io.UnsupportedEncodingException;
+
+public class HierarchicalUriComponentsTest {
+
+    @Test
+    public void encodePathComponentContainingPlusSign() throws UnsupportedEncodingException {
+        String in = "/foo+bar/foo+bar/";
+        String out = HierarchicalUriComponents.encodeUriComponent(
+                in, "UTF-8", HierarchicalUriComponents.Type.PATH);
+
+        // Regard plus sign ("+") as reserved character,
+        // see https://issues.apache.org/jira/browse/COUCHDB-1580.
+        assertEquals("/foo%2Bbar/foo%2Bbar/", out);
+    }
+
+    @Test
+    public void encodePathSegmentComponentContainingPlusSign() throws UnsupportedEncodingException {
+        String in = "foo+bar";
+        String out = HierarchicalUriComponents.encodeUriComponent(
+                in, "UTF-8", HierarchicalUriComponents.Type.PATH_SEGMENT);
+
+        // Regard plus sign ("+") as reserved character,
+        // see https://issues.apache.org/jira/browse/COUCHDB-1580.
+        assertEquals("foo%2Bbar", out);
+    }
+}


### PR DESCRIPTION
## What
Regard plus sign ("+") as reserved character in URI path and path segment components.

## How
Alter logic so that `type.isAllowed("+") = false` for `PATH` and `PATH_SEGMENT` types. This ensures that the plus sign ("+") is treated as a reserved character and therefore encoded as `%2B`.

## Testing
Includes additional unit tests.

## Issues
Fixes #335.
