### PR TITLE
Fix bugs in Changes.readNextRow() for continuous changes feeds

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# 2.11.0 (Unreleased)
+- [FIXED] An issue where `Changes.hasNext()` never returns on receipt
+  of `last_seq` for continuous changes feeds.
+
 # 2.10.0 (2017-11-07)
 - [NEW] Added API for upcoming IBM Cloud Identity and Access Management support for Cloudant on IBM
   Cloud. Note: IAM API key support is not yet enabled in the service.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-# 2.11.0 (Unreleased)
+# (Unreleased)
 - [FIXED] An issue where `Changes.hasNext()` never returns on receipt
   of `last_seq` for continuous changes feeds.
 

--- a/cloudant-client/src/main/java/com/cloudant/client/api/Changes.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/Changes.java
@@ -278,6 +278,7 @@ public class Changes {
             return true;
         }
         // we were stopped, end of changes feed
+        terminate();
         return false;
     }
 

--- a/cloudant-client/src/main/java/com/cloudant/client/api/Changes.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/Changes.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2011 lightcouch.org
- * Copyright (c) 2015, 2017 IBM Corp. All rights reserved.
+ * Copyright © 2015, 2017 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at

--- a/cloudant-client/src/main/java/com/cloudant/client/api/Changes.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/Changes.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2011 lightcouch.org
- * Copyright (c) 2015 2016 IBM Corp. All rights reserved.
+ * Copyright (c) 2015, 2017 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -25,6 +25,7 @@ import com.cloudant.client.org.lightcouch.internal.CouchDbUtil;
 import com.google.gson.Gson;
 
 import java.io.BufferedReader;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.UnsupportedEncodingException;
