### PR TITLE
Fixed connect test

### DIFF
--- a/cloudant-client/src/test/java/com/cloudant/tests/DesignDocumentsTest.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/DesignDocumentsTest.java
@@ -34,7 +34,6 @@ import com.cloudant.test.main.RequiresCloudant;
 import com.cloudant.test.main.RequiresDB;
 import com.cloudant.tests.util.CloudantClientResource;
 import com.cloudant.tests.util.DatabaseResource;
-import com.cloudant.tests.util.MockWebServerResources;
 import com.cloudant.tests.util.Utils;
 import com.google.gson.JsonObject;
 
@@ -46,7 +45,7 @@ import org.junit.experimental.categories.Category;
 
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
-import okhttp3.mockwebserver.RecordedRequest;
+import okhttp3.mockwebserver.SocketPolicy;
 
 import java.io.File;
 import java.util.Collections;
@@ -347,17 +346,7 @@ public class DesignDocumentsTest {
         CloudantClient mockClient = CloudantClientHelper.newMockWebServerClientBuilder
                 (mockWebServer).readTimeout(50, TimeUnit.MILLISECONDS).build();
         // Cause a read timeout to generate an IOException
-        mockWebServer.setDispatcher(new MockWebServerResources.SleepingDispatcher(100, TimeUnit
-                .MILLISECONDS) {
-            @Override
-            public MockResponse dispatch(RecordedRequest request) throws InterruptedException {
-                if ("HEAD".equals(request.getMethod())) {
-                    return super.dispatch(request);
-                } else {
-                    return new MockResponse();
-                }
-            }
-        });
+        mockWebServer.enqueue(new MockResponse().setSocketPolicy(SocketPolicy.NO_RESPONSE));
         Database database = mockClient.database(dbResource.getDatabaseName(), false);
         // Try to remove a design document by id only, generates a HEAD request for revision info
         database.getDesignDocumentManager().remove("example");

--- a/cloudant-client/src/test/java/com/cloudant/tests/util/MockWebServerResources.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/util/MockWebServerResources.java
@@ -106,27 +106,6 @@ public class MockWebServerResources {
     }
 
     /**
-     * A dispatcher that sleeps for the time specified at construction on each request before
-     * responding. Useful for getting a SocketTimeoutException.
-     */
-    public static class SleepingDispatcher extends Dispatcher {
-
-        private final long sleepTime;
-        private final TimeUnit unit;
-
-        public SleepingDispatcher(long sleepTime, TimeUnit unit) {
-            this.sleepTime = sleepTime;
-            this.unit = unit;
-        }
-
-        @Override
-        public MockResponse dispatch(RecordedRequest request) throws InterruptedException {
-            unit.sleep(sleepTime);
-            return new MockResponse();
-        }
-    }
-
-    /**
      * A dispatcher that repeatedly returns the same status code for all requests.
      */
     public static class ConstantResponseDispatcher extends Dispatcher {


### PR DESCRIPTION
## What

Fixed long delay in the `connectionTimeout()` test.

## How

The `connectionTimeout()` test was passing, but taking a lot longer than it should. Refactored to use the loopback address for that test to resolve the issue on some JVMs. On OpenJDK there is no difference between the connect and read timeouts (at least for the way this test provokes a connect timeout), so had to add a read timeout as well to make sure it didn't take 5 minutes.

Removed `SleepingDispatcher` class in favour of using MockWebServer’s `SocketPolicy.NO_RESPONSE`, which was able to recreate the behaviour needed for the timeout tests using the sleeping dispatcher. Refactored those tests as necessary.

## Testing

Test only changes.