### PR TITLE
[WIP] 166 text indexes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,10 @@
 # UNRELEASED
+- [NEW] Index creation APIs and builders including support for text indexes.
+- [DEPRECATED] Old index creation and listing APIs:
+    - `com.cloudant.client.api.model.Index`
+    - `com.cloudant.client.api.model.IndexField`
+    - `com.cloudant.client.api.Database.createIndex(java.lang.String, java.lang.String, java.lang.String, com.cloudant.client.api.model.IndexField[])`
+    - `com.cloudant.client.api.Database.listIndices`
 
 # 2.11.0 (2017-11-21)
 - [NEW] Added an extra bluemix method to the client builder allowing a custom service name to be
@@ -12,7 +18,7 @@
 - [IMPROVED] Updated documentation by replacing deprecated Cloudant links with the latest bluemix.net
   links.
 - [IMPROVED] Clarified documentation for search indexes.
-- [IMPROVED] Added `Row#getError` and `AllDocsResponse#getErrors` for returning any error messages 
+- [IMPROVED] Added `Row#getError` and `AllDocsResponse#getErrors` for returning any error messages
   from a `view` or `_all_docs` request.
 - [FIXED] Connection leaks in some session renewal error scenarios.
 - [FIXED] IllegalStateException now correctly thrown for additional case of calling

--- a/cloudant-client/findbugs_excludes.xml
+++ b/cloudant-client/findbugs_excludes.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2015 IBM Corp. All rights reserved.
+  ~ Copyright © 2015, 2017 IBM Corp. All rights reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
   ~ except in compliance with the License. You may obtain a copy of the License at
@@ -111,6 +111,29 @@ For example because it requires an API change
         <Bug code="UwF" pattern="UWF_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD"/>
         <Class name="com.cloudant.client.internal.util.CloudFoundryService$CloudFoundryServiceCredentials"/>
         <Field name="url"/>
+    </Match>
+
+
+    <!-- This is likely a false positive in Findbugs, the IDE doesn't complain an unchecked cast.
+    See https://sourceforge.net/p/findbugs/bugs/1242/
+
+    In these cases the Definition instance is a TextIndex.Definition and the type is specified in
+    the superclass by parameter "D" and instantiated in the TextIndex constructor so there should
+    never be a different type in the field so it should be safe to ignore these warnings.
+    -->
+    <Match>
+        <Bug code="BC" pattern="BC_UNCONFIRMED_CAST"/>
+        <!-- can't use a class name here because the bug type returns multiple classes for the cast
+        types and the calling locations -->
+        <!-- method names are the places where the cast occurs -->
+        <Or>
+            <Method name="getAnalyzer"/>
+            <Method name="getDefaultField"/>
+            <Method name="getIndexArrayLengths"/>
+            <Method name="analyzer"/>
+            <Method name="defaultField"/>
+            <Method name="indexArrayLengths"/>
+        </Or>
     </Match>
 
 </FindBugsFilter>

--- a/cloudant-client/src/main/java/com/cloudant/client/api/model/Index.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/model/Index.java
@@ -15,6 +15,8 @@
 package com.cloudant.client.api.model;
 
 import com.cloudant.client.api.model.IndexField.SortOrder;
+import com.cloudant.client.api.query.JsonIndex;
+import com.cloudant.client.api.query.TextIndex;
 
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -25,7 +27,10 @@ import java.util.List;
  *
  * @author Mario Briggs
  * @since 0.0.1
+ * @see JsonIndex
+ * @see TextIndex
  */