@@ -262,29 +263,31 @@ public class Changes {
      * Reads and sets the next feed in the stream.
      */
     private boolean readNextRow() {
-        boolean hasNext = false;
-        try {
-            if (!stop) {
-                while (true) {
-                    String row = getReader().readLine();
-                    if (row != null && row.isEmpty()) {
-                        continue;
-                    }
-                    if (row != null && !row.startsWith("{\"last_seq\":")) {
-                        setNextRow(gson.fromJson(row, ChangesResult.Row.class));
-                        hasNext = true;
-                        break;
-                    }
-                }
+        while (!stop) {
+            String row = getLineWrapped();
+            // end of stream - null indicates end of stream before we see last_seq which shouldn't
+            // be possible but we should handle it
+            if (row == null || row.startsWith("{\"last_seq\":")) {
+                terminate();
+                return false;
+            } else if (row.isEmpty()) {
+                // heartbeat
+                continue;
             }
-        } catch (Exception e) {
-            terminate();
-            throw new CouchDbException("Error reading continuous stream.", e);
+            setNextRow(gson.fromJson(row, ChangesResult.Row.class));
+            return true;
         }
-        if (!hasNext) {
+        // we were stopped, end of changes feed
+        return false;
+    }
+
+    private String getLineWrapped() {
+        try {
+            return getReader().readLine();
+        } catch (IOException ioe) {
             terminate();
+            throw new CouchDbException("Error reading continuous stream.", ioe);
         }
-        return hasNext;
     }
 
     private BufferedReader getReader() {

--- a/cloudant-client/src/test/java/com/cloudant/tests/ChangeNotificationsTest.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/ChangeNotificationsTest.java
@@ -152,4 +152,44 @@ public class ChangeNotificationsTest {
         assertTrue("There should be a custom parameter on the request", request.getPath()
                 .contains("myParam=paramValue"));
     }
+
+    /**
+     * Test that the continuous changes feed iterator correctly reads the last_seq line
+     */
+    @Test
+    public void changesFeedLastSeq() throws Exception {
+
+        CloudantClient client = CloudantClientHelper.newMockWebServerClientBuilder(mockWebServer)
+                .build();
+        Database db = client.database("notreal", false);
+
+        // Mock up a set of changes with a last_seq
+        String body = "{\"seq\":\"1" +
+                "-g1AAAAETeJzLYWBgYMlgTmGQT0lKzi9KdUhJMtNLykxPyilN1UvOyS9NScwr0ctLLckBKmRKZEiy____f1YiA6oWI9xakhyAZFI9SFcGcyJjLpDHbmxukmponkjYBKIdlscCJBkagBTQov0Y7jMmpPMARCfIZ1kA23taSg\",\"id\":\"llama\",\"changes\":[{\"rev\":\"6-77acefc448de2129bb6427ebdeb021df\"}]}\n" +
+                "{\"seq\":\"2-g1AAAAFDeJzLYWBgYMlgTmGQT0lKzi9KdUhJMtNLykxPyilN1UvOyS9NScwr0ctLLckBKmRKZEiy____f1YiA6oWI9xakhyAZFI9SFcGcyJjLpDHbmxukmponkjYBKIdlscCJBkagBTQov0Y7jMmpPMARCeyG41NTZPSTAmbkgUA-4RpJw\",\"id\":\"kookaburra\",\"changes\":[{\"rev\":\"4-6038cf35dfe1211f85484dec951142c7\"}]}\n" +
+                "{\"seq\":\"3-g1AAAAFDeJzLYWBgYMlgTmGQT0lKzi9KdUhJMtNLykxPyilN1UvOyS9NScwr0ctLLckBKmRKZEiy____f1YiA6oWI9xakhyAZFI9SFcGcyJjLpDHbmxukmponkjYBKIdlscCJBkagBTQov0Y7jMmpPMARCfYjUwQNxqbmialmRI2JQsA-7RpKA\",\"id\":\"panda\",\"changes\":[{\"rev\":\"2-f578490963b0bd266f6c5bbf92302977\"}]}\n" +
+                "{\"seq\":\"4-g1AAAAFDeJzLYWBgYMlgTmGQT0lKzi9KdUhJMtNLykxPyilN1UvOyS9NScwr0ctLLckBKmRKZEiy____f1YiA6oWI9xakhyAZFI9SFcGcyJjLpDHbmxukmponkjYBKIdlscCJBkagBTQov0Y7jMmpPMARCfYjcwQNxqbmialmRI2JQsA--RpKQ\",\"id\":\"snipe\",\"changes\":[{\"rev\":\"3-4b2fb3b7d6a226b13951612d6ca15a6b\"}]}\n" +
+                "{\"seq\":\"5-g1AAAAFzeJzLYWBgYMlgTmGQT0lKzi9KdUhJMtNLykxPyilN1UvOyS9NScwr0ctLLckBKmRKZEiy____f1YGcyJjLlCA3dwkLcXczISwdlQrjHBbkeQAJJPqUWwxNjdJNTRPJGwC0R7JYwGSDA1ACmjR_qxEBlSdxoR0HoDoBLuRGeJGY1PTpDRTwqZkAQAv9XgS\",\"id\":\"badger\",\"changes\":[{\"rev\":\"4-51aa94e4b0ef37271082033bba52b850\"}]}\n" +
+                "{\"seq\":\"6-g1AAAAGjeJzLYWBgYMlgTmGQT0lKzi9KdUhJMtNLykxPyilN1UvOyS9NScwr0ctLLckBKmRKZEiy____f1YGcyJjLlCA3dwkLcXczISwdlQrjHBbkeQAJJPqUWwxNjdJNTRPJGwC0R7JYwGSDA1ACmjRfoRNhubGZqaWlqT6x5iQTQcgNoH9xAzxk7GpaVKaKWFTsgBvlIad\",\"id\":\"870908b66ac0ed114512e6fb6d00260f\",\"changes\":[{\"rev\":\"2-eec205a9d413992850a6e32678485900\"}],\"deleted\":true}\n" +
+                "{\"seq\":\"7-g1AAAAGjeJzLYWBgYMlgTmGQT0lKzi9KdUhJMtNLykxPyilN1UvOyS9NScwr0ctLLckBKmRKZEiy____f1YGcyJTLlCA3dwkLcXczISwdlQrjHBbkeQAJJPqobYwgm0xNjdJNTRPJGwC0R7JYwGSDA1ACmjRfoRNhubGZqaWlqT6x5iQTQcgNoH9xAzxk7GpaVKaKWFTsgBw_oae\",\"id\":\"_design/validation\",\"changes\":[{\"rev\":\"2-97e93126a6337d173f9b2810c0b9c0b6\"}],\"deleted\":true}\n" +
+                "{\"seq\":\"8-g1AAAAGjeJzLYWBgYMlgTmGQT0lKzi9KdUhJMtNLykxPyilN1UvOyS9NScwr0ctLLckBKmRKZEiy____f1YGcyJzLlCA3dwkLcXczISwdlQrjHBbkeQAJJPqobYwgm0xNjdJNTRPJGwC0R7JYwGSDA1ACmjRfoRNhubGZqaWlqT6x5iQTQcgNiGFnLGxqWlSmilhU7IAcmiGnw\",\"id\":\"elephant\",\"changes\":[{\"rev\":\"3-f812228f45b5f4e496250556195372b2\"}]}\n" +
+                "{\"seq\":\"9-g1AAAAGjeJzLYWBgYMlgTmGQT0lKzi9KdUhJMtNLykxPyilN1UvOyS9NScwr0ctLLckBKmRKZEiy____f1YGcyJzLlCA3dwkLcXczISwdlQrjHBbkeQAJJPqobYwgm0xNjdJNTRPJGwC0R7JYwGSDA1ACmjRfpBNTGCbDM2NzUwtLUn1jzEhmw5AbEIKOWNjU9OkNFPCpmQBAHMChqA\",\"id\":\"_design/views101\",\"changes\":[{\"rev\":\"1-a918dd4f11704143b535f0ab3af4bf75\"}]}\n" +
+                "{\"seq\":\"10-g1AAAAGjeJzLYWBgYMlgTmGQT0lKzi9KdUhJMtNLykxPyilN1UvOyS9NScwr0ctLLckBKmRKZEiy____f1YGcyJLLlCA3dwkLcXczISwdlQrjHBbkeQAJJPqobYwgm0xNjdJNTRPJGwC0R7JYwGSDA1ACmjRfpBNTGCbDM2NzUwtLUn1jzEhmw5AbAL7iRniJ2NT06Q0U8KmZAEAdGyGoQ\",\"id\":\"lemur\",\"changes\":[{\"rev\":\"3-552d9dbf91fa914a07756e69b9ceaafa\"}]}\n" +
+                "{\"seq\":\"11-g1AAAAGjeJzLYWBgYMlgTmGQT0lKzi9KdUhJMtNLykxPyilN1UvOyS9NScwr0ctLLckBKmRKZEiy____f1YGcyJLLlCA3dwkLcXczISwdlQrjHBbkeQAJJPqobYwgm0xNjdJNTRPJGwC0R7JYwGSDA1ACmjRfpBNzGCbDM2NzUwtLUn1jzEhmw5AbPqPsMnY2NQ0Kc2UsClZAHUGhqI\",\"id\":\"aardvark\",\"changes\":[{\"rev\":\"3-fe45a3e06244adbe7ba145e74e57aba5\"}]}\n" +
+                "{\"seq\":\"12-g1AAAAGjeJzLYWBgYMlgTmGQT0lKzi9KdUhJMtNLykxPyilN1UvOyS9NScwr0ctLLckBKmRKZEiy____f1YGcyJrLlCA3dwkLcXczISwdlQrjHBbkeQAJJPqobYwgm0xNjdJNTRPJGwC0R7JYwGSDA1ACmjRfpBNzGCbDM2NzUwtLUn1jzEhmw5AbPqPsMnY2NQ0Kc2UsClZAHZwhqM\",\"id\":\"zebra\",\"changes\":[{\"rev\":\"3-750dac460a6cc41e6999f8943b8e603e\"}]}\n" +
+                "{\"seq\":\"13-g1AAAAGjeJzLYWBgYMlgTmGQT0lKzi9KdUhJMtNLykxPyilN1UvOyS9NScwr0ctLLckBKmRKZEiy____f1YGcyJrLlCA3dwkLcXczISwdlQrjHBbkeQAJJPqobYwgm0xNjdJNTRPJGwC0R7JYwGSDA1ACmjRfpBNLGCbDM2NzUwtLUn1jzEhmw5AbAL7iRniJ2NT06Q0U8KmZAEAdwqGpA\",\"id\":\"cat\",\"changes\":[{\"rev\":\"2-eec205a9d413992850a6e32678485900\"}],\"deleted\":true}\n" +
+                "{\"seq\":\"14-g1AAAAGjeJzLYWBgYMlgTmGQT0lKzi9KdUhJMtNLykxPyilN1UvOyS9NScwr0ctLLckBKmRKZEiy____f1YGcyJrLlCA3dwkLcXczISwdlQrjHBbkeQAJJPqobYwgm0xNjdJNTRPJGwC0R7JYwGSDA1ACmjRfoR_DM2NzUwtLUn1jzEhmw5AbAL7iRniJ2NT06Q0U8KmZAEAd6SGpQ\",\"id\":\"giraffe\",\"changes\":[{\"rev\":\"3-7665c3e66315ff40616cceef62886bd8\"}]}\n" +
+                "{\"last_seq\":\"14-g1AAAAGjeJzLYWBgYMlgTmGQT0lKzi9KdUhJMtNLykxPyilN1UvOyS9NScwr0ctLLckBKmRKZEiy____f1YGcyJrLlCA3dwkLcXczISwdlQrjHBbkeQAJJPqobYwgm0xNjdJNTRPJGwC0R7JYwGSDA1ACmjRfoR_DM2NzUwtLUn1jzEhmw5AbAL7iRniJ2NT06Q0U8KmZAEAd6SGpQ\",\"pending\":0}";
+        mockWebServer.enqueue(new MockResponse().setBody(body));
+        Changes c = db.changes().continuousChanges();
+        int nChanges = 0;
+        // check against regression where hasNext() will hang
+        while(c.hasNext()) {
+            nChanges++;
+        }
+        RecordedRequest request = mockWebServer.takeRequest(1, TimeUnit.SECONDS);
+        assertNotNull("There should be a changes request", request);
+        assertEquals("There should be 14 changes", 14, nChanges);
+    }
+
 }

--- a/cloudant-client/src/test/java/com/cloudant/tests/ChangeNotificationsTest.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/ChangeNotificationsTest.java
@@ -186,6 +186,7 @@ public class ChangeNotificationsTest {
         // check against regression where hasNext() will hang
         while(c.hasNext()) {
             nChanges++;
+            c.next();
         }
         RecordedRequest request = mockWebServer.takeRequest(1, TimeUnit.SECONDS);
         assertNotNull("There should be a changes request", request);


### PR DESCRIPTION
## What

Fix bugs in `Changes.readNextRow()`. Previously it was possible for  `readNextRow()` to hang indefinitely for continuous changes feeds.

## How

Exit the while loop early if the line we read from the stream was null or contains `{"last_seq":`.

In theory `row` should never be null because the stream should block if there is no more data or
send "last_seq" when we get to the end. However, it's a case worth handling so that the loop still
exits even if "last_seq" isn't set.

## Testing

Added mock server test `changesFeedLastSeq`.

## Issues

Fixes #390.