### PR TITLE
369 update search javadoc

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 # 2.10.0 (Unreleased)
 - [NEW] Add IAM cookie authentication method.
+- [IMPROVED] Clarified documentation for search indexes.
 
 # 2.9.0 (2017-04-26)
 - [NEW] Add faceted search variable argument to `drillDown` method allowing multiple drill down

--- a/cloudant-client/src/main/java/com/cloudant/client/api/Database.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/Database.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 IBM Corp. All rights reserved.
+ * Copyright (c) 2016, 2017 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -441,7 +441,18 @@ public class Database {
     /**
      * Provides access to Cloudant <tt>Search</tt> APIs.
      *
-     * @param searchIndexId the name of the index to search
+     * <p>Example usage:</p>
+     * <pre>
+     * {@code
+     *  // Search query using design document _id '_design/views101' and search index 'animals'
+     *  List<Bird> birds = db.search("views101/animals")
+     * 	.limit(10)
+     * 	.includeDocs(true)
+     * 	.query("class:bird", Bird.class);
+     * 	}
+     * </pre>
+     *
+     * @param searchIndexId the design document with the name of the index to search
      * @return Search object for searching the index
      * @see <a target="_blank" href="https://docs.cloudant.com/search.html">Search</a>
      */

--- a/cloudant-client/src/main/java/com/cloudant/client/api/Search.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/Search.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 IBM Corp. All rights reserved.
+ * Copyright (c) 2015, 2017 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -46,9 +46,12 @@ import java.util.logging.Logger;
 
 /**
  * This class provides access to the Cloudant <tt>Search</tt> APIs.
+ * <p><b>Note</b>: The design document name and search index name are required.
+ * Do not include the {@code _design} prefix from the {@code _id} of the design document.
  * <p>Usage Example:</p>
  * <pre>
  * {@code
+ *  // Search query using design document _id '_design/views101' and search index 'animals'
  *  List<Bird> birds = db.search("views101/animals")
  * 	.limit(10)
  * 	.includeDocs(true)


### PR DESCRIPTION
## What

Updated javadoc for `search` to clarify that the design document name (without `_design` prefix) and index name should be passed in when performing a query.

## Testing

No tests required.

## Issues

#369 