+@Deprecated
 public class Index {
 
     private String ddoc;

--- a/cloudant-client/src/main/java/com/cloudant/client/api/model/IndexField.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/model/IndexField.java
@@ -19,7 +19,9 @@ package com.cloudant.client.api.model;
  *
  * @author Mario Briggs
  * @since 0.0.1
+ * @see com.cloudant.client.api.query.JsonIndex.Field
  */
+@Deprecated
 public class IndexField {
 
     /**

--- a/cloudant-client/src/main/java/com/cloudant/client/api/query/Field.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/query/Field.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.client.api.query;
+
+public interface Field {
+    String getName();
+}

--- a/cloudant-client/src/main/java/com/cloudant/client/api/query/Index.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/query/Index.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.client.api.query;
+
+import java.util.List;
+
+public interface Index<F extends Field> {
+
+    /**
+     * @return the design document ID
+     */
+    String getDesignDocumentID();
+
+    /**
+     * @return the name of the index
+     */
+    String getName();
+
+    /**
+     * @return the type of the index
+     */
+    String getType();
+
+    /**
+     * Get the JSON string representation of the selector configured for this index.
+     *
+     * @return selector JSON as string
+     */
+    String getPartialFilterSelector();
+    /**
+     * @return the list of fields in the index
+     */
+    List<F> getFields();
+}

--- a/cloudant-client/src/main/java/com/cloudant/client/api/query/Indexes.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/query/Indexes.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.client.api.query;
+
+import com.cloudant.client.internal.query.ListableIndex;
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Class modelling the indexes defined for a database.
+ */
+public class Indexes {
+    private JsonArray indexes;
+
+    /**
+     * @return a list of the text indexes defined in the database
+     */
+    public List<TextIndex> textIndexes() {
+        return listIndexType("text", TextIndex.class);
+    }
+
+    /**
+     * @return a list of the JSON indexes defined in the database
+     */
+    public List<JsonIndex> jsonIndexes() {
+        return listIndexType("json", JsonIndex.class);
+    }
+
+    /**
+     * All the indexes defined in the database. Type widening means that the returned Index objects
+     * are limited to the name, design document and type of the index and the names of the fields.
+     *
+     * @return a list of defined indexes with name, design document, type and field names.
+     */
+    public List<Index<Field>> allIndexes() {
+        List<Index<Field>> indexesOfAnyType = new ArrayList<Index<Field>>();
+        indexesOfAnyType.addAll(listIndexType(null, ListableIndex.class));
+        return indexesOfAnyType;
+    }
+
+    /**
+     * Utility to list indexes of a given type.
+     *
+     * @param type      the type of index to list, null means all types
+     * @param modelType the class to deserialize the index into
+     * @param <T>       the type of the index
+     * @return the list of indexes of the specified type
+     */
+    private <T extends Index> List<T> listIndexType(String type, Class<T> modelType) {
+        List<T> indexesOfType = new ArrayList<T>();
+        Gson g = new Gson();
+        for (JsonElement index : indexes) {
+            if (index.isJsonObject()) {
+                JsonObject indexDefinition = index.getAsJsonObject();
+                JsonElement indexType = indexDefinition.get("type");
+                if (indexType != null && indexType.isJsonPrimitive()) {
+                    JsonPrimitive indexTypePrimitive = indexType.getAsJsonPrimitive();
+                    if (type == null || (indexTypePrimitive.isString() && indexTypePrimitive
+                            .getAsString().equals(type))) {
+                        indexesOfType.add(g.fromJson(indexDefinition, modelType));
+                    }
+                }
+            }
+        }
+        return indexesOfType;
+    }
+}

--- a/cloudant-client/src/main/java/com/cloudant/client/api/query/JsonIndex.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/query/JsonIndex.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.client.api.query;
+
+import com.cloudant.client.api.Database;
+import com.cloudant.client.internal.query.InternalIndex;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+import com.google.gson.annotations.JsonAdapter;
+import com.google.gson.reflect.TypeToken;
+
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * <P>
+ * Class model of a JSON index definition.
+ * </P>
+ * <P>
+ * This class should not be instantiated directly, use {@link JsonIndex.Builder} to create an
+ * index definition string to pass to {@link com.cloudant.client.api.Database#createIndex(String)}
+ * or use {@link Database#listIndexes()} and {@link Indexes#jsonIndexes()} to retrieve existing
+ * JSON index definitions.
+ * </P>
+ */
+public class JsonIndex extends InternalIndex<JsonIndex.Definition, JsonIndex.Field> {
+
+    private JsonIndex() {
+        super("json");
+        this.def = new Definition();
+    }
+
+    /**
+     * Get a new instance of a builder to configure a JsonIndex.
+     *
+     * @return a builder for configuring a JsonIndex
+     */
+    public static JsonIndex.Builder builder() {
+        return new JsonIndex.Builder();
+    }
+
+    static class Definition extends com.cloudant.client.internal.query.Definition<Field> {
+
+    }
+
+    /**
+     * Model of a field in a JSON index including the field name and sort order.
+     */
+    @JsonAdapter(Field.FieldAdapter.class)
+    public static class Field extends Sort {
+
+        /**
+         * Instantiate a new Field
+         *
+         * @param name  the name of the field
+         * @param order the sort order to apply
+         */
+        private Field(String name, Sort.Order order) {
+            super(name, order);
+        }
+
+        private static class FieldAdapter implements JsonSerializer<Field>,
+                JsonDeserializer<Field> {
+
+            private static final Type SORT_ORDER = new TypeToken<Sort.Order>() {
+            }.getType();
+
+            @Override
+            public Field deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext
+                    context) throws JsonParseException {
+                JsonObject fieldObject = json.getAsJsonObject();
+                Field field = null;
+                for (Map.Entry<String, JsonElement> fieldEntry : fieldObject.entrySet()) {
+                    field = new Field(fieldEntry.getKey(), context.<Sort.Order>deserialize
+                            (fieldEntry.getValue(), SORT_ORDER));
+                }
+                return field;
+            }
+
+            @Override
+            public JsonElement serialize(Field src, Type typeOfSrc, JsonSerializationContext
+                    context) {
+                if (src.getOrder() != null) {
+                    JsonObject field = new JsonObject();
+                    field.add(src.getName(), context.serialize(src.getOrder()));
+                    return field;
+                } else {
+                    return new JsonPrimitive(src.getName());
+                }
+            }
+        }
+    }
+
+    /**
+     * Class for building a definition for a JSON type index.
+     */
+    public static class Builder extends com.cloudant.client.internal.query.Builder<JsonIndex,
+            Definition, Builder, Field> {
+
+        private Builder() {
+            // Prevent instantiation except by static JsonIndex.builder()
+        }
+
+        protected JsonIndex newInstance() {
+            return new JsonIndex();
+        }
+
+        @Override
+        protected Builder returnThis() {
+            return this;
+        }
+
+        /**
+         * Add one or more fields to the JsonIndex configuration in ascending order.
+         *
+         * @param fieldNames names of the fields to index
+         * @return the builder for chaining
+         */
+        public Builder asc(String... fieldNames) {
+            return super.fields(fieldNamesToFieldList(Sort.Order.ASC, fieldNames));
+        }
+
+        /**
+         * Add one or more fields to the JsonIndex configuration in descending order.
+         *
+         * @param fieldNames names of the fields to index
+         * @return the builder for chaining
+         */
+        public Builder desc(String... fieldNames) {
+            return super.fields(fieldNamesToFieldList(Sort.Order.DESC, fieldNames));
+        }
+
+        private List<Field> fieldNamesToFieldList(Sort.Order order, String... fieldNames) {
+            List<Field> fields = new ArrayList<Field>(fieldNames.length);
+            for (String fieldName : fieldNames) {
+                fields.add(new Field(fieldName, order));
+            }
+            return fields;
+        }
+    }
+}

--- a/cloudant-client/src/main/java/com/cloudant/client/api/query/Sort.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/query/Sort.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.client.api.query;
+
+import com.cloudant.client.internal.query.NamedField;
+import com.google.gson.annotations.SerializedName;
+
+import java.util.Locale;
+
+public class Sort extends NamedField {
+
+    public enum Order {
+        /**
+         * ascending
+         */
+        @SerializedName("asc")
+        ASC,
+        /**
+         * descending
+         */
+        @SerializedName("desc")
+        DESC;
+
+        @Override
+        public String toString() {
+            return super.toString().toLowerCase(Locale.ENGLISH);
+        }
+    }
+
+    private Order order = null;
+
+    public Sort(String name) {
+        super(name);
+    }
+
+    public Sort(String name, Order order) {
+        super(name);
+        this.order = order;
+    }
+
+    /**
+     * @return the sort order
+     */
+    public Order getOrder() {
+        return this.order;
+    }
+
+    @Override
+    public String toString() {
+        return getName() + " : " + order;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+
+        Sort sort = (Sort) o;
+
+        return order == sort.order;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (order != null ? order.hashCode() : 0);
+        return result;
+    }
+}

--- a/cloudant-client/src/main/java/com/cloudant/client/api/query/TextIndex.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/query/TextIndex.java
@@ -1,0 +1,281 @@
+/*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.client.api.query;
+
+import com.cloudant.client.api.Database;
+import com.cloudant.client.internal.query.InternalIndex;
+import com.google.gson.Gson;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.annotations.JsonAdapter;
+import com.google.gson.annotations.SerializedName;
+import com.google.gson.reflect.TypeToken;
+
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * <P>
+ * Class model of a text index definition.
+ * </P>
+ * <P>
+ * This class should not be instantiated directly, use {@link TextIndex.Builder} to create a text
+ * index definition string to pass to {@link com.cloudant.client.api.Database#createIndex(String)}
+ * or use {@link Database#listIndexes()} and {@link Indexes#textIndexes()} to retrieve existing
+ * text index definitions.
+ * </P>
+ */
+public class TextIndex extends InternalIndex<TextIndex.Definition, TextIndex.Field> {
+
+    private TextIndex() {
+        super("text");
+        this.def = new Definition();
+    }
+
+    /**
+     * Get a new instance of a builder to configure a TextIndex.
+     *
+     * @return a builder for configuring a TextIndex
+     */
+    public static TextIndex.Builder builder() {
+        return new TextIndex.Builder();
+    }
+
+    /**
+     * Get the JSON string representation of the default field configuration.
+     *
+     * @return default field JSON as string
+     */
+    public String getDefaultField() {
+        return this.def.default_field.toString();
+    }
+
+    /**
+     * Get the JSON string representation of the analyzer configured for this text index.
+     *
+     * @return analyzer JSON as string
+     */
+    public String getAnalyzer() {
+        return def.analyzer.toString();
+    }
+
+    /**
+     * @return true if this index is configured to scan documents for arrays and store their lengths
+     */
+    public boolean getIndexArrayLengths() {
+        return def.index_array_lengths;
+    }
+
+    /**
+     * Model of a field in the text index including the field name and type.
+     */
+    @JsonAdapter(FieldAdapter.class)
+    public static class Field extends com.cloudant.client.internal.query.NamedField {
+
+        private Type type;
+
+        /**
+         * The type of the text index field.
+         */
+        public enum Type {
+            @SerializedName("string")
+            STRING,
+            @SerializedName("boolean")
+            BOOLEAN,
+            @SerializedName("number")
+            NUMBER;
+
+            @Override
+            public String toString() {
+                return super.toString().toLowerCase(Locale.ENGLISH);
+            }
+        }
+
+        /**
+         * Instantiate a new Field
+         *
+         * @param name the name of the field
+         * @param type the type of the field
+         */
+        private Field(String name, Type type) {
+            super(name);
+            this.type = type;
+        }
+
+        public Type getType() {
+            return this.type;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            if (!super.equals(o)) {
+                return false;
+            }
+
+            Field field = (Field) o;
+
+            return type == field.type;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = super.hashCode();
+            result = 31 * result + (type != null ? type.hashCode() : 0);
+            return result;
+        }
+    }
+
+    private static class FieldAdapter implements JsonDeserializer<Field> {
+
+        private static final Type TEXT_FIELD = new TypeToken<Field.Type>() {
+        }.getType();
+
+        @Override
+        public Field deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext
+                context) throws JsonParseException {
+            JsonObject fieldObject = json.getAsJsonObject();
+            Field field = null;
+            for (Map.Entry<String, JsonElement> fieldEntry : fieldObject.entrySet()) {
+                field = new Field(fieldEntry.getKey(), context.<Field.Type>deserialize
+                        (fieldEntry.getValue(), TEXT_FIELD));
+            }
+            return field;
+        }
+    }
+
+    /**
+     * Internal class for configuring and deserializing index defintions.
+     */
+    static class Definition extends com.cloudant.client.internal.query.Definition<Field> {
+
+        @SerializedName(value = "analyzer", alternate = {"default_analyzer"})
+        private JsonElement analyzer;
+        private JsonObject default_field;
+
+        private Boolean index_array_lengths = null;
+
+    }
+
+    /**
+     * Class for building a definition for a text type index.
+     */
+    public static class Builder extends com.cloudant.client.internal.query.Builder<TextIndex,
+            Definition, Builder, Field> {
+
+        private Builder() {
+            // Prevent instantiation except by static TextIndex.builder()
+        }
+
+        @Override
+        protected TextIndex.Builder returnThis() {
+            return this;
+        }
+
+        @Override
+        protected TextIndex newInstance() {
+            return new TextIndex();
+        }
+
+        /**
+         * Configure the default field for the text index.
+         *
+         * @param enabled  true to enable the default field
+         * @param analyzer analyzer to use for the default field
+         * @return the builder for chaining
+         */
+        public TextIndex.Builder defaultField(boolean enabled, String analyzer) {
+            instance.def.default_field = new JsonObject();
+            instance.def.default_field.addProperty("enabled", enabled);
+            instance.def.default_field.add("analyzer", new Gson().toJsonTree(analyzer));
+            return this;
+        }
+
+        /**
+         * <P>
+         * Configure the analyzer for the text index.
+         * </P>
+         * <P>
+         * // TODO string, object differences and example
+         * </P>
+         *
+         * @param analyzer string of JSON analyzer representation
+         * @return the builder for chaining
+         */
+        public TextIndex.Builder analyzer(String analyzer) {
+            instance.def.analyzer = new Gson().fromJson(analyzer, JsonElement.class);
+            return this;
+        }
+
+        /**
+         * @param indexArrayLengths true if the indexer should search for arrays and store their
+         *                          lengths
+         * @return the builder for chaining
+         */
+        public TextIndex.Builder indexArrayLengths(boolean indexArrayLengths) {
+            instance.def.index_array_lengths = indexArrayLengths;
+            return this;
+        }
+
+        /**
+         * Add one or more fields containing string values to the text index configuration.
+         *
+         * @param fieldNames names of the fields to index
+         * @return the builder for chaining
+         */
+        public TextIndex.Builder string(String... fieldNames) {
+            return super.fields(fieldNamesToFieldList(Field.Type.STRING, fieldNames));
+        }
+
+        /**
+         * Add one or more fields containing numerical values to the text index configuration.
+         *
+         * @param fieldNames names of the fields to index
+         * @return the builder for chaining
+         */
+        public TextIndex.Builder number(String... fieldNames) {
+            return super.fields(fieldNamesToFieldList(Field.Type.NUMBER, fieldNames));
+        }
+
+        /**
+         * Add a field containing boolean values to the text index configuration.
+         *
+         * @param fieldNames name of the field to index
+         * @return the builder for chaining
+         */
+        public TextIndex.Builder bool(String... fieldNames) {
+            return super.fields(fieldNamesToFieldList(Field.Type.BOOLEAN, fieldNames));
+        }
+
+        private List<Field> fieldNamesToFieldList(Field.Type type, String... fieldNames) {
+            List<Field> fields = new ArrayList<Field>(fieldNames.length);
+            for (String fieldName : fieldNames) {
+                fields.add(new Field(fieldName, type));
+            }
+            return fields;
+        }
+    }
+}

--- a/cloudant-client/src/main/java/com/cloudant/client/internal/query/Builder.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/internal/query/Builder.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.client.internal.query;
+
+import com.cloudant.client.api.Database;
+import com.cloudant.client.api.query.Field;
+import com.cloudant.client.api.query.TextIndex;
+import com.cloudant.client.internal.util.SelectorUtils;
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Abstract index definition builder to be extended by specific index type builders.
+ *
+ * @param <I> the typed index class
+ * @param <B> the typed index class builder
+ */
+public abstract class Builder<I extends InternalIndex<D, F>, D extends Definition<F>, B
+        extends Builder, F extends Field> {
+
+    /**
+     * The new instance of the typed index
+     */
+    protected I instance = newInstance();
+
+    /**
+     * Configure the name of the index, if not set a name will be generated.
+     *
+     * @param indexName name of the index
+     * @return the builder for chaining
+     */
+    public B name(String indexName) {
+        instance.name = indexName;
+        return returnThis();
+    }
+
+    /**
+     * Configure the design document name, if not set a new design document will be created with
+     * a generated name.
+     *
+     * @param designDocumentId design document ID (the _design prefix is added if not supplied)
+     * @return the builder for chaining
+     */
+    public B designDocument(String designDocumentId) {
+        instance.ddoc = designDocumentId;
+        return returnThis();
+    }
+
+    /**
+     * Configure a selector to choose documents that should be added to the index.
+     *
+     * //TODO add link to Selector builder
+     *
+     * @param selector string of JSON selector representation
+     * @return the builder for chaining
+     */
+    public B partialFilterSelector(String selector) {
+        instance.def.selector = SelectorUtils.getPartialFilterSelectorFromString(selector);
+        return returnThis();
+    }
+
+    /**
+     * Add fields to the text index configuration.
+     *
+     * @param fields the {@link TextIndex.Field} configurations to add
+     * @return the builder for chaining
+     */
+    protected B fields(List<F> fields) {
+        if (instance.def.fields == null) {
+            instance.def.fields = new ArrayList<F>(fields.size());
+        }
+        instance.def.fields.addAll(fields);
+        return returnThis();
+    }
+
+    /**
+     * @return the string form of the JSON object encapsulating the index definition
+     * @see Database#createIndex(String)
+     */
+    public String definition() {
+        JsonObject indexAsJson = new Gson().toJsonTree(instance).getAsJsonObject();
+        // Merge the def fields into the index object to cope with create/list asymmetry
+        JsonObject definition = indexAsJson.getAsJsonObject("def");
+        indexAsJson.remove("def");
+        indexAsJson.add("index", definition);
+        return indexAsJson.toString();
+    }
+
+    /**
+     * @return the instance of the typed index builder
+     */
+    protected abstract B returnThis();
+
+    /**
+     * @return a new instance of the typed index
+     */
+    protected abstract I newInstance();
+}

--- a/cloudant-client/src/main/java/com/cloudant/client/internal/query/Definition.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/internal/query/Definition.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.client.internal.query;
+
+import com.cloudant.client.api.query.Field;
+import com.google.gson.JsonObject;
+import com.google.gson.annotations.SerializedName;
+
+import java.util.List;
+
+/**
+ * Abstract model of common index definition parameters.
+ */
+public class Definition<F extends Field> {
+    //TODO decide if this alternate is needed
+    @SerializedName(value = "partial_filter_selector", alternate = {"selector"})
+    protected JsonObject selector;
+    protected List<F> fields;
+}

--- a/cloudant-client/src/main/java/com/cloudant/client/internal/query/InternalIndex.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/internal/query/InternalIndex.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.client.internal.query;
+
+import com.cloudant.client.api.query.Field;
+import com.cloudant.client.api.query.Index;
+
+import java.util.List;
+
+/**
+ * Abstract class for common index configuration properties such as the name, design document, type
+ * and list of fields.
+ *
+ * @param <D> index definition type
+ */
+public class InternalIndex<D extends Definition<F>, F extends Field> implements Index<F> {
+
+    protected String ddoc;
+    protected String name;
+    protected D def;
+
+    private String type;
+
+    /**
+     * Constructor for sub-classes to instantiate
+     *
+     * @param type the type of the index
+     */
+    protected InternalIndex(String type) {
+        this.type = type;
+    }
+
+    /**
+     * @return the design document ID
+     */
+    @Override
+    public String getDesignDocumentID() {
+        return this.ddoc;
+    }
+
+    /**
+     * @return the name of the index
+     */
+    @Override
+    public String getName() {
+        return this.name;
+    }
+
+    /**
+     * @return the type of the index
+     */
+    @Override
+    public String getType() {
+        return this.type;
+    }
+
+    /**
+     * Get the JSON string representation of the selector configured for this index.
+     *
+     * @return selector JSON as string
+     */
+    @Override
+    public String getPartialFilterSelector() {
+        return (def.selector != null) ? def.selector.toString() : null;
+    }
+
+    /**
+     * @return the list of fields in the index
+     */
+    @Override
+    public List<F> getFields() {
+        return this.def.fields;
+    }
+}

--- a/cloudant-client/src/main/java/com/cloudant/client/internal/query/ListableIndex.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/internal/query/ListableIndex.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.client.internal.query;
+
+import com.cloudant.client.api.query.Field;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.annotations.JsonAdapter;
+
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class ListableIndex extends InternalIndex<ListableIndex.Definition, Field> {
+
+    /**
+     * Constructor for sub-classes to instantiate
+     *
+     * @param type the type of the index
+     */
+    protected ListableIndex(String type) {
+        super(type);
+    }
+
+    @JsonAdapter(Adapter.class)
+    static class Definition extends com.cloudant.client.internal.query.Definition<Field> {
+
+    }
+
+    static class Adapter implements JsonDeserializer<Definition> {
+
+        @Override
+        public Definition deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext
+                context) throws JsonParseException {
+            Definition def = new Definition();
+            JsonObject d = json.getAsJsonObject();
+            JsonArray fields = d.getAsJsonArray("fields");
+            List<Field> namedFields = new ArrayList<Field>();
+            for (JsonElement field : fields) {
+                JsonObject f = field.getAsJsonObject();
+                for (Map.Entry<String, JsonElement> fieldEntry : f.entrySet()) {
+                    namedFields.add(new NamedField(fieldEntry.getKey()));
+                }
+            }
+            def.fields = namedFields;
+            return def;
+        }
+    }
+
+    public String toString() {
+        StringBuilder index = new StringBuilder();
+        index.append("ddoc: ");
+        index.append(getDesignDocumentID());
+        index.append(", name: ");
+        index.append(getName());
+        index.append(", type: ");
+        index.append(getType());
+        index.append(", fields: ");
+        index.append(getFields().toString());
+        index.append(", partial_filter_selector: ");
+        index.append(getPartialFilterSelector());
+        return index.toString();
+    }
+}

