### PR TITLE
Add createTextIndex

### DIFF
--- a/cloudant-client/src/main/java/com/cloudant/client/api/Database.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/Database.java
@@ -289,7 +289,26 @@ public class Database {
         createIndex(indexDefn.toString());
     }
 
-    /* TODO doc */
+    /**
+     * <p>
+     * Create a new text index
+     * </p>
+     * <p>
+     * Example usage of creating an index:
+     * </p>
+     * <pre>
+     * {@code
+     * db.createTextIndex("Movie_name", "Movie_name", "standard", new TextIndexField[]{
+     *     new TextIndexField("Movie_name", "string")});
+     * }
+     * </pre>
+     * @param indexName     optional name of the index (if not provided one will be generated)
+     * @param designDocName optional name of the design doc in which the index will be created
+     * @param analyzer      optional text <a target="_blank"
+     *                      href="https://console.ng.bluemix.net/docs/services/Cloudant/api/search.html#analyzers">
+     *                      analyzer</a>
+     * @param fields        array of fields in the index
+     */
     public void createTextIndex(String indexName, String designDocName, String analyzer,
                             TextIndexField[] fields) {
         JsonObject indexDefn = getTextIndexDefinition(indexName, designDocName, "text", analyzer, fields);

--- a/cloudant-client/src/main/java/com/cloudant/client/api/Database.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/Database.java
@@ -29,6 +29,7 @@ import com.cloudant.client.api.model.IndexField;
 import com.cloudant.client.api.model.Params;
 import com.cloudant.client.api.model.Permissions;
 import com.cloudant.client.api.model.Shard;
+import com.cloudant.client.api.model.TextIndexField;
 import com.cloudant.client.api.views.AllDocsRequestBuilder;
 import com.cloudant.client.api.views.ViewRequestBuilder;
 import com.cloudant.client.internal.DatabaseURIHelper;
@@ -285,6 +286,13 @@ public class Database {
     public void createIndex(String indexName, String designDocName, String indexType,
                             IndexField[] fields) {
         JsonObject indexDefn = getIndexDefinition(indexName, designDocName, indexType, fields);
+        createIndex(indexDefn.toString());
+    }
+
+    /* TODO doc */
+    public void createTextIndex(String indexName, String designDocName, String analyzer,
+                            TextIndexField[] fields) {
+        JsonObject indexDefn = getTextIndexDefinition(indexName, designDocName, "text", analyzer, fields);
         createIndex(indexDefn.toString());
     }
 
@@ -1162,8 +1170,36 @@ public class Database {
     /**
      * Form a create index json from parameters
      */
-    private JsonObject getIndexDefinition(String indexName, String designDocName,
-                                          String indexType, IndexField[] fields) {
+    private JsonObject getIndexDefinition(String indexName, String designDocName, String analyzer, IndexField[] fields) {
+        assertNotEmpty(fields, "index fields");
+        JsonObject indexObject = new JsonObject();
+        if (!(indexName == null || indexName.isEmpty())) {
+            indexObject.addProperty("name", indexName);
+        }
+        if (!(designDocName == null || designDocName.isEmpty())) {
+            indexObject.addProperty("ddoc", designDocName);
+        }
+        indexObject.addProperty("type", "json");
+
+        JsonArray fieldsArray = new JsonArray();
+        for (int i = 0; i < fields.length; i++) {
+            JsonObject fieldObject = new JsonObject();
+            fieldObject.addProperty(fields[i].getName(), fields[i].getOrder().toString());
+            fieldsArray.add(fieldObject);
+        }
+        JsonObject arrayOfFields = new JsonObject();
+        arrayOfFields.add("fields", fieldsArray);
+        indexObject.add("index", arrayOfFields);
+
+        return indexObject;
+    }
+
+
+    /**
+     * Form a create index json from parameters
+     */
+    private JsonObject getTextIndexDefinition(String indexName, String designDocName,
+                                          String indexType, String analyzer, TextIndexField[] fields) {
         assertNotEmpty(fields, "index fields");
         JsonObject indexObject = new JsonObject();
         if (!(indexName == null || indexName.isEmpty())) {
@@ -1180,10 +1216,17 @@ public class Database {
         JsonArray fieldsArray = new JsonArray();
         for (int i = 0; i < fields.length; i++) {
             JsonObject fieldObject = new JsonObject();
-            fieldObject.addProperty(fields[i].getName(), fields[i].getOrder().toString());
+            fieldObject.addProperty("name", fields[i].getName());
+            fieldObject.addProperty("type", fields[i].getType());
             fieldsArray.add(fieldObject);
         }
         JsonObject arrayOfFields = new JsonObject();
+        if (!(analyzer == null || analyzer.isEmpty())) {
+            JsonObject defaultField = new JsonObject();
+            arrayOfFields.add("default_field", defaultField);
+            defaultField.addProperty("enabled", true);
+            defaultField.addProperty("analyzer", analyzer);
+        }
         arrayOfFields.add("fields", fieldsArray);
         indexObject.add("index", arrayOfFields);
 

--- a/cloudant-client/src/main/java/com/cloudant/client/api/Database.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/Database.java
@@ -283,9 +283,10 @@ public class Database {
      * @param indexType     optional, type of index (only "json" as of now)
      * @param fields        array of fields in the index
      */
+    // NB: `indexType` is ignored, but is in the argument list to not break API compatibility
     public void createIndex(String indexName, String designDocName, String indexType,
                             IndexField[] fields) {
-        JsonObject indexDefn = getIndexDefinition(indexName, designDocName, indexType, fields);
+        JsonObject indexDefn = getIndexDefinition(indexName, designDocName, fields);
         createIndex(indexDefn.toString());
     }
 
@@ -1189,7 +1190,7 @@ public class Database {
     /**
      * Form a create index json from parameters
      */
-    private JsonObject getIndexDefinition(String indexName, String designDocName, String analyzer, IndexField[] fields) {
+    private JsonObject getIndexDefinition(String indexName, String designDocName, IndexField[] fields) {
         assertNotEmpty(fields, "index fields");
         JsonObject indexObject = new JsonObject();
         if (!(indexName == null || indexName.isEmpty())) {

--- a/cloudant-client/src/main/java/com/cloudant/client/api/model/IndexField.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/model/IndexField.java
@@ -14,6 +14,8 @@
 
 package com.cloudant.client.api.model;
 
+import com.google.gson.annotations.SerializedName;
+
 /**
  * Encapsulates a Cloudant IndexField definition
  *
@@ -23,7 +25,12 @@ package com.cloudant.client.api.model;
 public class IndexField {
 
     /**
-     * Ascending or descending sort order
+     * <p>
+     * JSON indexes: Ascending or descending sort order
+     * </p>
+     * <p>
+     * Text indexes: field type (boolean, string, or number)
+     * </p>
      */
     public enum SortOrder {
         /**
@@ -33,7 +40,11 @@ public class IndexField {
         /**
          * descending
          */
-        desc
+        desc,
+        @SerializedName("boolean")
+        bool,
+        string,
+        number
     }
 
     private String name;
@@ -48,7 +59,7 @@ public class IndexField {
     }
 
     /**
-     * @return the order
+     * @return the order (JSON indexes), or type (text indexes)
      */
     public SortOrder getOrder() {
         return order;

--- a/cloudant-client/src/main/java/com/cloudant/client/api/model/TextIndexField.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/model/TextIndexField.java
@@ -1,0 +1,24 @@
+package com.cloudant.client.api.model;
+
+/**
+ * Created by tomblench on 22/03/2017.
+ */
+public class TextIndexField {
+
+    private String name;
+
+    private String type;
+
+    public TextIndexField(String name, String type) {
+        this.name = name;
+        this.type = type;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getType() {
+        return type;
+    }
+}

--- a/cloudant-client/src/test/java/com/cloudant/tests/IndexTests.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/IndexTests.java
@@ -107,7 +107,9 @@ public class IndexTests {
             while (flds.hasNext()) {
                 IndexField fld = flds.next();
                 assertNotNull(fld.getName());
-                assertNotNull(fld.getOrder());
+                if (i.getType().equals("json")) {
+                    assertNotNull(fld.getOrder());
+                }
             }
 
         }

--- a/cloudant-client/src/test/java/com/cloudant/tests/IndexTests.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/IndexTests.java
@@ -25,6 +25,7 @@ import com.cloudant.client.api.model.FindByIndexOptions;
 import com.cloudant.client.api.model.Index;
 import com.cloudant.client.api.model.IndexField;
 import com.cloudant.client.api.model.IndexField.SortOrder;
+import com.cloudant.client.api.model.TextIndexField;
 import com.cloudant.test.main.RequiresCloudant;
 import com.cloudant.tests.util.CloudantClientResource;
 import com.cloudant.tests.util.DatabaseResource;
@@ -83,6 +84,7 @@ public class IndexTests {
                         new IndexField("Movie_year", SortOrder.asc)});
         db.createIndex("Movie_year", "Movie_year", null,
                 new IndexField[]{new IndexField("Movie_year", SortOrder.asc)});
+        db.createTextIndex("Text_index_standard", "Text_index_standard", "standard", new TextIndexField[]{new TextIndexField("Movie_name", "string")});
 
         //Create selector object: {"Movie_year": { "$gt": 1960}, "Person_name": "Alec Guinness"}
         Map<String, Object> year = new HashMap<String, Object>();
@@ -353,6 +355,22 @@ public class IndexTests {
                 "Person_name").useIndex("Movie_year");
         assertUseIndexString(getUseIndexFromRequest(options));
     }
+
+    @Test
+    public void testTextIndex() {
+        List<Movie> movies = db.findByIndex("\"selector\": { \"$text\": \"Simpsons\"}",
+                Movie.class,
+                new FindByIndexOptions()
+                        .fields("Movie_name").fields("Movie_year"));
+        assertNotNull(movies);
+        assert (movies.size() > 0);
+        for (Movie m : movies) {
+            assertNotNull(m.getMovie_name());
+            assertNotNull(m.getMovie_year());
+        }
+    }
+
+
 
     /**
      * Uses a mock web server to record a _find request using the specified options


### PR DESCRIPTION
See #166

_What_

Add support for creating text indexes in Cloudant Query

_How_

Add `createTextIndex` method to `Database` and `TextIndexField` class.

_Testing_

Add `testTextIndex` test method.

_TODO_
- ~~javadoc~~
- other documentation
- more tests?