### PR TITLE
Remove OpenJDK7 from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: java
 sudo: false
 
 jdk:
-  - openjdk7
   - oraclejdk8
 
 services:


### PR DESCRIPTION
Due to a bug in OpenJDK7, gradlew can't bootstrap and download the gradle jar.

See https://bugs.openjdk.java.net/browse/JDK-8080102 and https://redmine.dataone.org/issues/8101
