### PR TITLE
Session connection leaks

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # 2.10.0 (Unreleased)
 - [NEW] Add IAM cookie authentication method.
 - [IMPROVED] Clarified documentation for search indexes.
+- [FIXED] Connection leaks in some session renewal error scenarios.
 
 # 2.9.0 (2017-04-26)
 - [NEW] Add faceted search variable argument to `drillDown` method allowing multiple drill down

--- a/cloudant-client/build.gradle
+++ b/cloudant-client/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 IBM Corp. All rights reserved.
+ * Copyright © 2016, 2017 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at

--- a/cloudant-client/build.gradle
+++ b/cloudant-client/build.gradle
@@ -27,7 +27,7 @@ dependencies {
     //test dependencies
     testCompile group: 'junit', name: 'junit', version: '4.12'
     testCompile group: 'com.squareup.okhttp3', name: 'mockwebserver', version: '3.4.2'
-    testCompile group: 'org.jmockit', name: 'jmockit', version: '1.25'
+    testCompile group: 'org.jmockit', name: 'jmockit', version: '1.34'
     testCompile group: 'org.littleshoot', name: 'littleproxy', version: '1.1.0'
 }
 

--- a/cloudant-client/src/test/java/com/cloudant/tests/CloudantClientTests.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/CloudantClientTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015, 2016 IBM Corp. All rights reserved.
+ * Copyright © 2015, 2017 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -29,6 +29,7 @@ import com.cloudant.client.org.lightcouch.CouchDbException;
 import com.cloudant.client.org.lightcouch.NoDocumentException;
 import com.cloudant.client.org.lightcouch.PreconditionFailedException;
 import com.cloudant.http.Http;
+import com.cloudant.http.HttpConnection;
 import com.cloudant.http.interceptors.BasicAuthInterceptor;
 import com.cloudant.http.internal.interceptors.UserAgentInterceptor;
 import com.cloudant.test.main.RequiresCloudant;
