### PR TITLE
Okhttp shutdown

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 - [FIXED] Add URL to `CouchDbException` exception message (where applicable) for easier debugging.
 - [NEW] Add additional method to `GET` standalone attachments.
 - [FIXED] Issue with "+" (plus) not being regarded as a reserved character in URI path components.
+- [IMPROVED] Faster shutdown when using the optional OkHttp client.
 - [FIXED] Issue with double encoding of restricted URL characters in credentials when using
    `ClientBuilder.url()`.
 - [NEW] Added `bluemix` method to the client builder allowing service credentials to be passed using

--- a/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/CouchDbClient.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/CouchDbClient.java
@@ -155,6 +155,8 @@ public class CouchDbClient {
             log.warning("Error deleting session on client shutdown.");
         }
         // The execute method handles non-2xx response codes by throwing a CouchDbException.
+
+        factory.shutdown();
     }
 
     /**

--- a/cloudant-http/src/main/java/com/cloudant/http/HttpConnection.java
+++ b/cloudant-http/src/main/java/com/cloudant/http/HttpConnection.java
@@ -470,6 +470,11 @@ public class HttpConnection {
          * @param proxyAuthentication the password authentication to use for the proxy connection
          */
         void setProxyAuthentication(PasswordAuthentication proxyAuthentication);
+
+        /**
+         * Give the connection provider an opportunity to clean up
+         */
+        void shutdown();
     }
 
     /**

--- a/cloudant-http/src/main/java/com/cloudant/http/internal/DefaultHttpUrlConnectionFactory.java
+++ b/cloudant-http/src/main/java/com/cloudant/http/internal/DefaultHttpUrlConnectionFactory.java
@@ -60,4 +60,9 @@ public class DefaultHttpUrlConnectionFactory implements HttpConnection.HttpUrlCo
         // be irresponsible to set the default Authenticator because it applies globally and we
         // might disrupt other applications in the JVM.
     }
+
+    @Override
+    public void shutdown() {
+        // No - op
+    }
 }

--- a/cloudant-http/src/main/java/com/cloudant/http/internal/ok/OkHttpClientHttpUrlConnectionFactory.java
+++ b/cloudant-http/src/main/java/com/cloudant/http/internal/ok/OkHttpClientHttpUrlConnectionFactory.java
@@ -26,6 +26,7 @@ import java.net.HttpURLConnection;
 import java.net.PasswordAuthentication;
 import java.net.URL;
 import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 
 /**
@@ -76,4 +77,15 @@ public class OkHttpClientHttpUrlConnectionFactory extends DefaultHttpUrlConnecti
                 )));
     }
 
+    @Override
+    public void shutdown() {
+        try {
+            factory.client().dispatcher().executorService().shutdown();
+            factory.client().dispatcher().executorService().awaitTermination(5, TimeUnit.MINUTES);
+            // Evict all the connections
+            factory.client().connectionPool().evictAll();
+        } catch (InterruptedException e) {
+            // Oh well; we were only trying to aggressively shutdown
+        }
+    }
 }


### PR DESCRIPTION
## What

Added shutdown for the optional OkHttp client.

## How

Added connection factory shutdown methods.

Whilst https://square.github.io/okhttp/3.x/okhttp/okhttp3/OkHttpClient.html states that shutdown isn't necessary, it has been observed that, for example, sample applications can take some time to exit when using OkHttp as the threads shutdown. There are some shutdown procedures documented there that make things faster.
Added OK implementation that:
* Shuts down the dispatcher and awaits termination
* Evicts all the connection pool threads

## Testing

There are no new tests added for this because I can't think of a good way to test it explicitly within the framework. The `shutdown` is called as part of the tear down of most tests so the code should at least be exercised well.
