### PR TITLE
Ensured IllegalStateException thrown for view multibuilder

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 - [NEW] Add IAM cookie authentication method.
 - [IMPROVED] Clarified documentation for search indexes.
 - [FIXED] Connection leaks in some session renewal error scenarios.
+- [FIXED] IllegalStateException now correctly thrown for additional case of calling
+  `MultipleRequestBuilder#build()` before `add()` was called.
 - [UPGRADED] Optional OkHttp dependency to version 3.8.1.
 - [DEPRECATED] The `dbCopy` setter and getter on the `MapReduce` class.
 

--- a/cloudant-client/src/test/java/com/cloudant/tests/ViewsTest.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/ViewsTest.java
@@ -801,17 +801,97 @@ public class ViewsTest {
     }
 
     /**
+     * Validate that a request without parameters can be built after calling add().
+     */
+    @Test
+    public void multiRequestBuildSingle() {
+        ViewMultipleRequest<String, Object> multi = db.getViewRequestBuilder("example", "foo")
+                .newMultipleRequest(Key.Type.STRING, Object.class)
+                .add()
+                .build();
+    }
+
+    /**
+     * Validate that a multi request with parameters can be built after calling add().
+     */
+    @Test
+    public void multiRequestBuildParametersSingle() {
+        ViewMultipleRequest<String, Object> multi = db.getViewRequestBuilder("example", "foo")
+                .newMultipleRequest(Key.Type.STRING, Object.class)
+                .keys("key-1").add()
+                .build();
+    }
+
+    /**
+     * Validate that a multi request with parameters can be built after calling add().
+     */
+    @Test
+    public void multiRequestBuildParametersMulti() {
+        ViewMultipleRequest<String, Object> multi = db.getViewRequestBuilder("example", "foo")
+                .newMultipleRequest(Key.Type.STRING, Object.class)
+                .keys("key-1").add()
+                .keys("key-2").add()
+                .build();
+    }
+
+    /**
+     * Validate that a multi request with parameters can be built after calling add().
+     */
+    @Test
+    public void multiRequestBuildParametersFirst() {
+        ViewMultipleRequest<String, Object> multi = db.getViewRequestBuilder("example", "foo")
+                .newMultipleRequest(Key.Type.STRING, Object.class)
+                .keys("key-1").add()
+                .add()
+                .build();
+    }
+
+    /**
+     * Validate that a multi request with parameters can be built after calling add().
+     */
+    @Test
+    public void multiRequestBuildParametersSecond() {
+        ViewMultipleRequest<String, Object> multi = db.getViewRequestBuilder("example", "foo")
+                .newMultipleRequest(Key.Type.STRING, Object.class)
+                .add()
+                .keys("key-2").add()
+                .build();
+    }
+
+    /**
      * Validate that an IllegalStateException is thrown if an attempt is made to build a multi
-     * request without calling add() before build().
-     *
-     * @throws IOException
+     * request without calling add() before build() with two requests.
      */
     @Test(expected = IllegalStateException.class)
-    public void multiRequestBuildOnlyAfterAdd() throws IOException {
+    public void multiRequestBuildOnlyAfterAdd() {
         ViewMultipleRequest<String, Object> multi = db.getViewRequestBuilder("example", "foo")
                 .newMultipleRequest(Key.Type.STRING, Object.class)
                 .keys("key-1").add()
                 .keys("key-2").build();
+    }
+
+    /**
+     * Validate that an IllegalStateException is thrown if an attempt is made to build a multi
+     * request without calling add() before build() with a single request with parameters.
+     */
+    @Test(expected = IllegalStateException.class)
+    public void multiRequestBuildOnlyAfterAddSingle() {
+        ViewMultipleRequest<String, Object> multi = db.getViewRequestBuilder("example", "foo")
+                .newMultipleRequest(Key.Type.STRING, Object.class)
+                .keys("key-1")
+                .build();
+    }
+
+    /**
+     * Validate that an IllegalStateException is thrown if an attempt is made to build a multi
+     * request without calling add() before build() with a single request with no view request
+     * parameter calls.
+     */
+    @Test(expected = IllegalStateException.class)
+    public void multiRequestBuildOnlyAfterAddNoParams() {
+        ViewMultipleRequest<String, Object> multi = db.getViewRequestBuilder("example", "foo")
+                .newMultipleRequest(Key.Type.STRING, Object.class)
+                .build();
     }
 
     /**


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://github.com/cloudant/java-cloudant/blob/master/DCO1.1.txt)
- [x] You have added tests for any code changes
- [x] You have updated the [CHANGES.md](https://github.com/cloudant/java-cloudant/blob/master/CHANGES.md) 
- [x] You have completed the PR template below:

## What

Fixed `IllegalStateException` not thrown for `build()` before `add()` when no request parameters were used.

## How

Set `isBuildable=true` in instances after `add()`, but `false` on initial creation
and after adding parameters.

## Testing

Added new `com.cloudant.tests.ViewsTest#multiRequestBuildOnlyAfterAddNoParams` that is similar to `multiRequestBuildOnlyAfterAdd` but tries to build with no request parameters or add called first.
Added some additional permutations.

## Issues

Fixes #383 
