### PR TITLE
Query selector builder

### DIFF
--- a/cloudant-client/src/main/java/com/cloudant/client/api/query/Expression.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/query/Expression.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package com.cloudant.client.api.query;
+
+import static com.cloudant.client.internal.query.Helpers.quote;
+
+// expression, such as "widget_count" "$eq" 5
+public class Expression implements OperationOrExpression {
+
+    private String lhs;
+    private String op;
+    private Object[] rhs;
+
+    public Expression(String lhs, String op, Object... rhs) {
+        this.lhs = lhs;
+        this.op = op;
+        this.rhs = rhs;
+    }
+
+    public static Expression lt(String lhs, Object rhs) {
+        return new Expression(lhs, "$lt", rhs);
+    }
+
+    public static Expression lte(String lhs, Object rhs) {
+        return new Expression(lhs, "$lte", rhs);
+    }
+
+    public static Expression eq(String lhs, Object rhs) {
+        return new Expression(lhs, "$eq", rhs);
+    }
+
+    public static Expression ne(String lhs, Object rhs) {
+        return new Expression(lhs, "$ne", rhs);
+    }
+
+    public static Expression gte(String lhs, Object rhs) {
+        return new Expression(lhs, "$gte", rhs);
+    }
+
+    public static Expression gt(String lhs, Object rhs) {
+        return new Expression(lhs, "$gt", rhs);
+    }
+
+    public static Expression exists(String lhs, boolean rhs) {
+        return new Expression(lhs, "$exists", rhs);
+    }
+
+    public static Expression type(String lhs, String rhs) {
+        return new Expression(lhs, "$type", rhs);
+    }
+
+    public static Expression in(String lhs, Object... rhs) {
+        if (rhs.length == 1) {
+            throw new IllegalArgumentException("rhs must have more than 1 elements");
+        }
+        return new Expression(lhs, "$in", rhs);
+    }
+
+    public static Expression nin(String lhs, Object... rhs) {
+        if (rhs.length == 1) {
+            throw new IllegalArgumentException("rhs must have more than 1 elements");
+        }
+        return new Expression(lhs, "$nin", rhs);
+    }
+
+    public static Expression size(String lhs, Long rhs) {
+        return new Expression(lhs, "$size", rhs);
+    }
+
+    public static Expression mod(String lhs, Long rhs) {
+        return new Expression(lhs, "$mod", rhs);
+    }
+
+    public static Expression regex(String lhs, String rhs) {
+        return new Expression(lhs, "$regex", rhs);
+    }
+
+    public static Expression all(String lhs, String... rhs) {
+        if (rhs.length == 1) {
+            throw new IllegalArgumentException("rhs must have more than 1 elements");
+        }
+        return new Expression(lhs, "$all", rhs);
+    }
+
+    @Override
+    public String toString() {
+        // lhs op rhs format
+        return String.format("\"%s\": {\"%s\": %s}", this.lhs, this.op, quote(this.rhs));
+    }
+
+}