--- a/cloudant-client/src/main/java/com/cloudant/client/internal/query/NamedField.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/internal/query/NamedField.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.client.internal.query;
+
+/**
+ * Model of a field definition to be extended by specific index type fields.
+ */
+public class NamedField implements com.cloudant.client.api.query.Field {
+
+    private String name;
+
+    protected NamedField(String name) {
+        this.name = name;
+    }
+
+    /**
+     * @return the name of the field
+     */
+    public String getName() {
+        return this.name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        NamedField that = (NamedField) o;
+
+        return name != null ? name.equals(that.name) : that.name == null;
+    }
+
+    @Override
+    public int hashCode() {
+        return name != null ? name.hashCode() : 0;
+    }
+
+    @Override
+    public String toString() {
+        return name;
+    }
+}

--- a/cloudant-client/src/main/java/com/cloudant/client/internal/util/SelectorUtils.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/internal/util/SelectorUtils.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.client.internal.util;
+
+import static com.cloudant.client.org.lightcouch.internal.CouchDbUtil.assertNotEmpty;
+import static com.cloudant.client.org.lightcouch.internal.CouchDbUtil.assertNotNull;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+
+public class SelectorUtils {
+
+    public static JsonObject getPartialFilterSelectorFromString(String selectorJson) {
+        return getSelectorFromString("partial_filter_selector", selectorJson);
+    }
+
+    public static JsonObject getSelectorFromString(String selectorJson) {
+        return getSelectorFromString("selector", selectorJson);
+    }
+
+    private static JsonObject getSelectorFromString(String key, String selectorJson) {
+        selectorJson = sanitizeSelectorString(selectorJson);
+        JsonObject selector = selectorStringAsJsonObject(key, selectorJson);
+        selector = extractNestedSelectorObject(key, selector);
+        return selector;
+    }
+
+    private static String sanitizeSelectorString(String selectorJson) {
+        assertNotNull(selectorJson, "selectorJson");
+        // If it wasn't null we can safely trim
+        selectorJson = selectorJson.trim();
+        assertNotEmpty(selectorJson, "selectorJson");
+        return selectorJson;
+    }
+
+    private static JsonObject selectorStringAsJsonObject(String key, String selectorJson) {
+        Gson gson = new Gson();
+        JsonObject selectorObject = null;
+        boolean isObject = true;
+        try {
+            selectorObject = gson.fromJson(selectorJson, JsonObject.class);
+        } catch (JsonParseException e) {
+            isObject = false;
+        }
+
+        if (!isObject) {
+            if (selectorJson.startsWith(key) || selectorJson.startsWith("\"" + key + "\"")) {
+                selectorJson = selectorJson.substring(selectorJson.indexOf(":") + 1,
+                        selectorJson.length()).trim();
+                selectorObject = gson.fromJson(selectorJson, JsonObject.class);
+            } else {
+                throw new JsonParseException("selectorJson should be valid json or like " +
+                        "\"" + key + "\": {...} ");
+            }
+        }
+        return selectorObject;
+    }
+
+    private static JsonObject extractNestedSelectorObject(String key, JsonObject selectorObject) {
+        if (selectorObject.has(key)) {
+            return selectorObject.get(key).getAsJsonObject();
+        } else {
+            return selectorObject;
+        }
+    }
+}

