### PR TITLE
Support faceted search with multiple values for the drill down

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+# UNRELEASED
+- [NEW] Add faceted search variable argument to `drillDown` method allowing multiple drill down
+  values to be specified for a single field name.
+- [DEPRECATED] The `drillDown(String, String)` method. Use new `drillDown(String, String...)` which
+  allows multiple drill down values.
+
 # 2.8.0 (2017-02-15)
 - [NEW] Added `bluemix` method to the client builder allowing service credentials to be passed using
   the CloudFoundry VCAP_SERVICES environment variable.

--- a/cloudant-client/src/main/java/com/cloudant/client/api/Search.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/Search.java
@@ -365,7 +365,9 @@ public class Search {
      * @return this for additional parameter setting or to query
      * @see <a target="_blank" href="https://docs.cloudant.com/search.html#faceting">drilldown
      * query parameter</a>
+     * @deprecated Use {@link #drillDown(String, String...)}
      */
+    @Deprecated
     public Search drillDown(String fieldName, String fieldValue) {
         assertNotEmpty(fieldName, "fieldName");
         assertNotEmpty(fieldValue, "fieldValue");
@@ -378,6 +380,26 @@ public class Search {
         return this;
     }
 
+    /**
+     * @param fieldName   the name of the field
+     * @param fieldValues field values to add
+     * @return this for additional parameter setting or to query
+     * @see <a target="_blank" href="https://docs.cloudant.com/search.html#faceting">drilldown
+     * query parameter</a>
+     */
+    public Search drillDown(String fieldName, String... fieldValues) {
+        assertNotEmpty(fieldName, "fieldName");
+        assertNotEmpty(fieldValues, "fieldValues");
+        JsonArray drillDownArray = new JsonArray();
+        JsonPrimitive fieldNamePrimitive = new JsonPrimitive(fieldName);
+        drillDownArray.add(fieldNamePrimitive);
+        for (String fieldValue : fieldValues) {
+            JsonPrimitive fieldValuePrimitive = new JsonPrimitive(fieldValue);
+            drillDownArray.add(fieldValuePrimitive);
+        }
+        databaseHelper.query("drilldown", drillDownArray, false);
+        return this;
+    }
 
     /**
      * @param stale Accept values: ok

--- a/cloudant-client/src/test/java/com/cloudant/tests/SearchTests.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/SearchTests.java
@@ -16,6 +16,7 @@ package com.cloudant.tests;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import com.cloudant.client.api.CloudantClient;
 import com.cloudant.client.api.Database;
@@ -37,6 +38,8 @@ import org.junit.rules.RuleChain;
 
 import java.io.File;
 import java.net.URI;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -199,6 +202,24 @@ public class SearchTests {
         assertEquals(new Long(0), rslt.getRanges().get("min_length").get("small"));
         assertEquals(new Long(0), rslt.getRanges().get("min_length").get("medium"));
         assertEquals(new Long(0), rslt.getRanges().get("min_length").get("large"));
+    }
+
+    @Test
+    public void multiValueDrillDownTest() {
+        // do a faceted search for multi-value drilldown
+        Search srch = db.search("views101/animals");
+        SearchResult<Animal> rslt = srch.includeDocs(true)
+                .drillDown("diet", "carnivore", "omnivore")
+                .querySearchResult("class:mammal", Animal.class);
+        assertNotNull(rslt);
+        assertEquals(4, rslt.getTotalRows());
+
+        List<String> ids = new ArrayList<String>();
+        for (SearchResultRow row : rslt.getRows()) {
+            ids.add(row.getId());
+        }
+        List<String> expectedIds = Arrays.asList("panda", "aardvark", "badger", "lemur");
+        assertTrue(ids.containsAll(expectedIds));
     }
 
     @Test


### PR DESCRIPTION
## What
Add faceted search variable argument to `drillDown` method allowing multiple drill down values to be specified.

_This is a minor version change to the API as it does not break binary compatibility._

## How
`drillDown` method now takes variable argument as `fieldValues`.

## Testing
Includes additional until test.

## Issues
- Fixes #350 
