### PR TITLE
Use pre-fixed size array list during bulk call

### DIFF
--- a/cloudant-client/src/main/java/com/cloudant/client/api/Database.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/Database.java
@@ -965,7 +965,7 @@ public class Database {
     public List<com.cloudant.client.api.model.Response> bulk(List<?> objects) {
         List<Response> couchDbResponseList = db.bulk(objects, false);
         List<com.cloudant.client.api.model.Response> cloudantResponseList = new ArrayList<com
-                .cloudant.client.api.model.Response>();
+                .cloudant.client.api.model.Response>(couchDbResponseList.size());
         for (Response couchDbResponse : couchDbResponseList) {
             com.cloudant.client.api.model.Response response = new com.cloudant.client.api.model
                     .Response(couchDbResponse);


### PR DESCRIPTION
When there are large number of documents, the array list will resize several times if size is not prefixed. Since the size is already known, the size needs to be fixed while creating the array list.

Thanks for your hard work, please ensure all items are complete before opening.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://github.com/cloudant/java-cloudant/blob/master/DCO1.1.txt)
- [ ] You have added tests for any code changes
- [ ] You have updated the [CHANGES.md](https://github.com/cloudant/java-cloudant/blob/master/CHANGES.md) 
- [ ] You have completed the PR template below:

## What

Added initial size to response array construction.

## Testing

Bulk method covered by existing code path, core Java ctor does not need testing.

## Issues

N/A