--- a/cloudant-client/src/test/java/com/cloudant/api/query/FieldAssertHelper.java
+++ b/cloudant-client/src/test/java/com/cloudant/api/query/FieldAssertHelper.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.api.query;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import com.cloudant.client.api.query.Field;
+import com.cloudant.client.api.query.JsonIndex;
+import com.cloudant.client.api.query.Sort;
+import com.cloudant.client.api.query.TextIndex;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public abstract class FieldAssertHelper<T, F extends Field> {
+
+    protected final Map<String, T> expectedFields = new HashMap<String, T>();
+
+    public static class Json extends FieldAssertHelper<Sort.Order, JsonIndex.Field> {
+        Json(Map<String, Sort.Order>... expectedJsonFields) {
+            for (Map<String, Sort.Order> m : expectedJsonFields) {
+                this.expectedFields.putAll(m);
+            }
+        }
+
+        @Override
+        protected void assertField(JsonIndex.Field field, Sort.Order order) {
+            assertEquals("The order should be the same", order, field.getOrder());
+        }
+    }
+
+    public static class Text extends FieldAssertHelper<TextIndex.Field.Type, TextIndex.Field> {
+        Text(Map<String, TextIndex.Field.Type>... expectedTextFields) {
+            for (Map<String, TextIndex.Field.Type> m : expectedTextFields) {
+                this.expectedFields.putAll(m);
+            }
+        }
+
+        @Override
+        protected void assertField(TextIndex.Field field, TextIndex.Field.Type type) {
+            assertEquals("The type should be the same", type, field.getType());
+        }
+    }
+
+    public void assertFields(List<F> actualFields) {
+        assertEquals("There should be the correct number of fields", expectedFields.size(),
+                actualFields.size());
+        for (F field : actualFields) {
+            assertNotNull("The field should have a name", field.getName());
+            T expected = expectedFields.remove(field.getName());
+            assertNotNull("Unexpected field " + field.getName() + " found.", expected);
+            assertField(field, expected);
+        }
+        assertEquals("All fields should be asserted.", 0, expectedFields.size());
+    }
+
+    protected abstract void assertField(F field, T type);
+}

