### PR TITLE
Updated docs.cloudant.com deprecated links throughout library

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 # 2.10.0 (Unreleased)
 - [NEW] Add IAM cookie authentication method.
+- [IMPROVED] Updated documentation by replacing deprecated Cloudant links with the latest Bluemix links.
 - [IMPROVED] Clarified documentation for search indexes.
 - [FIXED] Connection leaks in some session renewal error scenarios.
 - [FIXED] IllegalStateException now correctly thrown for additional case of calling

--- a/README.md
+++ b/README.md
@@ -164,8 +164,8 @@ do not overlook the package overviews.
 
 ## Related documentation
 * [API reference (javadoc)](http://www.javadoc.io/doc/com.cloudant/cloudant-client/)
-* [Cloudant docs](http://docs.cloudant.com/)
-* [Cloudant for developers](https://cloudant.com/for-developers/)
+* [Cloudant docs](https://console.bluemix.net/docs/services/Cloudant/cloudant.html#overview)
+* [Cloudant Learning Center](https://developer.ibm.com/clouddataservices/cloudant-learning-center/)
 
 ## Development
 
@@ -199,7 +199,7 @@ includes only open issues, but it may already have been closed.
 ## Caching, Encryption, and Compression
 
 Caching data at the client, when it is appropriate for the application, can often improve performance considerably. In some cases, it may also be desirable to encrypt or compress data at the client.
-There is no built-in support for caching, encryption or compression at the client in java-cloudant. Other Java libraries that are [not officially supported by Cloudant](https://docs.cloudant.com/libraries.html#-client-libraries), but can provide these capabilities are:
+There is no built-in support for caching, encryption or compression at the client in java-cloudant. Other Java libraries that are [not officially supported by Cloudant](https://console.bluemix.net/docs/services/Cloudant/libraries/index.html#client-libraries), but can provide these capabilities are:
 
 * [java-cloudant-cache](https://github.com/cloudant-labs/java-cloudant-cache) can be used to provide caching integrated with the API of java-cloudant.
 

--- a/cloudant-client/overview.html
+++ b/cloudant-client/overview.html
@@ -148,7 +148,8 @@ There is no need to add a head/title as that is provided by Javadoc.
     Using the {@link com.cloudant.client.api.ClientBuilder#username(String)} and
     {@link com.cloudant.client.api.ClientBuilder#password(String)}
     options uses
-    <a href="https://docs.cloudant.com/authentication.html#cookie-authentication" target="_blank">
+    <a href="https://console.bluemix.net/docs/services/Cloudant/api/authentication.html
+    #cookie-authentication" target="_blank">
         cookie authentication</a> for the CloudantClient connection. The supplied credentials are
     used to request a session with the server and the session is renewed automatically if the cookie
     expires. If the credentials become invalid then a new instance of a CloudantClient needs to be
@@ -276,8 +277,8 @@ There is no need to add a head/title as that is provided by Javadoc.
 
 <h2 id="Attachments">Attachments</h2>
 
-See the <a href="https://docs.cloudant.com/attachments.html" target="_blank">Cloudant documentation
-</a> for more information about attachments.
+See the <a href="https://console.bluemix.net/docs/services/Cloudant/api/attachments.html
+#attachments" target="_blank">Cloudant documentation</a> for more information about attachments.
 
 <h3 id="Standalone Attachments">Standalone Attachments</h3>
 
@@ -300,7 +301,8 @@ See the <a href="https://docs.cloudant.com/attachments.html" target="_blank">Clo
 <h3 id="Inline Attachments">Inline Attachments</h3>
 
 <P>
-    <a href="https://docs.cloudant.com/attachments.html#inline" target="_blank">Inline attachments
+    <a href="https://console.bluemix.net/docs/services/Cloudant/api/attachments.html#inline"
+       target="_blank">Inline attachments
     </a> enclose the attachment data, Base64 encoded, within the document body. The
     {@link com.cloudant.client.api.model.Attachment} class represents an inline attachment.
     Classes that extend {@link com.cloudant.client.api.model.Document} automatically inherit
@@ -331,7 +333,8 @@ See the <a href="https://docs.cloudant.com/attachments.html" target="_blank">Clo
     Design documents are used to define server side operations, including querying the database
     using map-reduce views, <a href="#Cloudant Search">Cloudant Search</a>, and
     <a href="#Cloudant Query">Cloudant Query</a>. The results can be retrieved by the client. It is
-    recommend to read the <a href="https://docs.cloudant.com/design_documents.html" target="_blank">
+    recommend to read the <a href="https://console.bluemix.net/docs/services/Cloudant/api/
+    design_documents.html#design-documents" target="_blank">
     Cloudant design document documentation</a> before working with design documents to gain an
     understanding of the available parameters and functions.
 </P>
@@ -380,8 +383,9 @@ See the <a href="https://docs.cloudant.com/attachments.html" target="_blank">Clo
 <h2 id="Using Views">Using Views</h2>
 
 For background information about views please refer to the
-<a href="https://docs.cloudant.com/creating_views.html" target="_blank">Cloudant views documentation
-</a>. Refer to the <a href="{@docroot}com/cloudant/client/api/views/package-summary.html">
+<a href="https://console.bluemix.net/docs/services/Cloudant/api/using_views.html#using-views"
+   target="_blank">Cloudant views documentation </a>. Refer to the
+<a href="{@docroot}com/cloudant/client/api/views/package-summary.html">
     com.cloudant.client.api.views package</a> for information about and examples of using this
 library to query a view.
 
@@ -389,8 +393,8 @@ library to query a view.
 
 <P>
     This feature interfaces with Cloudant's query functionality. See the
-    <a href="https://docs.cloudant.com/cloudant_query.html" target="_blank">Cloudant Query
-        documentation</a> for details.
+    <a href="https://console.bluemix.net/docs/services/Cloudant/api/cloudant_query.html#query"
+       target="_blank">Cloudant Query documentation</a> for details.
 </P>
 <UL>
     <LI>To see all the indexes in a database use:
@@ -411,7 +415,8 @@ library to query a view.
 
 <P>
     This feature interfaces with Cloudant's full text search functionality. See the
-    <a href="https://docs.cloudant.com/search.html" target="_blank">Cloudant Search documentation
+    <a href="https://console.bluemix.net/docs/services/Cloudant/api/search.html#search"
+       target="_blank">Cloudant Search documentation
     </a> for details. Searches are based on index functions in design documents.
 </P>
 

--- a/cloudant-client/src/main/java/com/cloudant/client/api/Changes.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/Changes.java
@@ -73,8 +73,8 @@ import java.net.URI;
  *
  * @author Ganesh K Choudhary
  * @see ChangesResult
- * @see <a target="_blank" href="https://docs.cloudant.com/database.html#get-changes">Databases -
- * get changes</a>
+ * @see <a href="https://console.bluemix.net/docs/services/Cloudant/api/database.html#get-changes"
+ * target="_blank">Databases - get changes</a>
  * @since 0.0.1
  */
 public class Changes {

--- a/cloudant-client/src/main/java/com/cloudant/client/api/CloudantClient.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/CloudantClient.java
@@ -171,7 +171,8 @@ public class CloudantClient {
      * Get the list of active tasks from the server.
      *
      * @return List of tasks
-     * @see <a target="_blank" href="https://docs.cloudant.com/active_tasks.html">Active tasks</a>
+     * @see <a href="https://console.bluemix.net/docs/services/Cloudant/api/active_tasks.html">
+     *     Active tasks</a>
      */
     public List<Task> getActiveTasks() {
         InputStream response = null;
@@ -188,8 +189,9 @@ public class CloudantClient {
      * Get the list of all nodes and the list of active nodes in the cluster.
      *
      * @return Membership object encapsulating lists of all nodes and the cluster nodes
-     * @see <a target="_blank"
-     * href="https://docs.cloudant.com/advanced.html#get-/_membership">_membership</a>
+     * @see <a
+     * href="https://console.bluemix.net/docs/services/Cloudant/api/advanced.html#-get-_membership-">
+     * _membership</a>
      */
     public Membership getMembership() {
         URI uri = new URIBase(getBaseUri()).path("_membership").build();
@@ -210,8 +212,9 @@ public class CloudantClient {
      * @param name   name of database to access
      * @param create flag indicating whether to create the database if it does not exist
      * @return Database object
-     * @see <a target="_blank" href="https://docs.cloudant.com/database.html#read">Databases -
-     * read</a>
+     * @see <a
+     * href="https://console.bluemix.net/docs/services/Cloudant/api/database.html"
+     * target="_blank">Databases</a>
      */
     public Database database(String name, boolean create) {
         return new Database(this, couchDbClient.database(name, create));
@@ -221,9 +224,9 @@ public class CloudantClient {
      * Request to delete the database with the specified name.
      *
      * @param dbName the database name
-     * @see <a target="_blank"
-     * href="https://docs.cloudant.com/database.html#deleting-a-database">Databases - delete
-     * </a>
+     * @see <a
+     * href="https://console.bluemix.net/docs/services/Cloudant/api/database.html#deleting-a-database">
+     * Databases - delete</a>
      */
     public void deleteDB(String dbName) {
         couchDbClient.deleteDB(dbName);
@@ -236,8 +239,9 @@ public class CloudantClient {
      * @throws com.cloudant.client.org.lightcouch.PreconditionFailedException if a database with
      *                                                                        the same name
      *                                                                        already exists
-     * @see <a target="_blank" href="https://docs.cloudant.com/database.html#create">Databases -
-     * create</a>
+     * @see <a target="_blank"
+     * href="https://console.bluemix.net/docs/services/Cloudant/api/database.html#create">
+     * Databases - create</a>
      */
     public void createDB(String dbName) {
         couchDbClient.createDB(dbName);
@@ -254,8 +258,9 @@ public class CloudantClient {
      * List all the databases on the server for the Cloudant account.
      *
      * @return List of the names of all the databases
-     * @see <a target="_blank" href="https://docs.cloudant.com/database.html#get-databases">
-     * Databases - get databases</a>
+     * @see <a target="_blank"
+     * href="https://console.bluemix.net/docs/services/Cloudant/api/database.html#get-a-list-of-all-databases-in-the-account">
+     * Databases - get list of databases</a>
      */
     public List<String> getAllDbs() {
         return couchDbClient.getAllDbs();
@@ -265,8 +270,9 @@ public class CloudantClient {
      * Get the reported server version from the welcome message metadata.
      *
      * @return Cloudant server version.
-     * @see <a target="_blank" href="https://docs.cloudant.com/advanced.html#get-/">Welcome
-     * message</a>
+     * @see <a target="_blank"
+     * href="https://console.bluemix.net/docs/services/Cloudant/api/advanced.html#-get-">
+     * GET meta information about the cluster</a>
      */
     public String serverVersion() {
         return couchDbClient.serverVersion();
@@ -278,9 +284,8 @@ public class CloudantClient {
      * @return Replication object for configuration and triggering
      * @see com.cloudant.client.api.Replication
      * @see <a target="_blank"
-     * href="https://docs.cloudant.com/replication.html#the-/_replicate-endpoint">
-     * Replication - _replicate
-     * </a>
+     * href="https://console.bluemix.net/docs/services/Cloudant/api/advanced_replication.html#the-_replicate-endpoint">
+     * Replication - the _replicate endpoint</a>
      */
     public com.cloudant.client.api.Replication replication() {
         Replication couchDbReplication = couchDbClient.replication();
@@ -295,9 +300,8 @@ public class CloudantClient {
      * @return Replicator object for interacting with the _replicator DB
      * @see com.cloudant.client.api.Replicator
      * @see <a target="_blank"
-     * href="https://docs.cloudant.com/replication.html#the-/_replicator-database">
-     * Replication - _replicator
-     * </a>
+     * href="https://console.bluemix.net/docs/services/Cloudant/api/replication.html#the-_replicator-database">
+     * Replication - the _replicator database</a>
      */
     public com.cloudant.client.api.Replicator replicator() {
         Replicator couchDbReplicator = couchDbClient.replicator();
@@ -347,7 +351,9 @@ public class CloudantClient {
      *
      * @param count the number of UUIDs
      * @return a List of UUID Strings
-     * @see <a target="_blank" href="https://docs.cloudant.com/advanced.html#get-/_uuids">_uuids</a>
+     * @see <a target="_blank"
+     * href="https://console.bluemix.net/docs/services/Cloudant/api/advanced.html#-get-_uuids-">
+     * _uuids</a>
      */
     public List<String> uuids(long count) {
         return couchDbClient.uuids(count);

--- a/cloudant-client/src/main/java/com/cloudant/client/api/Database.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/Database.java
@@ -120,7 +120,8 @@ public class Database {
      * Set permissions for a user/apiKey on this database.
      * <p>
      * Note this method is only applicable to databases that support the
-     * <a target="_blank" href="http://docs.cloudant.com/authorization.html">
+     * <a target="_blank"
+     * href="https://console.bluemix.net/docs/services/Cloudant/api/authorization.html#authorization">
      * Cloudant authorization API
      * </a> such as Cloudant DBaaS. For unsupported databases consider using the /db/_security
      * endpoint.
@@ -144,10 +145,12 @@ public class Database {
      * @throws UnsupportedOperationException if called on a database that does not provide the
      *                                       Cloudant authorization API
      * @see CloudantClient#generateApiKey()
-     * @see <a target="_blank" href="http://docs.cloudant.com/authorization.html#roles">Roles</a>
-     * @see <a target="_blank"
-     * href="http://docs.cloudant.com/authorization.html#modifying-permissions">Modifying
-     * permissions</a>
+     * @see <a
+     * href="https://console.bluemix.net/docs/services/Cloudant/api/authorization.html#roles"
+     * target="_blank">Roles</a>
+     * @see <a
+     * href="https://console.bluemix.net/docs/services/Cloudant/api/authorization.html#modifying-permissions"
+     * target="_blank">Modifying permissions</a>
      */
     public void setPermissions(String userNameorApikey, EnumSet<Permissions> permissions) {
         assertNotEmpty(userNameorApikey, "userNameorApikey");
@@ -202,7 +205,8 @@ public class Database {
      * Returns the Permissions of this database.
      * <p>
      * Note this method is only applicable to databases that support the
-     * <a target="_blank" href="http://docs.cloudant.com/authorization.html">
+     * <a target="_blank"
+     * href="https://console.bluemix.net/docs/services/Cloudant/api/authorization.html#authorization">
      * Cloudant authorization API
      * </a> such as Cloudant DBaaS. For unsupported databases consider using the /db/_security
      * endpoint.
@@ -211,10 +215,12 @@ public class Database {
      * @return the map of userNames to their Permissions
      * @throws UnsupportedOperationException if called on a database that does not provide the
      *                                       Cloudant authorization API
-     * @see <a target="_blank" href="http://docs.cloudant.com/authorization.html#roles">Roles</a>
-     * @see <a target="_blank"
-     * href="http://docs.cloudant.com/authorization.html#viewing-permissions">Viewing
-     * permissions</a>
+     * @see <a
+     * href="https://console.bluemix.net/docs/services/Cloudant/api/authorization.html#roles"
+     * target="_blank">Roles</a>
+     * @see <a
+     * href="https://console.bluemix.net/docs/services/Cloudant/api/authorization.html#viewing-permissions"
+     * target="_blank">Viewing permissions</a>
      */
     public Map<String, EnumSet<Permissions>> getPermissions() {
         JsonObject perms = getPermissionsObject();
@@ -226,8 +232,9 @@ public class Database {
      * Get info about the shards in the database.
      *
      * @return List of shards
-     * @see <a target="_blank"
-     * href="https://docs.cloudant.com/advanced.html#get-/$db/_shards">_shards</a>
+     * @see <a
+     * href="https://console.bluemix.net/docs/services/Cloudant/api/advanced.html#-get-database-_shards-"
+     * target="_blank">_shards</a>
      */
     public List<Shard> getShards() {
         InputStream response = null;
@@ -245,8 +252,9 @@ public class Database {
      *
      * @param docId document ID
      * @return Shard info
-     * @see <a target="_blank"
-     * href="https://docs.cloudant.com/advanced.html#get-/$db/_shards">_shards</a>
+     * @see <a
+     * href="https://console.bluemix.net/docs/services/Cloudant/api/advanced.html#-get-database-_shards-"
+     * target="_blank">_shards</a>
      */
     public Shard getShard(String docId) {
         assertNotEmpty(docId, "docId");
@@ -293,9 +301,9 @@ public class Database {
      *
      * @param indexDefinition String representation of the index definition JSON
      * @see #createIndex(String, String, String, IndexField[])
-     * @see <a target="_blank"
-     * href="http://docs.cloudant.com/api/cloudant-query.html#creating-a-new-index">
-     * index definition</a>
+     * @see <a
+     * href="https://console.bluemix.net/docs/services/Cloudant/api/cloudant_query.html#creating-an-index"
+     * target="_blank">index definition</a>
      */
     public void createIndex(String indexDefinition) {
         assertNotEmpty(indexDefinition, "indexDefinition");
@@ -325,9 +333,9 @@ public class Database {
      * @param <T>          the type of the Java object to be returned
      * @return List of classOfT objects
      * @see #findByIndex(String, Class, FindByIndexOptions)
-     * @see <a target="_blank"
-     * href="http://docs.cloudant.com/api/cloudant-query.html#cloudant-query-selectors">
-     * selector syntax</a>
+     * @see <a
+     * href="https://console.bluemix.net/docs/services/Cloudant/api/cloudant_query.html#selector-syntax"
+     * target="_blank">selector syntax</a>
      */
     public <T> List<T> findByIndex(String selectorJson, Class<T> classOfT) {
         return findByIndex(selectorJson, classOfT, new FindByIndexOptions());
@@ -358,9 +366,9 @@ public class Database {
      * @param classOfT     The class of Java objects to be returned
      * @param <T>          the type of the Java object to be returned
      * @return List of classOfT objects
-     * @see <a target="_blank"
-     * href="http://docs.cloudant.com/api/cloudant-query.html#cloudant-query-selectors">
-     * selector syntax</a>
+     * @see <a
+     * href="https://console.bluemix.net/docs/services/Cloudant/api/cloudant_query.html#selector-syntax"
+     * target="_blank">selector syntax</a>
      */
     public <T> List<T> findByIndex(String selectorJson, Class<T> classOfT, FindByIndexOptions
             options) {
@@ -454,7 +462,9 @@ public class Database {
      *
      * @param searchIndexId the design document with the name of the index to search
      * @return Search object for searching the index
-     * @see <a target="_blank" href="https://docs.cloudant.com/search.html">Search</a>
+     * @see <a
+     * href="https://console.bluemix.net/docs/services/Cloudant/api/search.html#search"
+     * target="_blank">Search</a>
      */
     public Search search(String searchIndexId) {
         return new Search(client, this, searchIndexId);
@@ -475,8 +485,9 @@ public class Database {
      * @param viewName  the view name
      * @return a builder to build view requests for the specified design document and view of
      * this database
-     * @see <a target="_blank"
-     * href="https://docs.cloudant.com/creating_views.html#using-views">Using views</a>
+     * @see <a
+     * href="https://console.bluemix.net/docs/services/Cloudant/api/using_views.html#using-views"
+     * target="_blank">Using views</a>
      */
     public ViewRequestBuilder getViewRequestBuilder(String designDoc, String viewName) {
         return new ViewRequestBuilder(client, this, designDoc, viewName);
@@ -513,9 +524,9 @@ public class Database {
      *
      * @return a Changes object for using the changes feed
      * @see com.cloudant.client.api.Changes
-     * @see <a target="_blank"
-     * href="https://docs.cloudant.com/database.html#get-changes">Databases - get
-     * changes</a>
+     * @see <a
+     * href="https://console.bluemix.net/docs/services/Cloudant/api/database.html#get-changes"
+     * target="_blank">Databases - get changes</a>
      */
     public Changes changes() {
         return new Changes(client, this);
@@ -531,8 +542,9 @@ public class Database {
      * @return an object of type T
      * @throws NoDocumentException if the document is not found in the database
      * @see #find(Class, String, String)
-     * @see <a target="_blank" href="https://docs.cloudant.com/document.html#read">Documents -
-     * read</a>
+     * @see <a
+     * href="https://console.bluemix.net/docs/services/Cloudant/api/document.html#read"
+     * target="_blank">Documents - read</a>
      */
     public <T> T find(Class<T> classType, String id) {
         return db.find(classType, id);
@@ -557,8 +569,9 @@ public class Database {
      * @return An object of type T
      * @throws NoDocumentException if the document is not found in the database.
      * @see Params
-     * @see <a target="_blank" href="https://docs.cloudant.com/document.html#read">Documents -
-     * read</a>
+     * @see <a
+     * href="https://console.bluemix.net/docs/services/Cloudant/api/document.html#read"
+     * target="_blank">Documents - read</a>
      */
     public <T> T find(Class<T> classType, String id, Params params) {
         assertNotEmpty(params, "params");
@@ -581,8 +594,9 @@ public class Database {
      * @param rev       the document _rev field
      * @return an object of type T
      * @throws NoDocumentException if the document is not found in the database.
-     * @see <a target="_blank" href="https://docs.cloudant.com/document.html#read">Documents -
-     * read</a>
+     * @see <a
+     * href="https://console.bluemix.net/docs/services/Cloudant/api/document.html#read"
+     * target="_blank">Documents - read</a>
      */
     public <T> T find(Class<T> classType, String id, String rev) {
         return db.find(classType, id, rev);
@@ -646,8 +660,9 @@ public class Database {
      * @return the result as {@link InputStream}
      * @throws NoDocumentException if the document is not found in the database at the specified
      *                             revision
-     * @see <a target="_blank" href="https://docs.cloudant.com/document.html#read">Documents -
-     * read</a>
+     * @see <a
+     * href="https://console.bluemix.net/docs/services/Cloudant/api/document.html#read"
+     * target="_blank">Documents - read</a>
      */
     public InputStream find(String id, String rev) {
         return db.find(id, rev);
@@ -733,9 +748,9 @@ public class Database {
      * @return {@link com.cloudant.client.api.model.Response}
      * @throws DocumentConflictException If a conflict is detected during the save.
      * @see Database#save(Object)
-     * @see <a target="_blank"
-     * href="https://docs.cloudant.com/document.html#quorum---writing-and-reading-data">
-     * Documents - quorum</a>
+     * @see <a
+     * href="https://console.bluemix.net/docs/services/Cloudant/api/document.html#quorum-writing-and-reading-data"
+     * target="_blank">Documents - quorum</a>
      */
     public com.cloudant.client.api.model.Response save(Object object, int writeQuorum) {
         Response couchDbResponse = client.couchDbClient.put(getDBUri(), object, true, writeQuorum);
@@ -772,8 +787,9 @@ public class Database {
      *
      * @param object The object to save
      * @return {@link com.cloudant.client.api.model.Response}
-     * @see <a target="_blank"
-     * href="https://docs.cloudant.com/document.html#documentCreate">Documents - create</a>
+     * @see <a
+     * href="https://console.bluemix.net/docs/services/Cloudant/api/document.html#create"
+     * target="_blank">Documents - create</a>
      */
     public com.cloudant.client.api.model.Response post(Object object) {
         Response couchDbResponse = db.post(object);
@@ -790,9 +806,9 @@ public class Database {
      * @param writeQuorum the write Quorum
      * @return {@link com.cloudant.client.api.model.Response}
      * @see Database#post(Object)
-     * @see <a target="_blank"
-     * href="https://docs.cloudant.com/document.html#quorum---writing-and-reading-data">
-     * Documents - quorum</a>
+     * @see <a
+     * href="https://console.bluemix.net/docs/services/Cloudant/api/document.html#quorum-writing-and-reading-data"
+     * target="_blank">Documents - quorum</a>
      */
     public com.cloudant.client.api.model.Response post(Object object, int writeQuorum) {
         assertNotEmpty(object, "object");
@@ -841,8 +857,9 @@ public class Database {
      * @param object the object to update
      * @return {@link com.cloudant.client.api.model.Response}
      * @throws DocumentConflictException if a conflict is detected during the update.
-     * @see <a target="_blank" href="https://docs.cloudant.com/document.html#update">Documents -
-     * update</a>
+     * @see <a
+     * href="https://console.bluemix.net/docs/services/Cloudant/api/document.html#update"
+     * target="_blank">Documents - update</a>
      */
     public com.cloudant.client.api.model.Response update(Object object) {
         Response couchDbResponse = db.update(object);
@@ -860,9 +877,9 @@ public class Database {
      * @return {@link com.cloudant.client.api.model.Response}
      * @throws DocumentConflictException if a conflict is detected during the update.
      * @see Database#update(Object)
-     * @see <a target="_blank"
-     * href="https://docs.cloudant.com/document.html#quorum---writing-and-reading-data">
-     * Documents - quorum</a>
+     * @see <a
+     * href="https://console.bluemix.net/docs/services/Cloudant/api/document.html#quorum-writing-and-reading-data"
+     * target="_blank">Documents - quorum</a>
      */
     public com.cloudant.client.api.model.Response update(Object object, int writeQuorum) {
         Response couchDbResponse = client.couchDbClient.put(getDBUri(), object, false, writeQuorum);
@@ -887,8 +904,9 @@ public class Database {
      * @param object the document to remove as an object
      * @return {@link com.cloudant.client.api.model.Response}
      * @throws NoDocumentException If the document is not found in the database.
-     * @see <a target="_blank" href="https://docs.cloudant.com/document.html#delete">Documents -
-     * delete</a>
+     * @see <a
+     * href="https://console.bluemix.net/docs/services/Cloudant/api/document.html#delete"
+     * target="_blank">Documents - delete</a>
      */
     public com.cloudant.client.api.model.Response remove(Object object) {
         Response couchDbResponse = db.remove(object);
@@ -911,8 +929,9 @@ public class Database {
      * @param rev the document _rev field
      * @return {@link com.cloudant.client.api.model.Response}
      * @throws NoDocumentException If the document is not found in the database.
-     * @see <a target="_blank" href="https://docs.cloudant.com/document.html#delete">Documents -
-     * delete</a>
+     * @see <a
+     * href="https://console.bluemix.net/docs/services/Cloudant/api/document.html#delete"
+     * target="_blank">Documents - delete</a>
      */
     public com.cloudant.client.api.model.Response remove(String id, String rev) {
         Response couchDbResponse = db.remove(id, rev);
@@ -939,8 +958,9 @@ public class Database {
      *
      * @param objects the {@link List} of objects
      * @return {@code List<Response>} one per object
-     * @see <a target="_blank" href="https://docs.cloudant.com/document.html#bulk-operations">
-     * Documents - bulk operations</a>
+     * @see <a
+     * href="https://console.bluemix.net/docs/services/Cloudant/api/document.html#bulk-operations"
+     * target="_blank">Documents - bulk operations</a>
      */
     public List<com.cloudant.client.api.model.Response> bulk(List<?> objects) {
         List<Response> couchDbResponseList = db.bulk(objects, false);
@@ -998,7 +1018,9 @@ public class Database {
      * @param name        The attachment name.
      * @param contentType The attachment "Content-Type".
      * @return {@link com.cloudant.client.api.model.Response}
-     * @see <a target="_blank" href="https://docs.cloudant.com/attachments.html">Attachments</a>
+     * @see <a
+     * href="https://console.bluemix.net/docs/services/Cloudant/api/attachments.html#attachments"
+     * target="_blank">Attachments</a>
      */
     public com.cloudant.client.api.model.Response saveAttachment(InputStream in, String name,
                                                                  String contentType) {
@@ -1036,7 +1058,9 @@ public class Database {
      *                    when saving to a new document.
      * @return {@link Response}
      * @throws DocumentConflictException if the attachment cannot be saved because of a conflict
-     * @see <a target="_blank" href="https://docs.cloudant.com/attachments.html">Attachments</a>
+     * @see <a
+     * href="https://console.bluemix.net/docs/services/Cloudant/api/attachments.html#attachments"
+     * target="_blank">Attachments</a>
      */
     public com.cloudant.client.api.model.Response saveAttachment(InputStream in, String name,
                                                                  String contentType, String
@@ -1066,8 +1090,9 @@ public class Database {
      * @return {@link com.cloudant.client.api.model.Response}
      * @throws NoDocumentException If the document is not found in the database.
      * @throws DocumentConflictException If a conflict is detected during the removal.
-     * @see <a target="_blank" href="https://docs.cloudant.com/attachments.html#delete">Documents -
-     * delete</a>
+     * @see <a
+     * href="https://console.bluemix.net/docs/services/Cloudant/api/attachments.html#delete"
+     * target="_blank">Documents - delete</a>
      */
     public com.cloudant.client.api.model.Response removeAttachment(Object object, String attachmentName) {
         Response couchDbResponse = db.removeAttachment(object, attachmentName);
@@ -1092,8 +1117,9 @@ public class Database {
      * @return {@link com.cloudant.client.api.model.Response}
      * @throws NoDocumentException If the document is not found in the database.
      * @throws DocumentConflictException if the attachment cannot be removed because of a conflict
-     * @see <a target="_blank" href="https://docs.cloudant.com/attachments.html#delete">Documents -
-     * delete</a>
+     * @see <a
+     * href="https://console.bluemix.net/docs/services/Cloudant/api/attachments.html#delete"
+     * target="_blank">Documents - delete</a>
      */
     public com.cloudant.client.api.model.Response removeAttachment(String id, String rev, String attachmentName) {
         Response couchDbResponse = db.removeAttachment(id, rev, attachmentName);
@@ -1127,9 +1153,9 @@ public class Database {
      *                         If no id is provided, then a document will be created.
      * @param params           The query parameters as {@link Params}.
      * @return The output of the request.
-     * @see <a target="_blank"
-     * href="https://docs.cloudant.com/design_documents.html#update-handlers">
-     * Design documents - update handlers</a>
+     * @see <a
+     * href="https://console.bluemix.net/docs/services/Cloudant/api/design_documents.html#update-handlers"
+     * target="_blank">Design documents - update handlers</a>
      */
     public String invokeUpdateHandler(String updateHandlerUri, String docId,
                                       Params params) {
@@ -1148,8 +1174,9 @@ public class Database {
      * Get information about this database.
      *
      * @return DbInfo encapsulating the database info
-     * @see <a target="_blank" href="https://docs.cloudant.com/database.html#read">Databases -
-     * read</a>
+     * @see <a
+     * href="https://console.bluemix.net/docs/services/Cloudant/api/database.html#getting-database-details"
+     * target="_blank">Databases - read</a>
      */
     public DbInfo info() {
         return client.couchDbClient.get(new DatabaseURIHelper(db.getDBUri()).getDatabaseUri(),

--- a/cloudant-client/src/main/java/com/cloudant/client/api/Search.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/Search.java
@@ -279,8 +279,9 @@ public class Search {
      *
      * @param sortJson JSON string specifying the sort order
      * @return this for additional parameter setting or to query
-     * @see <a target="_blank" href="http://docs.cloudant.com/api/search.html">sort query
-     * parameter format</a>
+     * @see <a target="_blank"
+     * href="https://console.bluemix.net/docs/services/Cloudant/api/search.html#query-syntax">
+     * Search query syntax</a>
      */
     public Search sort(String sortJson) {
         assertNotEmpty(sortJson, "sort");
@@ -322,8 +323,9 @@ public class Search {
      *
      * @param groupsortJson JSON string specifying the group sort
      * @return this for additional parameter setting or to query
-     * @see <a target="_blank" href="http://docs.cloudant.com/api/search.html">sort query
-     * parameter format</a>
+     * @see <a target="_blank"
+     * href="https://console.bluemix.net/docs/services/Cloudant/api/search.html#query-syntax">
+     * Search query syntax</a>
      */
     public Search groupSort(String groupsortJson) {
         assertNotEmpty(groupsortJson, "groupsortJson");
@@ -336,8 +338,9 @@ public class Search {
      *
      * @param rangesJson JSON string specifying the ranges
      * @return this for additional parameter setting or to query
-     * @see <a target="_blank" href="http://docs.cloudant.com/api/search.html">ranges query
-     * argument format</a>
+     * @see <a target="_blank"
+     * href="https://console.bluemix.net/docs/services/Cloudant/api/search.html#query-syntax">
+     * Search query syntax</a>
      */
     public Search ranges(String rangesJson) {
         assertNotEmpty(rangesJson, "rangesJson");
@@ -366,8 +369,9 @@ public class Search {
      * @param fieldName  the name of the field
      * @param fieldValue the value of the field
      * @return this for additional parameter setting or to query
-     * @see <a target="_blank" href="https://docs.cloudant.com/search.html#faceting">drilldown
-     * query parameter</a>
+     * @see <a target="_blank"
+     * href="https://console.bluemix.net/docs/services/Cloudant/api/search.html#faceting">
+     * drilldown query parameter</a>
      * @deprecated Use {@link #drillDown(String, String...)}
      */
     @Deprecated
@@ -387,8 +391,8 @@ public class Search {
      * @param fieldName   the name of the field
      * @param fieldValues field values to add
      * @return this for additional parameter setting or to query
-     * @see <a target="_blank" href="https://docs.cloudant.com/search.html#faceting">drilldown
-     * query parameter</a>
+     * @see <a href="https://console.bluemix.net/docs/services/Cloudant/api/search.html#faceting"
+     * target="_blank">drilldown query parameter</a>
      */
     public Search drillDown(String fieldName, String... fieldValues) {
         assertNotEmpty(fieldName, "fieldName");

--- a/cloudant-client/src/main/java/com/cloudant/client/api/model/DesignDocument.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/model/DesignDocument.java
@@ -99,8 +99,9 @@ public class DesignDocument extends com.cloudant.client.org.lightcouch.Document 
      *
      * @return a map of view name to {@link MapReduce}
      * from the view
-     * @see <a target="_blank"
-     * href="https://docs.cloudant.com/design_documents.html#views">Views</a>
+     * @see <a
+     * href="https://console.bluemix.net/docs/services/Cloudant/api/design_documents.html#views"
+     * target="_blank">Views</a>
      */
     public Map<String, MapReduce> getViews() {
         return views;
@@ -111,9 +112,9 @@ public class DesignDocument extends com.cloudant.client.org.lightcouch.Document 
      * validate_doc_update} property.
      *
      * @return string of validate_doc_update function
-     * @see <a target="_blank"
-     * href="https://docs.cloudant.com/design_documents.html#update-validators">Update validators
-     * </a>
+     * @see <a
+     * href="https://console.bluemix.net/docs/services/Cloudant/api/design_documents.html#update-validators"
+     * target="_blank">Update validators</a>
      */
     public String getValidateDocUpdate() {
         return validateDocUpdate;
@@ -123,8 +124,9 @@ public class DesignDocument extends com.cloudant.client.org.lightcouch.Document 
      * Get the array of URL rewriting rules set in the design document's {@code rewrites} property.
      *
      * @return array of JSON objects each representing a rewrite rule
-     * @see <a target="_blank"
-     * href="https://docs.cloudant.com/design_documents.html#rewrite-rules">Rewrite rules</a>
+     * @see <a
+     * href="https://console.bluemix.net/docs/services/Cloudant/api/design_documents.html#rewrite-rules"
+     * target="_blank">Rewrite rules</a>
      */
     public JsonArray getRewrites() {
         return rewrites;
@@ -141,8 +143,9 @@ public class DesignDocument extends com.cloudant.client.org.lightcouch.Document 
      * Get a JSON object containing all the indexes defined in the design document.
      *
      * @return the JSON object stored in the design document's {@code indexes} property
-     * @see <a target="_blank"
-     * href="https://docs.cloudant.com/design_documents.html#indexes">Indexes</a>
+     * @see <a
+     * href="https://console.bluemix.net/docs/services/Cloudant/api/design_documents.html#indexes"
+     * target="_blank">Indexes</a>
      */
     public JsonObject getIndexes() {
         return indexes;
@@ -152,8 +155,9 @@ public class DesignDocument extends com.cloudant.client.org.lightcouch.Document 
      * Get the changes feed filter functions defined in this design document.
      *
      * @return map of filter name to function string
-     * @see <a target="_blank"
-     * href="https://docs.cloudant.com/design_documents.html#filter-functions">Filter functions</a>
+     * @see <a
+     * href="https://console.bluemix.net/docs/services/Cloudant/api/design_documents.html#filter-functions"
+     * target="_blank">Filter functions</a>
      */
     public Map<String, String> getFilters() {
         return filters;
@@ -163,8 +167,9 @@ public class DesignDocument extends com.cloudant.client.org.lightcouch.Document 
      * Get the show functions defined in this design document.
      *
      * @return map of show function name to function string
-     * @see <a target="_blank"
-     * href="https://docs.cloudant.com/design_documents.html#show-functions">Show functions</a>
+     * @see <a
+     * href="https://console.bluemix.net/docs/services/Cloudant/api/design_documents.html#show-functions"
+     * target="_blank">Show functions</a>
      */
     public Map<String, String> getShows() {
         return shows;
@@ -174,8 +179,9 @@ public class DesignDocument extends com.cloudant.client.org.lightcouch.Document 
      * Get the list functions defined in this design document.
      *
      * @return map of list function name to function string
-     * @see <a target="_blank"
-     * href="https://docs.cloudant.com/design_documents.html#list-functions">List functions</a>
+     * @see <a
+     * href="https://console.bluemix.net/docs/services/Cloudant/api/design_documents.html#list-functions"
+     * target="_blank">List functions</a>
      */
     public Map<String, String> getLists() {
         return lists;
@@ -185,8 +191,9 @@ public class DesignDocument extends com.cloudant.client.org.lightcouch.Document 
      * Get the update handlers defined in this design document.
      *
      * @return map of update handler name to function string
-     * @see <a target="_blank"
-     * href="https://docs.cloudant.com/design_documents.html#update-handlers">Update handlers</a>
+     * @see <a
+     * href="https://console.bluemix.net/docs/services/Cloudant/api/design_documents.html#update-handlers"
+     * target="_blank">Update handlers</a>
      */
     public Map<String, String> getUpdates() {
         return updates;
@@ -205,8 +212,9 @@ public class DesignDocument extends com.cloudant.client.org.lightcouch.Document 
      * Set the views defined in this design document's view property.
      *
      * @param views map of view name to MapReduce class
-     * @see <a target="_blank"
-     * href="https://docs.cloudant.com/design_documents.html#views">Views</a>
+     * @see <a
+     * href="https://console.bluemix.net/docs/services/Cloudant/api/design_documents.html#views"
+     * target="_blank">Views</a>
      */
     public void setViews(Map<String, MapReduce> views) {
         this.views = views;
@@ -216,9 +224,9 @@ public class DesignDocument extends com.cloudant.client.org.lightcouch.Document 
      * Set the javascript function for the design document's {@code validate_doc_update} property.
      *
      * @param validateDocUpdate string defining validate_doc_update function
-     * @see <a target="_blank"
-     * href="https://docs.cloudant.com/design_documents.html#update-validators">Update validators
-     * </a>
+     * @see <a
+     * href="https://console.bluemix.net/docs/services/Cloudant/api/design_documents.html#update-validators"
+     * target="_blank">Update validators</a>
      */
     public void setValidateDocUpdate(String validateDocUpdate) {
         this.validateDocUpdate = validateDocUpdate;
@@ -228,8 +236,9 @@ public class DesignDocument extends com.cloudant.client.org.lightcouch.Document 
      * Set the array of URL rewriting rules set in the design document's {@code rewrites} property.
      *
      * @param rewrites array of JsonObjects each representing a rewrite rule
-     * @see <a target="_blank"
-     * href="https://docs.cloudant.com/design_documents.html#rewrite-rules">Rewrite rules</a>
+     * @see <a
+     * href="https://console.bluemix.net/docs/services/Cloudant/api/design_documents.html#rewrite-rules"
+     * target="_blank">Rewrite rules</a>
      */
     public void setRewrites(JsonArray rewrites) {
         this.rewrites = rewrites;
@@ -246,8 +255,9 @@ public class DesignDocument extends com.cloudant.client.org.lightcouch.Document 
      * Set a JSON object defining the indexes of this design document.
      *
      * @param indexes JsonObject defining the indexes
-     * @see <a target="_blank"
-     * href="https://docs.cloudant.com/design_documents.html#indexes">Indexes</a>
+     * @see <a
+     * href="https://console.bluemix.net/docs/services/Cloudant/api/design_documents.html#indexes"
+     * target="_blank">Indexes</a>
      */
     public void setIndexes(JsonObject indexes) {
         this.indexes = indexes;
@@ -257,8 +267,9 @@ public class DesignDocument extends com.cloudant.client.org.lightcouch.Document 
      * Define the changes feed filter functions set in this design document.
      *
      * @param filters map of filter name to function string
-     * @see <a target="_blank"
-     * href="https://docs.cloudant.com/design_documents.html#filter-functions">Filter functions</a>
+     * @see <a
+     * href="https://console.bluemix.net/docs/services/Cloudant/api/design_documents.html#filter-functions"
+     * target="_blank">Filter functions</a>
      */
     public void setFilters(Map<String, String> filters) {
         this.filters = filters;
@@ -268,8 +279,9 @@ public class DesignDocument extends com.cloudant.client.org.lightcouch.Document 
      * Set the show functions defined in this design document.
      *
      * @param shows map of show function name to function string
-     * @see <a target="_blank"
-     * href="https://docs.cloudant.com/design_documents.html#show-functions">Show functions</a>
+     * @see <a
+     * href="https://console.bluemix.net/docs/services/Cloudant/api/design_documents.html#show-functions"
+     * target="_blank">Show functions</a>
      */
     public void setShows(Map<String, String> shows) {
         this.shows = shows;
@@ -279,8 +291,9 @@ public class DesignDocument extends com.cloudant.client.org.lightcouch.Document 
      * Set the list functions defined in this design document.
      *
      * @param lists map of list function name to function string
-     * @see <a target="_blank"
-     * href="https://docs.cloudant.com/design_documents.html#list-functions">List functions</a>
+     * @see <a
+     * href="https://console.bluemix.net/docs/services/Cloudant/api/design_documents.html#list-functions"
+     * target="_blank">List functions</a>
      */
     public void setLists(Map<String, String> lists) {
         this.lists = lists;
@@ -290,8 +303,9 @@ public class DesignDocument extends com.cloudant.client.org.lightcouch.Document 
      * Set the update handlers defined in this design document.
      *
      * @param updates map of update handler name to function string
-     * @see <a target="_blank"
-     * href="https://docs.cloudant.com/design_documents.html#update-handlers">Update handlers</a>
+     * @see <a
+     * href="https://console.bluemix.net/docs/services/Cloudant/api/design_documents.html#update-handlers"
+     * target="_blank">Update handlers</a>
      */
     public void setUpdates(Map<String, String> updates) {
         this.updates = updates;

--- a/cloudant-client/src/main/java/com/cloudant/client/api/model/IndexField.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/model/IndexField.java
@@ -57,9 +57,10 @@ public class IndexField {
 
     /**
      * Encapsulates a Cloudant Sort Syntax for a json field. Used to specify
-     * an element of the 'index.fields' array (POST db/_index) and 'sort' array (db/_find) @see <a
-     * href = "http://docs.cloudant.com/api/cloudant-query.html#cloudant-query-sort-syntax"> sort
-     * Syntax</a>
+     * an element of the 'index.fields' array (POST db/_index) and 'sort' array (db/_find)
+     * @see <a
+     * href="https://console.bluemix.net/docs/services/Cloudant/api/cloudant_query.html#sort-syntax">
+     * Sort Syntax</a>
      *
      * @param name  can be any field (dotted notation is available for sub-document fields)
      * @param order can be "asc" or "desc"

--- a/cloudant-client/src/main/java/com/cloudant/client/api/views/Key.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/views/Key.java
@@ -79,7 +79,7 @@ public class Key {
         /**
          * Type constant for
          * <a target="_blank"
-         * href="https://docs.cloudant.com/creating_views.html#map-function-examples">
+         * href="https://console.bluemix.net/docs/services/Cloudant/api/creating_views.html#map-function-examples">
          * complex keys.</a>
          *
          * @since 2.0.0

--- a/cloudant-client/src/main/java/com/cloudant/client/api/views/SettableViewParameters.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/views/SettableViewParameters.java
@@ -18,7 +18,7 @@ package com.cloudant.client.api.views;
  * Describes the parameters that can be set when building view requests.
  *
  * <P>
- * <a target="_blank" href="https://docs.cloudant.com/creating_views.html#using-views">
+ * <a target="_blank" href="https://console.bluemix.net/docs/services/Cloudant/api/using_views.html#using-views">
  * Cloudant API reference
  * </a>
  * </P>
@@ -96,7 +96,7 @@ public interface SettableViewParameters {
          * <P>
          * Note that using include_docs=true might have
          * <a target="_blank"
-         * href="https://docs.cloudant.com/creating_views.html#multi-document-fetching">
+         * href="https://console.bluemix.net/docs/services/Cloudant/api/using_views.html#multi-document-fetching">
          * performance implications.</a>
          * </P>
          *

--- a/cloudant-client/src/main/java/com/cloudant/client/api/views/ViewMultipleRequest.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/views/ViewMultipleRequest.java
@@ -57,10 +57,8 @@ import java.util.List;
  *
  * }
  * </pre>
- * <a target="_blank"
- * href="https://docs.cloudant.com/creating_views.html#sending-several-queries-to-a-view">
- * Cloudant API reference
- * </a>
+ * <a href="https://console.bluemix.net/docs/services/Cloudant/api/using_views.html#sending-several-queries-to-a-view"
+ * target="_blank">Cloudant API reference</a>
  *
  * @param <K> the type of key emitted by the view, fixed by the
  *            {@link com.cloudant.client.api.views.Key.Type} supplied to the

--- a/cloudant-client/src/main/java/com/cloudant/client/api/views/package-info.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/views/package-info.java
@@ -14,7 +14,9 @@
 
 /**
  * This package provides access to the
- * <a target="_blank" href="https://docs.cloudant.com/creating_views.html">view API</a>.
+ * <a target="_blank"
+ * href="https://console.bluemix.net/docs/services/Cloudant/api/creating_views.html#views-mapreduce-">
+ * view API</a>.
  *
  * <H1>Overview</H1>
  * <P>

--- a/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/Replication.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/Replication.java
@@ -60,10 +60,8 @@ import java.util.logging.Logger;
  * @author Ahmed Yehia
  * @see ReplicationResult
  * @see com.cloudant.client.api.model.ReplicationResult.ReplicationHistory
- * @see <a target="_blank"
- * href="https://docs.cloudant.com/replication.html#the-/_replicate-endpoint">
- * Replication - _replicate
- * </a>
+ * @see <a href="https://console.bluemix.net/docs/services/Cloudant/api/advanced_replication.html#the-_replicate-endpoint"
+ * target="_blank">Replication - the _replicate endpoint</a>
  * @since 0.0.2
  */
 public class Replication {

--- a/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/Replicator.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/Replicator.java
@@ -79,10 +79,8 @@ import java.util.Map;
  *
  * @author Ahmed Yehia
  * @see ReplicatorDocument
- * @see <a target="_blank"
- * href="https://docs.cloudant.com/replication.html#the-/_replicator-database">
- * Replication - _replicator
- * </a>
+ * @see <a href="https://console.bluemix.net/docs/services/Cloudant/api/replication.html#the-_replicator-database"
+ * target="_blank">Replication - the _replicator database</a>
  * @since 0.0.2
  */
 public class Replicator {


### PR DESCRIPTION
## What

Updated `docs.cloudant.com` links to the latest Bluemix `console.bluemix.net/docs/` documentation.

## How

- Replaced all deprecated links in library with the appropriate Bluemix doc links
- Replaced `Cloudant for developers` with `Cloudant Learning Center` link

## Testing

No new tests.