--- a/cloudant-client/src/main/java/com/cloudant/client/api/query/Expression.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/query/Expression.java
@@ -21,6 +21,7 @@ public class Expression implements OperationOrExpression {
     private String lhs;
     private String op;
     private Object[] rhs;
+    private boolean single;
 
     public Expression(String lhs, String op, Object... rhs) {
         this.lhs = lhs;
@@ -56,22 +57,24 @@ public class Expression implements OperationOrExpression {
         return new Expression(lhs, "$exists", rhs);
     }
 
-    public static Expression type(String lhs, String rhs) {
-        return new Expression(lhs, "$type", rhs);
+    public static Expression type(String lhs, Type rhs) {
+        return new Expression(lhs, "$type", rhs.toString());
     }
 
     public static Expression in(String lhs, Object... rhs) {
+        Expression ex = new Expression(lhs, "$in", rhs);
         if (rhs.length == 1) {
-            throw new IllegalArgumentException("rhs must have more than 1 elements");
+            ex.single = true;
         }
-        return new Expression(lhs, "$in", rhs);
+        return ex;
     }
 
     public static Expression nin(String lhs, Object... rhs) {
+        Expression ex = new Expression(lhs, "$nin", rhs);
         if (rhs.length == 1) {
-            throw new IllegalArgumentException("rhs must have more than 1 elements");
+            ex.single = true;
         }
-        return new Expression(lhs, "$nin", rhs);
+        return ex;
     }
 
     public static Expression size(String lhs, Long rhs) {
@@ -87,16 +90,17 @@ public class Expression implements OperationOrExpression {
     }
 
     public static Expression all(String lhs, Object... rhs) {
+        Expression ex = new Expression(lhs, "$all", rhs);
         if (rhs.length == 1) {
-            throw new IllegalArgumentException("rhs must have more than 1 elements");
+            ex.single = true;
         }
-        return new Expression(lhs, "$all", rhs);
+        return ex;
     }
 
     @Override
     public String toString() {
         // lhs op rhs format
-        return String.format("\"%s\": {\"%s\": %s}", this.lhs, this.op, quote(this.rhs));
+        return String.format("\"%s\": {\"%s\": %s}", this.lhs, this.op, quote(this.rhs, this.single));
     }
 
 }

--- a/cloudant-client/src/main/java/com/cloudant/client/api/query/Expression.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/query/Expression.java
@@ -18,9 +18,9 @@ import static com.cloudant.client.internal.query.Helpers.quote;
 // expression, such as "widget_count" "$eq" 5
 public class Expression implements OperationOrExpression {
 
-    private String lhs;
-    private String op;
-    private Object[] rhs;
+    private final String lhs;
+    private final String op;
+    private final Object[] rhs;
     private boolean single;
 
     private Expression(String lhs, String op, Object... rhs) {

--- a/cloudant-client/src/main/java/com/cloudant/client/api/query/Expression.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/query/Expression.java
@@ -86,7 +86,7 @@ public class Expression implements OperationOrExpression {
         return new Expression(lhs, "$regex", rhs);
     }
 
-    public static Expression all(String lhs, String... rhs) {
+    public static Expression all(String lhs, Object... rhs) {
         if (rhs.length == 1) {
             throw new IllegalArgumentException("rhs must have more than 1 elements");
         }

--- a/cloudant-client/src/main/java/com/cloudant/client/api/query/Expression.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/query/Expression.java
@@ -23,7 +23,7 @@ public class Expression implements OperationOrExpression {
     private Object[] rhs;
     private boolean single;
 
-    public Expression(String lhs, String op, Object... rhs) {
+    private Expression(String lhs, String op, Object... rhs) {
         this.lhs = lhs;
         this.op = op;
         this.rhs = rhs;

--- a/cloudant-client/src/main/java/com/cloudant/client/api/query/Operation.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/query/Operation.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package com.cloudant.client.api.query;
+
+import static com.cloudant.client.internal.query.Helpers.quoteCurly;
+
+// operation - used to combine an operator such as "$and" and a series of operations or expressions
+// on the rhs
+public class Operation implements OperationOrExpression {
+
+    private String op;
+    private OperationOrExpression[] rhs;
+
+    public Operation(String op, OperationOrExpression... rhs) {
+        this.op = op;
+        this.rhs = rhs;
+    }
+
+    public static Operation and(OperationOrExpression... rhs) {
+        return new Operation("$and", rhs);
+    }
+
+    public static Operation or(OperationOrExpression... rhs) {
+        return new Operation("$or", rhs);
+    }
+
+    public static Operation not(OperationOrExpression rhs) {
+        return new Operation("$not", rhs);
+    }
+
+    public static Operation nor(OperationOrExpression... rhs) {
+        return new Operation("$nor", rhs);
+    }
+
+    @Override
+    public String toString() {
+        // op rhs format ($and etc)
+        return String.format("\"%s\": %s", this.op, quoteCurly(this.rhs));
+    }
+
+}

--- a/cloudant-client/src/main/java/com/cloudant/client/api/query/Operation.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/query/Operation.java
@@ -22,7 +22,7 @@ public class Operation implements OperationOrExpression {
     private String op;
     private OperationOrExpression[] rhs;
 
-    public Operation(String op, OperationOrExpression... rhs) {
+    private Operation(String op, OperationOrExpression... rhs) {
         this.op = op;
         this.rhs = rhs;
     }

--- a/cloudant-client/src/main/java/com/cloudant/client/api/query/Operation.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/query/Operation.java
@@ -19,8 +19,8 @@ import static com.cloudant.client.internal.query.Helpers.quoteCurly;
 // on the rhs
 public class Operation implements OperationOrExpression {
 
-    private String op;
-    private OperationOrExpression[] rhs;
+    private final String op;
+    private final OperationOrExpression[] rhs;
 
     private Operation(String op, OperationOrExpression... rhs) {
         this.op = op;

--- a/cloudant-client/src/main/java/com/cloudant/client/api/query/OperationOrExpression.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/query/OperationOrExpression.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package com.cloudant.client.api.query;
+
+// marker interface - used to signify the rhs of an operation which can be another operation or an
+// expression
+public interface OperationOrExpression
+{
+
+}

--- a/cloudant-client/src/main/java/com/cloudant/client/api/query/PredicateExpression.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/query/PredicateExpression.java
@@ -18,10 +18,10 @@ import static com.cloudant.client.internal.query.Helpers.quote;
 // predicate expression, such as "$eq" 5
 public class PredicateExpression implements OperationOrExpression {
 
-    String op;
-    Object[] rhs;
+    private String op;
+    private Object[] rhs;
 
-    public PredicateExpression(String op, Object... rhs) {
+    private PredicateExpression(String op, Object... rhs) {
         this.op = op;
         this.rhs = rhs;
     }

--- a/cloudant-client/src/main/java/com/cloudant/client/api/query/PredicateExpression.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/query/PredicateExpression.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package com.cloudant.client.api.query;
+
+import static com.cloudant.client.internal.query.Helpers.quote;
+
+// predicate expression, such as "$eq" 5
+public class PredicateExpression implements OperationOrExpression {
+
+    String op;
+    Object[] rhs;
+
+    public PredicateExpression(String op, Object... rhs) {
+        this.op = op;
+        this.rhs = rhs;
+    }
+
+    // predicate format expressions, as used by $elemMatch
+    public static PredicateExpression lt(Object rhs) {
+        return new PredicateExpression("$lt", rhs);
+    }
+
+    public static PredicateExpression lte(Object rhs) {
+        return new PredicateExpression("$lte", rhs);
+    }
+
+    public static PredicateExpression eq(Object rhs) {
+        return new PredicateExpression("$eq", rhs);
+    }
+
+    public static PredicateExpression ne(Object rhs) {
+        return new PredicateExpression("$ne", rhs);
+    }
+
+    public static PredicateExpression gte(Object rhs) {
+        return new PredicateExpression("$gte", rhs);
+    }
+
+    public static PredicateExpression gt(Object rhs) {
+        return new PredicateExpression("$gt", rhs);
+    }
+
+    @Override
+    public String toString() {
+        // op rhs format
+        return String.format("\"%s\": %s", this.op, quote(this.rhs));
+    }
+
+}

--- a/cloudant-client/src/main/java/com/cloudant/client/api/query/PredicateExpression.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/query/PredicateExpression.java
@@ -18,8 +18,8 @@ import static com.cloudant.client.internal.query.Helpers.quote;
 // predicate expression, such as "$eq" 5
 public class PredicateExpression implements OperationOrExpression {
 
-    private String op;
-    private Object[] rhs;
+    private final String op;
+    private final Object[] rhs;
 
     private PredicateExpression(String op, Object... rhs) {
         this.op = op;

--- a/cloudant-client/src/main/java/com/cloudant/client/api/query/PredicatedOperation.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/query/PredicatedOperation.java
@@ -22,7 +22,7 @@ public class PredicatedOperation implements OperationOrExpression {
     private String op;
     private PredicateExpression[] rhs;
 
-    public PredicatedOperation(String lhs, String op, PredicateExpression... rhs) {
+    private PredicatedOperation(String lhs, String op, PredicateExpression... rhs) {
         this.lhs = lhs;
         this.op = op;
         this.rhs = rhs;

--- a/cloudant-client/src/main/java/com/cloudant/client/api/query/PredicatedOperation.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/query/PredicatedOperation.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package com.cloudant.client.api.query;
+
+import static com.cloudant.client.internal.query.Helpers.quoteCurlyNoSquare;
+
+// predicated operation - an operation which takes one or more predicates such as "$eq" 5 as its rhs
+public class PredicatedOperation implements OperationOrExpression {
+
+    private String lhs;
+    private String op;
+    private PredicateExpression[] rhs;
+
+    public PredicatedOperation(String lhs, String op, PredicateExpression... rhs) {
+        this.lhs = lhs;
+        this.op = op;
+        this.rhs = rhs;
+    }
+
+    public static PredicatedOperation elemMatch(String lhs, PredicateExpression... rhs) {
+        // TODO each expression key must be unique
+        return new PredicatedOperation(lhs, "$elemMatch", rhs);
+    }
+
+    @Override
+    public String toString() {
+        // op rhs format ($and etc)
+        return String.format("\"%s\": {\"%s\": %s}", this.lhs, this.op, quoteCurlyNoSquare(this.rhs));
+    }
+
+}

--- a/cloudant-client/src/main/java/com/cloudant/client/api/query/PredicatedOperation.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/query/PredicatedOperation.java
@@ -18,9 +18,9 @@ import static com.cloudant.client.internal.query.Helpers.quoteCurlyNoSquare;
 // predicated operation - an operation which takes one or more predicates such as "$eq" 5 as its rhs
 public class PredicatedOperation implements OperationOrExpression {
 
-    private String lhs;
-    private String op;
-    private PredicateExpression[] rhs;
+    private final String lhs;
+    private final String op;
+    private final PredicateExpression[] rhs;
 
     private PredicatedOperation(String lhs, String op, PredicateExpression... rhs) {
         this.lhs = lhs;

--- a/cloudant-client/src/main/java/com/cloudant/client/api/query/QueryBuilder.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/query/QueryBuilder.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package com.cloudant.client.api.query;
+
+public class QueryBuilder {
+
+    OperationOrExpression query;
+
+    public QueryBuilder(OperationOrExpression query) {
+        this.query = query;
+    }
+
+    public String build() {
+        return String.format("{\"selector\": {%s}}", query.toString());
+    }
+}

--- a/cloudant-client/src/main/java/com/cloudant/client/api/query/QueryBuilder.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/query/QueryBuilder.java
@@ -19,11 +19,11 @@ import java.util.LinkedList;
 
 public class QueryBuilder {
 
-    OperationOrExpression selector;
-    String[] fields;
-    String[][] sort;
-    Long limit;
-    Long skip;
+    private OperationOrExpression selector;
+    private String[] fields;
+    private String[][] sort;
+    private Long limit;
+    private Long skip;
 
     public QueryBuilder(OperationOrExpression selector) {
         this.selector = selector;
@@ -80,7 +80,7 @@ public class QueryBuilder {
     }
 
     // sorts are a bit more awkward and need a helper...
-    private String quoteSort(String[][] sort) {
+    private static String quoteSort(String[][] sort) {
         LinkedList<String> sorts = new LinkedList<String>();
         for (String[] pair : sort) {
             sorts.add(String.format("{%s}", Helpers.quoteNoSquare(pair)));

--- a/cloudant-client/src/main/java/com/cloudant/client/api/query/QueryBuilder.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/query/QueryBuilder.java
@@ -19,7 +19,7 @@ import java.util.LinkedList;
 
 public class QueryBuilder {
 
-    private OperationOrExpression selector;
+    private final OperationOrExpression selector;
     private String[] fields;
     private String[][] sort;
     private Long limit;

--- a/cloudant-client/src/main/java/com/cloudant/client/api/query/QueryBuilder.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/query/QueryBuilder.java
@@ -13,15 +13,78 @@
  */
 package com.cloudant.client.api.query;
 
+import com.cloudant.client.internal.query.Helpers;
+
+import java.util.LinkedList;
+
 public class QueryBuilder {
 
-    OperationOrExpression query;
+    OperationOrExpression selector;
+    String[] fields;
+    String[][] sort;
+    Long limit;
+    Long skip;
 
-    public QueryBuilder(OperationOrExpression query) {
-        this.query = query;
+    public QueryBuilder(OperationOrExpression selector) {
+        this.selector = selector;
+    }
+
+    public QueryBuilder fields(String... fields) {
+        this.fields = fields;
+        return this;
+    }
+
+    // TODO this is likely to take an array of FieldSorts or similar when merged with Rich's code
+    public QueryBuilder sort(String[]... sort) {
+        this.sort = sort;
+        return this;
+    }
+
+    public QueryBuilder limit(long limit) {
+        this.limit = limit;
+        return this;
+    }
+
+    public QueryBuilder skip(long skip) {
+        this.skip = skip;
+        return this;
     }
 
     public String build() {
-        return String.format("{\"selector\": {%s}}", query.toString());
+        String selectorString = selector.toString();
+        String fieldsString = this.fields == null ? null : Helpers.quote(this.fields);
+        String sortString = this.sort == null ? null : quoteSort(this.sort);
+        String limitString = this.limit == null ? null : Helpers.quote(this.limit);
+        String skipString = this.skip == null ? null : Helpers.quote(this.skip);
+        StringBuilder builder = new StringBuilder();
+        // build up components...
+        // selector
+        builder.append(String.format("\"selector\": {%s}", selectorString));
+        // fields
+        if (fieldsString != null) {
+            builder.append(String.format(", \"fields\": %s", fieldsString));
+        }
+        // sort
+        if (sortString != null) {
+            builder.append(String.format(", \"sort\": %s", sortString));
+        }
+        // limit
+        if (limitString != null) {
+            builder.append(String.format(", \"limit\": %s", limitString));
+        }
+        // skip
+        if (skipString != null) {
+            builder.append(String.format(", \"skip\": %s", skipString));
+        }
+        return String.format("{%s}", builder.toString());
+    }
+
+    // sorts are a bit more awkward and need a helper...
+    private String quoteSort(String[][] sort) {
+        LinkedList<String> sorts = new LinkedList<String>();
+        for (String[] pair : this.sort) {
+            sorts.add(String.format("{%s}", Helpers.quoteNoSquare(pair)));
+        }
+        return sorts.toString();
     }
 }

--- a/cloudant-client/src/main/java/com/cloudant/client/api/query/QueryBuilder.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/query/QueryBuilder.java
@@ -82,7 +82,7 @@ public class QueryBuilder {
     // sorts are a bit more awkward and need a helper...
     private String quoteSort(String[][] sort) {
         LinkedList<String> sorts = new LinkedList<String>();
-        for (String[] pair : this.sort) {
+        for (String[] pair : sort) {
             sorts.add(String.format("{%s}", Helpers.quoteNoSquare(pair)));
         }
         return sorts.toString();

--- a/cloudant-client/src/main/java/com/cloudant/client/api/query/Type.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/query/Type.java
@@ -1,0 +1,15 @@
+package com.cloudant.client.api.query;
+
+import java.util.Locale;
+
+public enum Type {
+
+    BOOLEAN,
+    STRING,
+    NUMBER;
+
+    @Override
+    public String toString() {
+        return super.toString().toLowerCase(Locale.ENGLISH);
+    }
+}

--- a/cloudant-client/src/main/java/com/cloudant/client/api/query/Type.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/query/Type.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
 package com.cloudant.client.api.query;
 
 import java.util.Locale;

--- a/cloudant-client/src/main/java/com/cloudant/client/internal/query/Helpers.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/internal/query/Helpers.java
@@ -29,7 +29,12 @@ public class Helpers {
     }
 
     public static String quote(Object[] os) {
-        if (os.length == 1) {
+        return quote(os, false);
+    }
+
+
+    public static String quote(Object[] os, boolean single) {
+        if (!single && os.length == 1) {
             return quote(os[0]);
         }
         return quoteInternal(os, ", ", "", "", "[", "]");

--- a/cloudant-client/src/main/java/com/cloudant/client/internal/query/Helpers.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/internal/query/Helpers.java
@@ -35,6 +35,13 @@ public class Helpers {
         return quoteInternal(os, ", ", "", "", "[", "]");
     }
 
+    public static String quoteNoSquare(Object[] os) {
+        if (os.length == 1) {
+            return quote(os[0]);
+        }
+        return quoteInternal(os, ", ", "", "", "", "");
+    }
+
     public static String quoteCurly(Object[] os) {
         if (os.length == 1) {
             // the operation "not" only takes one argument, so we don't need to make an array

--- a/cloudant-client/src/main/java/com/cloudant/client/internal/query/Helpers.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/internal/query/Helpers.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package com.cloudant.client.internal.query;
+
+import java.util.LinkedList;
+import java.util.List;
+
+public class Helpers {
+
+    public static String quote(Object o) {
+        if (o.getClass().equals(String.class)) {
+            // string
+            return String.format("\"%s\"", o);
+        } else {
+            // int, float, bool
+            return String.format("%s", o);
+        }
+    }
+
+    public static String quote(Object[] os) {
+        if (os.length == 1) {
+            return quote(os[0]);
+        }
+        return quoteInternal(os, ", ", "", "", "[", "]");
+    }
+
+    public static String quoteCurly(Object[] os) {
+        if (os.length == 1) {
+            // the operation "not" only takes one argument, so we don't need to make an array
+            return String.format("%s%s%s", "{", quote(os[0]), "}");
+        }
+        return quoteInternal(os, ", ", "{", "}", "[", "]");
+    }
+
+    public static String quoteCurlyNoSquare(Object[] os) {
+        return quoteInternal(os, ", ", "{", "}", "", "");
+    }
+
+    private static String quoteInternal(Object[] os,
+                                        String joiner,
+                                        String start,
+                                        String end,
+                                        String arrayStart,
+                                        String arrayEnd) {
+        List<String> ss = new LinkedList<String>();
+        for (Object o : os) {
+            ss.add(quote(o));
+        }
+        return String.format("%s%s%s%s%s",
+                arrayStart,
+                start,
+                joinInternal(end+joiner+start, ss.toArray(new String[0])),
+                end,
+                arrayEnd
+        );
+    }
+
+    private static String joinInternal(String delimiter, String... args) {
+        StringBuilder sb = new StringBuilder();
+        int i = 0;
+        for (String arg : args) {
+            sb.append(arg);
+            if (++i != args.length) {
+                sb.append(delimiter);
+            }
+        }
+        return sb.toString();
+    }
+
+}

--- a/cloudant-client/src/test/java/com/cloudant/tests/QueryTests.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/QueryTests.java
@@ -31,6 +31,8 @@ import static com.cloudant.client.api.query.PredicatedOperation.elemMatch;
 
 import com.cloudant.client.api.query.PredicateExpression;
 import com.cloudant.client.api.query.QueryBuilder;
+import com.cloudant.client.api.query.Type;
+
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -74,6 +76,16 @@ public class QueryTests {
                 in("year", 1984, 1991)
         ));
         Assert.assertEquals("{\"selector\": {\"$and\": [{\"$text\": {\"$eq\": \"Schwarzenegger\"}}, {\"year\": {\"$in\": [1984, 1991]}}]}}", qb.build());
+    }
+
+    // "$and operator used with full text indexing"
+    @Test
+    public void basicSelector5_single() {
+        QueryBuilder qb = new QueryBuilder(and(
+                eq("$text", "Schwarzenegger"),
+                in("year", 1984)
+        ));
+        Assert.assertEquals("{\"selector\": {\"$and\": [{\"$text\": {\"$eq\": \"Schwarzenegger\"}}, {\"year\": {\"$in\": [1984]}}]}}", qb.build());
     }
 
     // "$or operator used with full text indexing"
@@ -131,6 +143,13 @@ public class QueryTests {
         Assert.assertEquals("{\"selector\": {\"genre\": {\"$all\": [\"Comedy\", \"Short\"]}}}", qb.build());
     }
 
+    // "$all operator used with full text indexing"
+    @Test
+    public void basicSelector10_single() {
+        QueryBuilder qb = new QueryBuilder(all("genre", "Comedy"));
+        Assert.assertEquals("{\"selector\": {\"genre\": {\"$all\": [\"Comedy\"]}}}", qb.build());
+    }
+
     // "elemMatch operator used with full text indexing"
     @Test
     public void basicSelector11() {
@@ -156,7 +175,7 @@ public class QueryTests {
     // "$type operator used with full text indexing"
     @Test
     public void basicSelector14() {
-        QueryBuilder qb = new QueryBuilder(type("year", "number"));
+        QueryBuilder qb = new QueryBuilder(type("year", Type.NUMBER));
         Assert.assertEquals("{\"selector\": {\"year\": {\"$type\": \"number\"}}}", qb.build());
     }
 
@@ -167,12 +186,27 @@ public class QueryTests {
         Assert.assertEquals("{\"selector\": {\"year\": {\"$in\": [2010, 2015]}}}", qb.build());
     }
 
+    // "$in operator used with full text indexing"
+    @Test
+    public void basicSelector15_single() {
+        QueryBuilder qb = new QueryBuilder(in("year", 2010));
+        Assert.assertEquals("{\"selector\": {\"year\": {\"$in\": [2010]}}}", qb.build());
+    }
+
     // "$nin operator used with full text indexing"
     @Test
     public void basicSelector16() {
         QueryBuilder qb = new QueryBuilder(and(gt("year", 2009),
             nin("year", 2010, 2015)));
         Assert.assertEquals("{\"selector\": {\"$and\": [{\"year\": {\"$gt\": 2009}}, {\"year\": {\"$nin\": [2010, 2015]}}]}}", qb.build());
+    }
+
+    // "$nin operator used with full text indexing"
+    @Test
+    public void basicSelector16_single() {
+        QueryBuilder qb = new QueryBuilder(and(gt("year", 2009),
+                nin("year", 2010)));
+        Assert.assertEquals("{\"selector\": {\"$and\": [{\"year\": {\"$gt\": 2009}}, {\"year\": {\"$nin\": [2010]}}]}}", qb.build());
     }
 
     @Test

--- a/cloudant-client/src/test/java/com/cloudant/tests/QueryTests.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/QueryTests.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package com.cloudant.tests;
+
+import static com.cloudant.client.api.query.Expression.all;
+import static com.cloudant.client.api.query.Expression.eq;
+import static com.cloudant.client.api.query.Expression.exists;
+import static com.cloudant.client.api.query.Expression.gt;
+import static com.cloudant.client.api.query.Expression.gte;
+import static com.cloudant.client.api.query.Expression.in;
+import static com.cloudant.client.api.query.Expression.lt;
+import static com.cloudant.client.api.query.Expression.lte;
+import static com.cloudant.client.api.query.Expression.nin;
+import static com.cloudant.client.api.query.Expression.type;
+import static com.cloudant.client.api.query.Operation.and;
+import static com.cloudant.client.api.query.Operation.nor;
+import static com.cloudant.client.api.query.Operation.not;
+import static com.cloudant.client.api.query.Operation.or;
+import static com.cloudant.client.api.query.PredicatedOperation.elemMatch;
+
+import com.cloudant.client.api.query.PredicateExpression;
+import com.cloudant.client.api.query.QueryBuilder;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class QueryTests {
+
+    // "Selector basics"
+    @Test
+    public void basicSelector1() {
+        QueryBuilder qb = new QueryBuilder(eq("director", "Lars von Trier"));
+        Assert.assertEquals("{\"selector\": {\"director\": {\"$eq\": \"Lars von Trier\"}}}", qb.build());
+    }
+
+    // "Selector with two fields"
+    @Test
+    public void basicSelector2() {
+        QueryBuilder qb = new QueryBuilder(and(
+                eq("name", "Paul"),
+                eq("location", "Boston")));
+        Assert.assertEquals("{\"selector\": {\"$and\": [{\"name\": {\"$eq\": \"Paul\"}}, {\"location\": {\"$eq\": \"Boston\"}}]}}", qb.build());
+    }
+
+    // "SUBFIELDS"
+    @Test
+    public void basicSelector3() {
+        QueryBuilder qb = new QueryBuilder(eq("imdb.rating", 8));
+        Assert.assertEquals("{\"selector\": {\"imdb.rating\": {\"$eq\": 8}}}", qb.build());
+    }
+
+    // "Example selector using an operator to match any document, where the age field has a value greater than 20:"
+    @Test
+    public void basicSelector4() {
+        QueryBuilder qb = new QueryBuilder(gt("year", 2018));
+        Assert.assertEquals("{\"selector\": {\"year\": {\"$gt\": 2018}}}", qb.build());
+    }
+
+    // "$and operator used with full text indexing"
+    @Test
+    public void basicSelector5() {
+        QueryBuilder qb = new QueryBuilder(and(
+                eq("$text", "Schwarzenegger"),
+                in("year", 1984, 1991)
+        ));
+        Assert.assertEquals("{\"selector\": {\"$and\": [{\"$text\": {\"$eq\": \"Schwarzenegger\"}}, {\"year\": {\"$in\": [1984, 1991]}}]}}", qb.build());
+    }
+
+    // "$or operator used with full text indexing"
+    @Test
+    public void basicSelector6() {
+        QueryBuilder qb = new QueryBuilder(or(
+                eq("director", "George Lucas"),
+                eq("director", "Steven Spielberg")
+        ));
+        Assert.assertEquals("{\"selector\": {\"$or\": [{\"director\": {\"$eq\": \"George Lucas\"}}, {\"director\": {\"$eq\": \"Steven Spielberg\"}}]}}", qb.build());
+    }
+
+    // "$or operator used with database indexed on the field "year"
+    @Test
+    public void basicSelector7() {
+        QueryBuilder qb = new QueryBuilder(and(
+                eq("year", 1977),
+                or(
+                        eq("director", "George Lucas"),
+                        eq("director", "Steven Spielberg")
+                )
+        ));
+        Assert.assertEquals("{\"selector\": {\"$and\": [{\"year\": {\"$eq\": 1977}}, {\"$or\": [{\"director\": {\"$eq\": \"George Lucas\"}}, {\"director\": {\"$eq\": \"Steven Spielberg\"}}]}]}}", qb.build());
+    }
+
+    // "$not operator used with database indexed on the field "year""
+    @Test
+    public void basicSelector8() {
+        QueryBuilder qb = new QueryBuilder(and(
+                gte("year", 1900),
+                lte("year", 1903),
+                not(eq("year", 1901))
+        ));
+        Assert.assertEquals("{\"selector\": {\"$and\": [{\"year\": {\"$gte\": 1900}}, {\"year\": {\"$lte\": 1903}}, {\"$not\": {\"year\": {\"$eq\": 1901}}}]}}", qb.build());
+    }
+
+    // "$nor operator used with database indexed on the field "year""
+    @Test
+    public void basicSelector9() {
+        QueryBuilder qb = new QueryBuilder(and(
+                gte("year", 1900),
+                lte("year", 1910),
+                nor(
+                        eq("year", 1901),
+                        eq("year", 1905),
+                        eq("year", 1907))
+        ));
+        Assert.assertEquals("{\"selector\": {\"$and\": [{\"year\": {\"$gte\": 1900}}, {\"year\": {\"$lte\": 1910}}, {\"$nor\": [{\"year\": {\"$eq\": 1901}}, {\"year\": {\"$eq\": 1905}}, {\"year\": {\"$eq\": 1907}}]}]}}", qb.build());
+    }
+
+    // "$all operator used with full text indexing"
+    @Test
+    public void basicSelector10() {
+        QueryBuilder qb = new QueryBuilder(all("genre", "Comedy", "Short"));
+        Assert.assertEquals("{\"selector\": {\"genre\": {\"$all\": [\"Comedy\", \"Short\"]}}}", qb.build());
+    }
+
+    // "elemMatch operator used with full text indexing"
+    @Test
+    public void basicSelector11() {
+        QueryBuilder qb = new QueryBuilder(elemMatch("genre", PredicateExpression.eq("Horror")));
+        Assert.assertEquals("{\"selector\": {\"genre\": {\"$elemMatch\": {\"$eq\": \"Horror\"}}}}", qb.build());
+    }
+
+    // "$lt operator used with database indexed on the field "year""
+    // (similar for all (in)equality tests, so one is representative
+    @Test
+    public void basicSelector12() {
+        QueryBuilder qb = new QueryBuilder(lt("year", 1900));
+        Assert.assertEquals("{\"selector\": {\"year\": {\"$lt\": 1900}}}", qb.build());
+    }
+
+    // "$exists operator used with database indexed on the field "year""
+    @Test
+    public void basicSelector13() {
+        QueryBuilder qb = new QueryBuilder(and(eq("year", 2015), exists("title", true)));
+        Assert.assertEquals("{\"selector\": {\"$and\": [{\"year\": {\"$eq\": 2015}}, {\"title\": {\"$exists\": true}}]}}", qb.build());
+    }
+
+    // "$type operator used with full text indexing"
+    @Test
+    public void basicSelector14() {
+        QueryBuilder qb = new QueryBuilder(type("year", "number"));
+        Assert.assertEquals("{\"selector\": {\"year\": {\"$type\": \"number\"}}}", qb.build());
+    }
+
+    // "$in operator used with full text indexing"
+    @Test
+    public void basicSelector15() {
+        QueryBuilder qb = new QueryBuilder(in("year", 2010, 2015));
+        Assert.assertEquals("{\"selector\": {\"year\": {\"$in\": [2010, 2015]}}}", qb.build());
+    }
+
+    // "$nin operator used with full text indexing"
+    @Test
+    public void basicSelector16() {
+        QueryBuilder qb = new QueryBuilder(and(gt("year", 2009),
+            nin("year", 2010, 2015)));
+        Assert.assertEquals("{\"selector\": {\"$and\": [{\"year\": {\"$gt\": 2009}}, {\"year\": {\"$nin\": [2010, 2015]}}]}}", qb.build());
+    }
+
+    @Test
+    public void complexSelector1() {
+        QueryBuilder qb = new QueryBuilder(not(and(gt("year", 2009),
+                nin("year", 2010, 2015))));
+        Assert.assertEquals("{\"selector\": {\"$not\": {\"$and\": [{\"year\": {\"$gt\": 2009}}, {\"year\": {\"$nin\": [2010, 2015]}}]}}}", qb.build());
+    }
+
+    @Test
+    public void complexSelector2() {
+        QueryBuilder qb = new QueryBuilder(or(
+                and(
+                        eq("Actor", "Schwarzenegger"),
+                        eq("Year",2012)),
+                and(
+                        eq("Actor","de Vito"),
+                        eq("Year", 2001))
+        ));
+        Assert.assertEquals("{\"selector\": {\"$or\": [{\"$and\": [{\"Actor\": {\"$eq\": \"Schwarzenegger\"}}, {\"Year\": {\"$eq\": 2012}}]}, {\"$and\": [{\"Actor\": {\"$eq\": \"de Vito\"}}, {\"Year\": {\"$eq\": 2001}}]}]}}", qb.build());
+    }
+
+}

--- a/cloudant-client/src/test/java/com/cloudant/tests/QueryTests.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/QueryTests.java
@@ -195,4 +195,36 @@ public class QueryTests {
         Assert.assertEquals("{\"selector\": {\"$or\": [{\"$and\": [{\"Actor\": {\"$eq\": \"Schwarzenegger\"}}, {\"Year\": {\"$eq\": 2012}}]}, {\"$and\": [{\"Actor\": {\"$eq\": \"de Vito\"}}, {\"Year\": {\"$eq\": 2001}}]}]}}", qb.build());
     }
 
+    // "Selector basics"
+    @Test
+    public void basicSelector1WithFields() {
+        QueryBuilder qb = new QueryBuilder(eq("director", "Lars von Trier")).fields("_id", "_rev", "year", "title");
+        Assert.assertEquals("{\"selector\": {\"director\": {\"$eq\": \"Lars von Trier\"}}, " +
+                "\"fields\": [\"_id\", \"_rev\", \"year\", \"title\"]}", qb.build());
+    }
+
+    // "Selector basics"
+    @Test
+    public void basicSelector1WithSort() {
+        QueryBuilder qb = new QueryBuilder(eq("director", "Lars von Trier")).sort(new String[]{"year", "asc"}, new String[]{"director", "desc"});
+        Assert.assertEquals("{\"selector\": {\"director\": {\"$eq\": \"Lars von Trier\"}}, " +
+                "\"sort\": [{\"year\", \"asc\"}, {\"director\", \"desc\"}]}", qb.build());
+    }
+
+    // "Selector basics"
+    @Test
+    public void basicSelector1WithAllOptions() {
+        QueryBuilder qb = new QueryBuilder(eq("director", "Lars von Trier")).
+                fields("_id", "_rev", "year", "title").
+                sort(new String[]{"year", "asc"}, new String[]{"director", "desc"}).
+                limit(10).
+                skip(0);
+        Assert.assertEquals("{\"selector\": {\"director\": {\"$eq\": \"Lars von Trier\"}}, " +
+                        "\"fields\": [\"_id\", \"_rev\", \"year\", \"title\"], " +
+                "\"sort\": [{\"year\", \"asc\"}, {\"director\", \"desc\"}], \"limit\": 10, " +
+                "\"skip\": 0}", qb.build());
+    }
+
+
+
 }


### PR DESCRIPTION
## What

Easier generation of `selector` for [Cloudant Query](https://docs.cloudant.com/cloudant_query.html)

## How

Add `QueryBuilder` class and classes for operations and expressions with static helpers for compact and fluent creation of selectors aided by IDE auto-complete. 

## Testing

See `QueryTests` class (TODO rename?)

## Issues

See #184

## TODO:

other stuff in the query body:
- ~~fields~~
- ~~sort~~
- ~~limit~~
- ~~skip~~

documentation
- javadoc
- CHANGES
- README