--- a/cloudant-client/src/test/java/com/cloudant/api/query/IndexCreationTests.java
+++ b/cloudant-client/src/test/java/com/cloudant/api/query/IndexCreationTests.java
@@ -1,0 +1,251 @@
+/*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.api.query;
+
+import static org.junit.Assert.assertEquals;
+
+import com.cloudant.client.api.query.JsonIndex;
+import com.cloudant.client.api.query.TextIndex;
+import com.cloudant.tests.util.MockedServerTest;
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+
+import org.junit.Test;
+
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.RecordedRequest;
+
+import java.util.concurrent.TimeUnit;
+
+public class IndexCreationTests extends MockedServerTest {
+
+    private static MockResponse CREATED = new MockResponse().setBody("{\"result\": \"created\"}");
+
+    // Strings for creating partial indexes
+    private String selectorContent = "{year: {$gt: 2010}}";
+    private String selectorPair = "partial_filter_selector: " + selectorContent;
+    private String selector = "{" + selectorPair + "}";
+
+    @Test
+    public void createJsonIndex() throws Exception {
+        createIndexTest(JsonIndex.builder()
+                        .asc("a")
+                        .definition(),
+                "{type: \"json\", index: {fields: [{\"a\":\"asc\"}]}}");
+    }
+
+    /**
+     * Note mixed indexes are currently unsupported on the server, but we should still construct a
+     * valid object even if the server will reject it.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void createJsonIndexSpecifyFieldOrder() throws Exception {
+        createIndexTest(JsonIndex.builder()
+                        .asc("a")
+                        .desc("d")
+                        .definition(),
+                "{type: \"json\", index: {fields: [{\"a\":\"asc\"},{\"d\":\"desc\"}]}}");
+    }
+
+    @Test
+    public void createNamedJsonIndex() throws Exception {
+        createIndexTest(JsonIndex.builder()
+                        .name("testindex")
+                        .asc("a")
+                        .definition(),
+                "{type: \"json\", name: \"testindex\", index: {fields: [{\"a\":\"asc\"}]}}");
+    }
+
+    @Test
+    public void createJsonIndexInDesignDoc() throws Exception {
+        createIndexTest(JsonIndex.builder()
+                        .designDocument("testddoc")
+                        .asc("a")
+                        .definition(),
+                "{type: \"json\", ddoc: \"testddoc\", index: {fields: [{\"a\":\"asc\"}]}}");
+    }
+
+    @Test
+    public void createJsonIndexAllOptions() throws Exception {
+        createIndexTest(JsonIndex.builder()
+                        .designDocument("testddoc")
+                        .name("testindex")
+                        .asc("a")
+                        .desc("d")
+                        .definition(),
+                "{type: \"json\", ddoc: \"testddoc\", name: \"testindex\", " +
+                        "index: {fields: [{\"a\":\"asc\"},{\"d\":\"desc\"}]}}");
+    }
+
+    @Test
+    public void createJsonIndexPartialSelectorOnly() throws Exception {
+        createIndexTest(JsonIndex.builder()
+                        .asc("a")
+                        .partialFilterSelector(selectorContent)
+                        .definition(),
+                "{type: \"json\", index: {" + selectorPair + ", fields: [{\"a\":\"asc\"}]}}");
+    }
+
+    @Test
+    public void createJsonIndexPartialSelectorPair() throws Exception {
+        createIndexTest(JsonIndex.builder()
+                        .asc("a")
+                        .partialFilterSelector(selectorPair)
+                        .definition(),
+                "{type: \"json\", index: {" + selectorPair + ", fields: [{\"a\":\"asc\"}]}}");
+    }
+
+    @Test
+    public void createJsonIndexPartialSelectorObject() throws Exception {
+        createIndexTest(JsonIndex.builder()
+                        .asc("a")
+                        .partialFilterSelector(selector)
+                        .definition(),
+                "{type: \"json\", index: {" + selectorPair + ", fields: [{\"a\":\"asc\"}]}}");
+    }
+
+    @Test
+    public void createTextIndex() throws Exception {
+        createIndexTest(TextIndex.builder()
+                        .definition(),
+                "{type: \"text\", index: {}}");
+    }
+
+    @Test
+    public void createNamedTextIndex() throws Exception {
+        createIndexTest(TextIndex.builder()
+                        .name("testindex")
+                        .definition(),
+                "{type: \"text\", name: \"testindex\", index: {}}");
+    }
+
+    @Test
+    public void createTextIndexInDesignDoc() throws Exception {
+        createIndexTest(TextIndex.builder()
+                .designDocument("testddoc")
+                        .definition(),
+                "{type: \"text\", ddoc: \"testddoc\", index: {}}");
+    }
+
+    @Test
+    public void createTextIndexWithFields() throws Exception {
+        createIndexTest(TextIndex.builder()
+                        .string("s")
+                        .bool("b")
+                        .number("n")
+                        .definition(),
+                "{type: \"text\", index: {fields: [{name: \"s\", type:\"string\"}," +
+                        "{name: \"b\", type:\"boolean\"},{name: \"n\", type:\"number\"}]}}");
+    }
+
+    @Test
+    public void createTextIndexWithDefaultField() throws Exception {
+        createIndexTest(TextIndex.builder()
+                        .defaultField(true, "german")
+                        .definition(),
+                "{type: \"text\", index: { default_field: {enabled: true, analyzer: \"german\"}}}");
+    }
+
+    @Test
+    public void createTextIndexWithStringAnalyzer() throws Exception {
+        createIndexTest(TextIndex.builder()
+                        .analyzer("keyword")
+                        .definition(),
+                "{type: \"text\", index: {analyzer: \"keyword\"}}");
+    }
+
+    @Test
+    public void createTextIndexWithObjectAnalyzer() throws Exception {
+        String a = "{\"name\": \"perfield\"," +
+                "\"default\": \"english\"," +
+                "\"fields\": {" +
+                "\"spanish\": \"spanish\"," +
+                "\"german\": \"german\"}}";
+        createIndexTest(TextIndex.builder()
+                        .analyzer(a)
+                        .definition(),
+                "{type: \"text\", index: {analyzer: " + a + "}}");
+    }
+
+    @Test
+    public void createTextIndexPartialSelectorOnly() throws Exception {
+        createIndexTest(TextIndex.builder()
+                        .partialFilterSelector(selectorContent)
+                        .definition(),
+                "{type: \"text\", index: " + selector + "}");
+    }
+
+    @Test
+    public void createTextIndexPartialSelectorPair() throws Exception {
+        createIndexTest(TextIndex.builder()
+                        .partialFilterSelector(selectorPair)
+                        .definition(),
+                "{type: \"text\", index: " + selector + "}");
+    }
+
+    @Test
+    public void createTextIndexPartialSelectorObject() throws Exception {
+        createIndexTest(TextIndex.builder()
+                        .partialFilterSelector(selector)
+                        .definition(),
+                "{type: \"text\", index: " + selector + "}");
+    }
+
+    @Test
+    public void createTextIndexWithIndexArrayLengths() throws Exception {
+        createIndexTest(TextIndex.builder()
+                        .indexArrayLengths(false)
+                        .definition(),
+                "{type: \"text\", index: {index_array_lengths: false}}");
+    }
+
+    @Test
+    public void createTextIndexWithAllOptions() throws Exception {
+        createIndexTest(TextIndex.builder()
+                        .name("testindex")
+                        .designDocument("testddoc")
+                        .string("s")
+                        .bool("b")
+                        .number("n")
+                        .defaultField(true, "german")
+                        .analyzer("keyword")
+                        .partialFilterSelector(selector)
+                        .indexArrayLengths(false)
+                        .definition(),
+                "{type: \"text\"," +
+                        "name: \"testindex\"," +
+                        "ddoc: \"testddoc\"," +
+                        "index: {" +
+                        "fields: [{name: \"s\", type:\"string\"}," +
+                        "{name: \"b\", type:\"boolean\"}," +
+                        "{name: \"n\", type:\"number\"}]," +
+                        "default_field: {enabled: true, analyzer: \"german\"}," +
+                        "analyzer: \"keyword\"," +
+                        "partial_filter_selector: " + selectorContent + "," +
+                        "index_array_lengths: false" +
+                        "}}");
+    }
+
+    private void createIndexTest(String definition, String expected) throws Exception {
+        JsonObject exp = new Gson().fromJson(expected, JsonObject.class);
+        server.enqueue(CREATED);
+        db.createIndex(definition);
+        RecordedRequest request = server.takeRequest(1, TimeUnit.SECONDS);
+        JsonObject actual = new Gson().fromJson(request.getBody().readUtf8(), JsonObject.class);
+        assertEquals("The request body should match the expected", exp, actual);
+    }
+}

--- a/cloudant-client/src/test/java/com/cloudant/api/query/IndexDeletionTests.java
+++ b/cloudant-client/src/test/java/com/cloudant/api/query/IndexDeletionTests.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.api.query;
+
+import static org.junit.Assert.assertEquals;
+
+import com.cloudant.tests.util.MockWebServerResources;
+import com.cloudant.tests.util.MockedServerTest;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import okhttp3.mockwebserver.RecordedRequest;
+
+import java.util.concurrent.TimeUnit;
+
+public class IndexDeletionTests extends MockedServerTest {
+
+    @Before
+    public void enqueueOK() {
+        server.enqueue(MockWebServerResources.JSON_OK);
+    }
+
+    @Test
+    public void deleteDefaultJsonIndex() throws Exception {
+        db.deleteIndex("testddoc", "testindex");
+        assertDelete("testddoc", "testindex", "json");
+    }
+
+    @Test
+    public void deleteJsonIndex() throws Exception {
+        db.deleteIndex("testddoc", "testindex", "json");
+        assertDelete("testddoc", "testindex", "json");
+    }
+
+    @Test
+    public void deleteTextIndex() throws Exception {
+        db.deleteIndex("testddoc", "testindex", "text");
+        assertDelete("testddoc", "testindex", "text");
+    }
+
+    private void assertDelete(String name, String ddoc, String type) throws Exception {
+        RecordedRequest request = server.takeRequest(1, TimeUnit.SECONDS);
+        assertEquals("The request body should match the expected", "/" + dbResource.getDatabaseName() +
+                "/_index/_design/" + ddoc + "/" + type + "/" + name, request.getPath());
+    }
+}

--- a/cloudant-client/src/test/java/com/cloudant/api/query/IndexLifecycleTest.java
+++ b/cloudant-client/src/test/java/com/cloudant/api/query/IndexLifecycleTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.api.query;
+
+import static org.junit.Assert.assertEquals;
+
+import com.cloudant.client.api.Database;
+import com.cloudant.client.api.query.Field;
+import com.cloudant.client.api.query.Index;
+import com.cloudant.client.api.query.JsonIndex;
+import com.cloudant.client.api.query.Sort;
+import com.cloudant.client.api.query.TextIndex;
+import com.cloudant.test.main.RequiresCloudant;
+import com.cloudant.tests.util.CloudantClientResource;
+import com.cloudant.tests.util.DatabaseResource;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.RuleChain;
+
+import java.util.Collections;
+import java.util.List;
+
+
+// This really requires Couch2.0 + text index support, but we don't have a way of expressing that
+@Category(RequiresCloudant.class)
+
+/**
+ * Index lifecycle test.
+ * Before create indexes
+ * Test list indexes
+ * After delete indexes
+ */
+public class IndexLifecycleTest {
+
+    private CloudantClientResource clientResource = new CloudantClientResource();
+    private DatabaseResource dbResource = new DatabaseResource(clientResource);
+    @Rule
+    public RuleChain chain = RuleChain.outerRule(clientResource).around(dbResource);
+
+    private Database db;
+
+    @Before
+    public void createIndexes() throws Exception {
+        db = dbResource.get();
+
+        // Create a JSON index
+        db.createIndex(JsonIndex.builder()
+                .designDocument("indexlifecycle")
+                .name("testjson")
+                .asc("testDefaultAsc", "testAsc")
+                .definition()
+        );
+
+        // Create a text index
+        db.createIndex(TextIndex.builder()
+                .designDocument("indexlifecycle")
+                .name("testtext")
+                .string("testString")
+                .number("testNumber")
+                .bool("testBoolean")
+                .definition()
+        );
+    }
+
+    @Test
+    public void listIndexes() throws Exception {
+        {
+            // JSON index
+            List<JsonIndex> jIndexes = db.listIndexes().jsonIndexes();
+            assertEquals("There should be one JSON index", 1, jIndexes.size());
+            JsonIndex jIndex = jIndexes.get(0);
+            assertEquals("The ddoc should be correct", "_design/indexlifecycle", jIndex
+                    .getDesignDocumentID());
+            assertEquals("The name should be correct", "testjson", jIndex.getName());
+            assertEquals("The type should be correct", "json", jIndex.getType());
+            List<JsonIndex.Field> fields = jIndex.getFields();
+            assertEquals("There should be two fields", 2, fields.size());
+            // Field assertions
+            new FieldAssertHelper.Json(Collections.singletonMap("testDefaultAsc", Sort.Order.ASC)
+                    , Collections.singletonMap("testAsc", Sort.Order.ASC)).assertFields(fields);
+        }
+
+        {
+            // Text index
+            List<TextIndex> tIndexes = db.listIndexes().textIndexes();
+            assertEquals("There should be one text index", 1, tIndexes.size());
+            TextIndex tIndex = tIndexes.get(0);
+            assertEquals("The ddoc should be correct", "_design/indexlifecycle", tIndex
+                    .getDesignDocumentID());
+            assertEquals("The name should be correct", "testtext", tIndex.getName());
+            assertEquals("The type should be correct", "text", tIndex.getType());
+            List<TextIndex.Field> fields = tIndex.getFields();
+            assertEquals("There should be three fields", 3, fields.size());
+            // Field assertions
+            new FieldAssertHelper.Text(Collections.singletonMap("testString", TextIndex.Field.Type.STRING),
+                    Collections.singletonMap("testNumber", TextIndex.Field.Type.NUMBER),
+                    Collections.singletonMap("testBoolean", TextIndex.Field.Type.BOOLEAN)).assertFields(fields);
+        }
+
+        {
+            // All indexes
+            List<Index<Field>> allIndexes = db.listIndexes().allIndexes();
+            assertEquals("There should be three total indexes", 3, allIndexes.size());
+            for (Index<Field> index : allIndexes) {
+                if (index.getType().equals("special")) {
+                    assertEquals("The name should be correct", "_all_docs", index.getName());
+                    assertEquals("There should be 1 field", 1, index.getFields().size());
+                    assertEquals("There field should be called _id", "_id", index.getFields().get(0)
+                            .getName());
+                }
+            }
+        }
+    }
+
+    @After
+    public void deleteIndexes() throws Exception {
+        db.deleteIndex("testjson", "indexlifecycle", "json");
+        db.deleteIndex("testtext", "indexlifecycle", "text");
+        List<Index<Field>> allIndexes = db.listIndexes().allIndexes();
+        assertEquals("There should be one (special) index", 1, allIndexes.size());
+    }
+}

