### PR TITLE
Improve handling of non-existent doc ids in view response

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 - [NEW] Add IAM cookie authentication method.
 - [IMPROVED] Updated documentation by replacing deprecated Cloudant links with the latest Bluemix links.
 - [IMPROVED] Clarified documentation for search indexes.
+- [IMPROVED] Added `Row#getError` and `AllDocsResponse#getErrors` for returning any error messages 
+  from a `view` or `_all_docs` request.
 - [FIXED] Connection leaks in some session renewal error scenarios.
 - [FIXED] IllegalStateException now correctly thrown for additional case of calling
   `MultipleRequestBuilder#build()` before `add()` was called.

--- a/cloudant-client/src/main/java/com/cloudant/client/api/views/AllDocsResponse.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/views/AllDocsResponse.java
@@ -60,4 +60,14 @@ public interface AllDocsResponse {
      */
     List<String> getDocIds();
 
+    /**
+     * Gets a map of the document id and error message if an error exists for any result
+     * in the _all_docs request.
+     * For example, if a doc id does not exist the error message will show "not_found".
+     *
+     * @return a map with an entry for key of the doc id and value of error
+     * @since 2.10.0
+     */
+    Map<String, String> getErrors();
+
 }

--- a/cloudant-client/src/main/java/com/cloudant/client/api/views/ViewResponse.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/views/ViewResponse.java
@@ -111,6 +111,14 @@ public interface ViewResponse<K, V> extends Iterable<ViewResponse<K, V>> {
          * @since 2.0.0
          */
         <D> D getDocumentAsType(Class<D> docType);
+
+        /**
+         * Gets the error message if an error exists.
+         *
+         * @return the error message for this row or null if there is no error
+         * @since 2.10.0
+         */
+        String getError();
     }
 
     /**

--- a/cloudant-client/src/main/java/com/cloudant/client/internal/views/AllDocsRequestResponse.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/internal/views/AllDocsRequestResponse.java
@@ -72,6 +72,17 @@ public class AllDocsRequestResponse implements AllDocsRequest, AllDocsResponse {
         return response.getKeys();
     }
 
+    @Override
+    public Map<String, String> getErrors() {
+        Map<String, String> errors = new HashMap<String, String>();
+        for (ViewResponse.Row<String, Revision> row : response.getRows()) {
+            if(row.getError() != null) {
+                errors.put(row.getKey(), row.getError());
+            }
+        }
+        return errors;
+    }
+
     /*
          * Object representation of rev field from a JSON object.
          * <P>

--- a/cloudant-client/src/main/java/com/cloudant/client/internal/views/RowImpl.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/internal/views/RowImpl.java
@@ -58,11 +58,23 @@ public class RowImpl<K, V> implements ViewResponse.Row<K, V> {
 
     @Override
     public Document getDocument() {
-        return gson.fromJson(row.get("doc"), Document.class);
+        return getDocumentAsType(Document.class);
     }
 
     public <D> D getDocumentAsType(Class<D> docType) {
-        return gson.fromJson(row.get("doc"), docType);
+        D doc = null;
+        if(row.has("doc")) {
+            doc = gson.fromJson(row.get("doc"), docType);
+        }
+        return doc;
     }
 
+    @Override
+    public String getError() {
+        String error = null;
+        if(row.has("key") && row.has("error")) {
+            error = row.get("error").getAsString();
+        }
+        return error;
+    }
 }

--- a/cloudant-client/src/main/java/com/cloudant/client/internal/views/ViewResponseImpl.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/internal/views/ViewResponseImpl.java
@@ -163,7 +163,10 @@ class ViewResponseImpl<K, V> implements ViewResponse<K, V> {
             if (docs == null) {
                 docs = new ArrayList<Document>();
                 for (Row row : getRows()) {
-                    docs.add(row.getDocument());
+                    Document doc = row.getDocument();
+                    if(doc != null) {
+                        docs.add(doc);
+                    }
                 }
             }
             return docs;


### PR DESCRIPTION
## What

Improved handling of non-existent doc ids in view response.

## How

- Check that row has `doc` key and does not have `error` key

## Testing
Added `_all_docs` tests with a) only non-existing doc ids and b) an existing and non-existing doc id.

## Issues

fixes #379