### PR TITLE
Ensured VERSION file has qualified path

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ subprojects {
     apply plugin: 'signing'
 
     group = 'com.cloudant'
-    version = new File('VERSION').text.trim()
+    version = new File(rootDir, 'VERSION').text.trim()
 
     // Note the gradle subproject names (e.g. cloudant-client, cloudant-http) are the maven
     // artifactIds - the maven pom project name entry and User-Agent name in com.cloudant.client.properties are


### PR DESCRIPTION
## What

Ensured `VERSION` file has qualified path

## Why

Running in the IDE could use a working directory at a lower level than the project root and hence `VERSION` file and therefore throw an error when building.
```
FAILURE: Build failed with an exception.
* Where:
Build file '.../java-cloudant/build.gradle' line: 21
* What went wrong:
A problem occurred evaluating root project 'java-cloudant'.
> VERSION (No such file or directory)
```

## How

Added `rootDir` to `VERSION` file path before reading in `build.gradle`.

## Testing

Existing tests pass.