--- a/cloudant-client/src/test/java/com/cloudant/api/query/IndexListTests.java
+++ b/cloudant-client/src/test/java/com/cloudant/api/query/IndexListTests.java
@@ -1,0 +1,273 @@
+/*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.api.query;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import com.cloudant.client.api.query.Field;
+import com.cloudant.client.api.query.Index;
+import com.cloudant.client.api.query.JsonIndex;
+import com.cloudant.client.api.query.Sort;
+import com.cloudant.client.api.query.TextIndex;
+import com.cloudant.tests.util.MockedServerTest;
+
+import org.apache.commons.io.IOUtils;
+import org.junit.Test;
+
+import okhttp3.mockwebserver.MockResponse;
+
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public class IndexListTests extends MockedServerTest {
+
+    private static String SELECTOR_STRING = "{\"year\":{\"$gt\":2010}}";
+
+    // _all_docs
+    private static String ALL_DOCS = fromFile("index_all_docs");
+    private static String JSON_SIMPLE = fromFile("index_json_simple");
+    private static String JSON_COMPLEX = fromFile("index_json_complex");
+    private static String TEXT_SIMPLE = fromFile("index_text_simple");
+    private static String TEXT_COMPLEX = fromFile("index_text_complex");
+    private static String TEXT_ALL_FIELDS = fromFile("index_text_all");
+    private static String TEXT_SIMPLE_SELECTOR = fromFile("index_text_simple_selector");
+
+    /**
+     * Utility to convert a test resource file into a string.
+     *
+     * @param resourceFileName name of the file excluding path and extension
+     * @return
+     */
+    private static String fromFile(String resourceFileName) {
+        System.out.println(new File(".").getAbsolutePath());
+        try {
+            return IOUtils.toString(new BufferedInputStream(new FileInputStream("" +
+                    "./src/test/resources/query-tests/" + resourceFileName + ".js")), "UTF-8");
+        } catch (Exception e) {
+            fail("Error reading test resource: " +  e.getMessage());
+        }
+        return null;
+    }
+
+    private void enqueueList(String... indexes) {
+        MockResponse response = new MockResponse();
+        StringBuilder responseContent = new StringBuilder("{\"indexes\": [");
+        // Always add the special index
+        responseContent.append(ALL_DOCS);
+        // Add the rest of the indexes
+        for (String index : indexes) {
+            responseContent.append(",");
+            responseContent.append(index);
+        }
+        responseContent.append("], \"total_rows\": " + (indexes.length + 1) + "}");
+        response.setBody(responseContent.toString());
+        server.enqueue(response);
+    }
+
+    private void assertIndex(Index index, String name, String type, String selector) throws
+            Exception {
+        if (selector == null) {
+            selector = "{}";
+        }
+        assertIndex(index, name, "_design/testindexddoc", type, selector);
+    }
+
+    private void assertIndex(Index index, String name, String ddoc, String type, String selector)
+            throws Exception {
+        assertEquals("The index should have the correct name", name, index.getName());
+        assertEquals("The index should have the correct ddoc", ddoc, index
+                .getDesignDocumentID());
+        assertEquals("The index should have the correct type", type, index.getType());
+        assertEquals("The index should have the correct selector", selector, index
+                .getPartialFilterSelector());
+    }
+
+    private void assertJsonIndex(JsonIndex index, String name, String selector, Map<String, Sort
+            .Order>... expectedFields) throws Exception {
+        assertIndex(index, name, "json", selector);
+        // Assert the fields
+        new FieldAssertHelper.Json(expectedFields).assertFields(index.getFields());
+    }
+
+    private void assertTextIndex(TextIndex index, String name, String selector, String analyzer,
+                                 String defaultField, Map<String, TextIndex.Field.Type>...
+                                         expectedFields) throws Exception {
+        assertIndex(index, name, "text", selector);
+        assertEquals("The analyzer should be correct", analyzer, index.getAnalyzer());
+        assertEquals("The default field should be correct", defaultField, index.getDefaultField());
+        // Assert the fields
+        new FieldAssertHelper.Text(expectedFields).assertFields(index.getFields());
+    }
+
+    private void assertSimpleJson(JsonIndex index) throws Exception {
+        assertJsonIndex(index, "simplejson", null, Collections.singletonMap("Person_dob", Sort.Order
+                .ASC));
+    }
+
+    private void assertComplexJson(JsonIndex index) throws Exception {
+        assertJsonIndex(index, "complexjson", SELECTOR_STRING, Collections.singletonMap
+                ("Person_name", Sort.Order
+                        .ASC), Collections.singletonMap("Movie_year", Sort.Order.DESC));
+    }
+
+    private void assertSimpleText(TextIndex index) throws Exception {
+        assertTextIndex(index, "simpletext", null, "\"keyword\"", "{}", Collections.singletonMap
+                ("Movie_name", TextIndex.Field.Type.STRING));
+    }
+
+    private void assertComplexText(TextIndex index) throws Exception {
+        assertTextIndex(index, "complextext", SELECTOR_STRING, "{\"name\":\"perfield\"," +
+                        "\"default\":\"english\",\"fields\":{\"spanish\":\"spanish\"," +
+                        "\"german\":\"german\"}}", "{\"enabled\":true,\"analyzer\":\"spanish\"}",
+                Collections.singletonMap("Movie_name", TextIndex.Field.Type.STRING), Collections
+                        .singletonMap("Movie_runtime", TextIndex.Field.Type.NUMBER), Collections
+                        .singletonMap("Movie_wonaward", TextIndex.Field.Type.BOOLEAN));
+    }
+
+    @Test
+    public void listSimpleJsonIndex() throws Exception {
+        enqueueList(JSON_SIMPLE);
+        List<JsonIndex> indexes = db.listIndexes().jsonIndexes();
+        assertEquals("There should be 1 JSON index", 1, indexes.size());
+        JsonIndex simple = indexes.get(0);
+        assertSimpleJson(simple);
+    }
+
+    @Test
+    public void listComplexJsonIndex() throws Exception {
+        enqueueList(JSON_COMPLEX);
+        List<JsonIndex> indexes = db.listIndexes().jsonIndexes();
+        assertEquals("There should be 1 JSON index", 1, indexes.size());
+        JsonIndex complex = indexes.get(0);
+        assertComplexJson(complex);
+
+    }
+
+    @Test
+    public void listMultipleJsonIndexes() throws Exception {
+        enqueueList(JSON_SIMPLE, JSON_COMPLEX);
+        List<JsonIndex> indexes = db.listIndexes().jsonIndexes();
+        assertEquals("There should be 2 JSON indexes", 2, indexes.size());
+        JsonIndex simple = indexes.get(0);
+        assertSimpleJson(simple);
+        JsonIndex complex = indexes.get(1);
+        assertComplexJson(complex);
+    }
+
+    @Test
+    public void listSimpleTextIndex() throws Exception {
+        enqueueList(TEXT_SIMPLE);
+        List<TextIndex> indexes = db.listIndexes().textIndexes();
+        assertEquals("There should be 1 text index", 1, indexes.size());
+        TextIndex simple = indexes.get(0);
+        assertSimpleText(simple);
+    }
+
+    /**
+     * Note this checks deserialization of the old "selector" field instead of
+     * partial_filter_selector
+     *
+     * @throws Exception
+     */
+    @Test
+    public void listSimpleTextIndexWithSelector() throws Exception {
+        enqueueList(TEXT_SIMPLE_SELECTOR);
+        List<TextIndex> indexes = db.listIndexes().textIndexes();
+        assertEquals("There should be 1 text index", 1, indexes.size());
+        TextIndex simple = indexes.get(0);
+        assertTextIndex(simple, "simpleselector", SELECTOR_STRING, "\"keyword\"", "{}",
+                Collections.singletonMap
+                        ("Movie_name", TextIndex.Field.Type.STRING));
+    }
+
+    @Test
+    public void listComplexTextIndex() throws Exception {
+        enqueueList(TEXT_COMPLEX);
+        List<TextIndex> indexes = db.listIndexes().textIndexes();
+        assertEquals("There should be 1 text index", 1, indexes.size());
+        TextIndex complex = indexes.get(0);
+        assertComplexText(complex);
+    }
+
+    @Test
+    public void listMultipleTextIndexes() throws Exception {
+        enqueueList(TEXT_SIMPLE, TEXT_COMPLEX, TEXT_ALL_FIELDS);
+        List<TextIndex> indexes = db.listIndexes().textIndexes();
+        assertEquals("There should be 3 text indexes", 3, indexes.size());
+        TextIndex simple = indexes.get(0);
+        assertSimpleText(simple);
+        TextIndex complex = indexes.get(1);
+        assertComplexText(complex);
+        // Assert the all text index
+        TextIndex all = indexes.get(2);
+        assertTextIndex(all, "textallfields", null, "\"keyword\"", "{\"enabled\":false}");
+    }
+
+    @Test
+    public void listAllIndexes() throws Exception {
+        enqueueList(JSON_SIMPLE, JSON_COMPLEX, TEXT_SIMPLE, TEXT_COMPLEX, TEXT_ALL_FIELDS);
+        List<Index<Field>> indexes = db.listIndexes().allIndexes();
+        // Note 5 listed here, plus the special index that is always included
+        assertEquals("There should be 6 indexes", 6, indexes.size());
+        for (int i = 0; i < indexes.size(); i++) {
+            String name;
+            String type;
+            String selector;
+            switch (i) {
+                case 0:
+                    Index<Field> a = indexes.get(i);
+                    assertIndex(a, "_all_docs", null, "special", null);
+                    assertEquals("There should be 1 field", 1, a.getFields().size());
+                    assertEquals("There field should be called _id", "_id", a.getFields().get(0)
+                            .getName());
+                    return;
+                case 1:
+                    name = "simplejson";
+                    type = "json";
+                    selector = null;
+                    break;
+                case 2:
+                    name = "complexjson";
+                    type = "json";
+                    selector = SELECTOR_STRING;
+                    break;
+                case 3:
+                    name = "simpletext";
+                    type = "text";
+                    selector = null;
+                    break;
+                case 4:
+                    name = "complextext";
+                    type = "text";
+                    selector = SELECTOR_STRING;
+                    break;
+                case 5:
+                    name = "textallfields";
+                    type = "text";
+                    selector = null;
+                    break;
+                default:
+                    fail("Unknown index");
+                    return;
+            }
+            assertIndex(indexes.get(i), name, type, selector);
+        }
+    }
+}