@@ -415,8 +416,10 @@ public class CloudantClientTests {
         server.enqueue(MockWebServerResources.OK_COOKIE);
         server.enqueue(MockWebServerResources.JSON_OK);
 
-        c.executeRequest(Http.GET(c.getBaseUri()));
-
+        HttpConnection conn = c.executeRequest(Http.GET(c.getBaseUri()));
+        // Consume response stream and assert ok: true
+        String responseStr = conn.responseAsString();
+        assertNotNull(responseStr);
 
         // One request to _session then one to get info
         assertEquals("There should be two requests", 2, server.getRequestCount());

--- a/cloudant-client/src/test/java/com/cloudant/tests/HttpTest.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/HttpTest.java
@@ -50,6 +50,7 @@ import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
 
+import org.apache.commons.io.IOUtils;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -562,6 +563,9 @@ public class HttpTest extends HttpFactoryParameterizedTest {
                 try {
                     if (444 == context.connection.getConnection().getResponseCode()) {
                         context.replayRequest = true;
+                        // Close the error stream
+                        InputStream errors = context.connection.getConnection().getErrorStream();
+                        if (errors != null) IOUtils.closeQuietly(errors);
                     }
                 } catch (IOException e) {
                     e.printStackTrace();

--- a/cloudant-http/src/main/java/com/cloudant/http/interceptors/Replay429Interceptor.java
+++ b/cloudant-http/src/main/java/com/cloudant/http/interceptors/Replay429Interceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 IBM Corp. All rights reserved.
+ * Copyright © 2016, 2017 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -16,12 +16,10 @@ package com.cloudant.http.interceptors;
 
 import com.cloudant.http.HttpConnectionInterceptorContext;
 import com.cloudant.http.HttpConnectionResponseInterceptor;
+import com.cloudant.http.internal.Utils;
 import com.cloudant.http.internal.interceptors.HttpConnectionInterceptorException;
 
-import org.apache.commons.io.IOUtils;
-
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -137,17 +135,8 @@ public class Replay429Interceptor implements HttpConnectionResponseInterceptor {
                     }
                 }
                 // Read the reasons and log a warning
-                InputStream errorStream = urlConnection.getErrorStream();
-                try {
-                    String errorString = IOUtils.toString(errorStream, "UTF-8");
-                    logger.warning(errorString + " will retry in " +
-                            sleepTime + " ms");
-
-                } finally {
-                    errorStream.close();
-                }
-
-
+                String errorString = Utils.collectAndCloseStream(urlConnection.getErrorStream());
+                logger.warning(errorString + " will retry in " + sleepTime + " ms");
                 logger.fine("Too many requests backing off for " + sleepTime + " ms.");
 
                 // Sleep the thread for the appropriate backoff time

--- a/cloudant-http/src/main/java/com/cloudant/http/internal/Utils.java
+++ b/cloudant-http/src/main/java/com/cloudant/http/internal/Utils.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.http.internal;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.io.output.NullOutputStream;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class Utils {
+
+    private static final Logger logger = Logger.getLogger(Utils.class.getName());
+
+    /**
+     * Closes a closeable (usually stream), suppressing any IOExceptions.
+     *
+     * @param closeable the resource to close quietly, may be {@code null}
+     */
+    public static void close(Closeable closeable) {
+        if (closeable != null) {
+            try {
+                closeable.close();
+            } catch (IOException ioe) {
+                // Suppress the exception
+                logger.log(Level.FINEST, "Unable to close resource.", ioe);
+            }
+        }
+    }
+
+    /**
+     * Consumes any available content from the stream (effectively sending it to /dev/null).
+     *
+     * @param is the stream to consume, may be {@code null}
+     */
+    public static void consumeStream(InputStream is) {
+        if (is != null) {
+            try {
+                // Copy the stream to a null destination
+                long copied = IOUtils.copyLarge(is, NullOutputStream.NULL_OUTPUT_STREAM);
+                if (copied > 0) {
+                    logger.log(Level.WARNING, "Consumed unused HTTP response error stream.");
+                }
+            } catch (IOException ioe) {
+                // The stream was probably already closed, there's nothing further we can do anyway
+                logger.log(Level.FINEST, "Unable to consume stream.", ioe);
+            }
+        }
+    }
+
+    /**
+     * Equivalent to {@link Utils#consumeStream} followed by {@link Utils#close}.
+     *
+     * @param is - an input stream to consume and close, may be {@code null}
+     */
+    public static void consumeAndCloseStream(InputStream is) {
+        try {
+            consumeStream(is);
+        } finally {
+            close(is);
+        }
+    }
+
+    /**
+     * Collects the string content of a stream (UTF8) and then closes it.
+     *
+     * @param is - an input stream to consume and close, may be {@code null}
+     * @return UTF-8 string content of the stream or null if there was no stream
+     * @throws IOException if there was a problem reading the stream
+     */
+    public static String collectAndCloseStream(InputStream is) throws IOException {
+        if (is != null) {
+            try {
+                return IOUtils.toString(is, "UTF-8");
+            } finally {
+                close(is);
+            }
+        } else {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://github.com/cloudant/java-cloudant/blob/master/DCO1.1.txt)
- [x] You have added tests for any code changes
- [x] You have updated the [CHANGES.md](https://github.com/cloudant/java-cloudant/blob/master/CHANGES.md) 
- [x] You have completed the PR template below:

## What

Fixed various connection leaks.

## How

Fixed connection leaks:
* Ensured the error stream is consumed in `CookieInterceptorBase`.
* Added a defensive attempt to cleanup to the `HttpConnection` so any missed consumes will be handled as a last resort.

Renamed some fields from `*Session*` to `*Token*` in the `IamCookieInterceptor` to avoid confusion since they were associated with requests to the token endpoint not the `_iam_session` endpoint.

## Testing

Existing tests using OkHttp exposed messages in the logs for these leaks.
Fixed tests that were themselves leaking connections:
* `com.cloudant.tests.CloudantClientTests#testUserInfoWithSpecials`.
* `com.cloudant.tests.CloudantClientTests#testUserInfoInUrlWithSpecials`.
* `com.cloudant.tests.CloudantClientTests#testUserInfoInUrl`.
* `com.cloudant.tests.HttpTest` inputStreamRetry tests.
* `com.cloudant.tests.SessionInterceptorExpiryTests`

Fixed NPE in `com.cloudant.tests.HttpIamTest`.

## Issues

N/A