--- a/cloudant-client/src/test/java/com/cloudant/tests/CloudantClientHelper.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/CloudantClientHelper.java
@@ -113,8 +113,7 @@ public abstract class CloudantClientHelper {
         return testAddressClient(false);
     }
 
-    public static ClientBuilder newMockWebServerClientBuilder(MockWebServer mockServer) throws
-            MalformedURLException {
+    public static ClientBuilder newMockWebServerClientBuilder(MockWebServer mockServer) {
         return ClientBuilder.url(mockServer.url("/").url());
     }
 

--- a/cloudant-client/src/test/java/com/cloudant/tests/UnicodeTest.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/UnicodeTest.java
@@ -17,8 +17,9 @@ package com.cloudant.tests;
 import static org.junit.Assert.assertEquals;
 
 import com.cloudant.client.api.Database;
-import com.cloudant.client.api.model.Index;
-import com.cloudant.client.api.model.IndexField;
+import com.cloudant.client.api.query.Field;
+import com.cloudant.client.api.query.Index;
+import com.cloudant.client.api.query.JsonIndex;
 import com.cloudant.client.api.views.Key;
 import com.cloudant.client.internal.DatabaseURIHelper;
 import com.cloudant.http.Http;
@@ -339,13 +340,14 @@ public class UnicodeTest {
     @Test
     @Category(RequiresCloudant.class)
     public void testUnicodeInObject() throws Exception {
-        db.createIndex(
-                "myview", "mydesigndoc", "json",
-                new IndexField[]{
-                        new IndexField("foo", IndexField.SortOrder.asc)
-                });
+        db.createIndex(JsonIndex.builder()
+                .name("myview")
+                .designDocument("mydesigndoc")
+                .asc("foo")
+                .definition());
+
         // Show the indices.
-        for (Index index : db.listIndices()) {
+        for (Index<Field> index : db.listIndexes().allIndexes()) {
             TEST_LOG.logger.info(index.toString());
         }
         // Create an object.

--- a/cloudant-client/src/test/java/com/cloudant/tests/util/CloudantClientMockServerResource.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/util/CloudantClientMockServerResource.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.tests.util;
+
+import com.cloudant.tests.CloudantClientHelper;
+
+import okhttp3.mockwebserver.MockWebServer;
+
+public class CloudantClientMockServerResource extends CloudantClientResource {
+
+    private final MockWebServer server;
+
+    public CloudantClientMockServerResource(MockWebServer mockWebServer) {
+        super(CloudantClientHelper.newMockWebServerClientBuilder(mockWebServer));
+        this.server = mockWebServer;
+    }
+
+    @Override
+    public void after() {
+        // Queue a 200 for the _session DELETE that is called on shutdown.
+        server.enqueue(MockWebServerResources.JSON_OK);
+        super.after();
+    }
+}

--- a/cloudant-client/src/test/java/com/cloudant/tests/util/DatabaseResource.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/util/DatabaseResource.java
@@ -34,6 +34,7 @@ public class DatabaseResource extends ExternalResource {
     private CloudantClient client;
     private String databaseName = Utils.generateUUID();
     private Database database;
+    private boolean mock = false;
 
     /**
      * Create a database resource from the specified clientResource. Note that if the resources
@@ -53,6 +54,11 @@ public class DatabaseResource extends ExternalResource {
      */
     public DatabaseResource(CloudantClientResource clientResource) {
         this.clientResource = clientResource;
+    }
+
+    public DatabaseResource(CloudantClientMockServerResource mockServerResource) {
+        this.clientResource = mockServerResource;
+        this.mock = true;
     }
 
     @Override
@@ -94,12 +100,18 @@ public class DatabaseResource extends ExternalResource {
     @Override
     public void before() {
         client = clientResource.get();
-        database = client.database(databaseName, true);
+        if (!mock) {
+            database = client.database(databaseName, true);
+        } else {
+            database = client.database(databaseName, false);
+        }
     }
 
     @Override
     public void after() {
-        client.deleteDB(databaseName);
+        if (!mock) {
+            client.deleteDB(databaseName);
+        }
     }
 
     public Database get() {

--- a/cloudant-client/src/test/java/com/cloudant/tests/util/MockedServerTest.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/util/MockedServerTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2017 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.tests.util;
+
+import com.cloudant.client.api.CloudantClient;
+import com.cloudant.client.api.Database;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.rules.RuleChain;
+
+import okhttp3.mockwebserver.MockWebServer;
+
+/**
+ * Class of tests that run against a MockWebServer. This class handles set up and tear down of the
+ * mock server and associated client and db objects before/after each test.
+ */
+public abstract class MockedServerTest {
+
+    protected MockWebServer server = new MockWebServer();
+    protected CloudantClient client;
+    protected Database db;
+
+    protected CloudantClientMockServerResource clientResource = new
+            CloudantClientMockServerResource(server);
+    protected DatabaseResource dbResource = new DatabaseResource(clientResource);
+    @Rule
+    public RuleChain chain = RuleChain.outerRule(server).around(clientResource).around(dbResource);
+
+    @Before
+    public void setup() throws Exception {
+        client = clientResource.get();
+        db = dbResource.get();
+    }
+}

--- a/cloudant-client/src/test/resources/query-tests/index_all_docs.js
+++ b/cloudant-client/src/test/resources/query-tests/index_all_docs.js
@@ -1,0 +1,10 @@
+{
+  "ddoc": null,
+  "name": "_all_docs",
+  "type": "special",
+  "def": {
+    "fields": [{
+      "_id": "asc"
+    }]
+  }
+}

--- a/cloudant-client/src/test/resources/query-tests/index_json_complex.js
+++ b/cloudant-client/src/test/resources/query-tests/index_json_complex.js
@@ -1,0 +1,17 @@
+{
+  "ddoc": "_design/testindexddoc",
+  "name": "complexjson",
+  "type": "json",
+  "def": {
+    "partial_filter_selector": {
+      "year": {
+        "$gt": 2010
+      }
+    },
+    "fields": [{
+      "Person_name": "asc"
+    }, {
+      "Movie_year": "desc"
+    }]
+  }
+}

--- a/cloudant-client/src/test/resources/query-tests/index_json_simple.js
+++ b/cloudant-client/src/test/resources/query-tests/index_json_simple.js
@@ -1,0 +1,11 @@
+{
+  "ddoc": "_design/testindexddoc",
+  "name": "simplejson",
+  "type": "json",
+  "def": {
+    "fields": [{
+      "Person_dob": "asc"
+    }],
+    "partial_filter_selector": {}
+  }
+}

--- a/cloudant-client/src/test/resources/query-tests/index_text_all.js
+++ b/cloudant-client/src/test/resources/query-tests/index_text_all.js
@@ -1,0 +1,14 @@
+{
+  "ddoc": "_design/testindexddoc",
+  "name": "textallfields",
+  "type": "text",
+  "def": {
+    "default_analyzer": "keyword",
+    "default_field": {
+      "enabled": false
+    },
+    "partial_filter_selector": {},
+    "fields": [],
+    "index_array_lengths": false
+  }
+}

--- a/cloudant-client/src/test/resources/query-tests/index_text_complex.js
+++ b/cloudant-client/src/test/resources/query-tests/index_text_complex.js
@@ -1,0 +1,32 @@
+{
+  "ddoc": "_design/testindexddoc",
+  "name": "complextext",
+  "type": "text",
+  "def": {
+    "default_analyzer": {
+      "name": "perfield",
+      "default": "english",
+      "fields": {
+        "spanish": "spanish",
+        "german": "german"
+      }
+    },
+    "default_field": {
+      "enabled": true,
+      "analyzer": "spanish"
+    },
+    "partial_filter_selector": {
+      "year": {
+        "$gt": 2010
+      }
+    },
+    "fields": [{
+      "Movie_name": "string"
+    }, {
+      "Movie_runtime": "number"
+    }, {
+      "Movie_wonaward": "boolean"
+    }],
+    "index_array_lengths": true
+  }
+}

--- a/cloudant-client/src/test/resources/query-tests/index_text_simple.js
+++ b/cloudant-client/src/test/resources/query-tests/index_text_simple.js
@@ -1,0 +1,14 @@
+{
+  "ddoc": "_design/testindexddoc",
+  "name": "simpletext",
+  "type": "text",
+  "def": {
+    "default_analyzer": "keyword",
+    "default_field": {},
+    "partial_filter_selector": {},
+    "fields": [{
+      "Movie_name": "string"
+    }],
+    "index_array_lengths": true
+  }
+}

--- a/cloudant-client/src/test/resources/query-tests/index_text_simple_selector.js
+++ b/cloudant-client/src/test/resources/query-tests/index_text_simple_selector.js
@@ -1,0 +1,18 @@
+{
+  "ddoc": "_design/testindexddoc",
+  "name": "simpleselector",
+  "type": "text",
+  "def": {
+    "default_analyzer": "keyword",
+    "default_field": {},
+    "selector": {
+      "year": {
+        "$gt": 2010
+      }
+    },
+    "fields": [{
+      "Movie_name": "string"
+    }],
+    "index_array_lengths": true
+  }
+}


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://github.com/cloudant/java-cloudant/blob/master/DCO1.1.txt)
- [x] You have added tests for any code changes
- [x] You have updated the [CHANGES.md](https://github.com/cloudant/java-cloudant/blob/master/CHANGES.md) 
- [x] You have completed the PR template below:

## What

Added new APIs for creating, deleting and listing indexes, including text index support.

## How

* Deprecated old index list and create methods.
* Added new `Builder`s for creating JSON and text index definitions.
    * `new JsonIndex.Builder()`
    * `new TextIndex.Builder()`
* Added common index types
    * `Index` and `Field` interfaces
    * `InternalIndex`, `NamedField` and `Sort`
* Added specialised models for text and JSON indexes
    * `JsonIndex`
    * `TextIndex`
* Added new `Indexes` class for listing multiple types.
* Added new `Database#deleteIndex(... String type)`, redirected old `deleteIndex` to be for
JSON index only to preserve old behaviour.
* Removed now unused internal code.
* Added `SelectorUtils` for parsing selector strings.
* Added custom serializers for field types and API asymmetry.
* Added `partial_filter_selector` support.

## Testing

* Updated existing `IndexTests` (server) for new API
* Added new `com.cloudant.client.api.query` test package with
    * IndexCreationTests (mocks)
    * IndexDeletionTests (mocks)
    * IndexListTests (mocks)
    * IndexLifecycleTests (server)

## Issues

Fixes #166 
