### PR TITLE
Allow custom service name in CloudFoundry VCAP_SERVICES environment variable.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
-# (Unreleased)
-- [FIXED] An issue where `Changes.hasNext()` never returns on receipt
-  of `last_seq` for continuous changes feeds.
+# UNRELEASED
+- [NEW] Added an extra bluemix method to the client builder allowing a custom service name to be
+  used with the VCAP_SERVICES environment variable content.
+- [FIXED] An issue where `Changes.hasNext()` never returns on receipt of `last_seq` for continuous
+  changes feeds.
 
 # 2.10.0 (2017-11-07)
 - [NEW] Added API for upcoming IBM Cloud Identity and Access Management support for Cloudant on IBM

--- a/cloudant-client/findbugs_excludes.xml
+++ b/cloudant-client/findbugs_excludes.xml
@@ -95,16 +95,22 @@ For example because it requires an API change
         <Method name="readNextRow"/>
     </Match>
 
-    <!-- This bug is because com.cloudant.client.internal.util.CloudFoundryServices
-    ($CloudFoundryServiceCredentials) is populated via GSON. -->
+    <!-- This bug is because com.cloudant.client.internal.util.CloudFoundryService is populated via
+    GSON. -->
     <Match>
-        <Bug code="UWF" pattern="UWF_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD"/>
-        <Class name="com.cloudant.client.internal.util.CloudFoundryServices$CloudFoundryService"/>
+        <Bug code="UwF" pattern="UWF_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD"/>
+        <Class name="com.cloudant.client.internal.util.CloudFoundryService"/>
+        <Field name="credentials"/>
     </Match>
-
     <Match>
-        <Bug code="UWF" pattern="UWF_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD"/>
-        <Class name="com.cloudant.client.internal.util.CloudFoundryServices$CloudFoundryServiceCredentials"/>
+        <Bug code="UwF" pattern="UWF_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD"/>
+        <Class name="com.cloudant.client.internal.util.CloudFoundryService"/>
+        <Field name="name"/>
+    </Match>
+    <Match>
+        <Bug code="UwF" pattern="UWF_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD"/>
+        <Class name="com.cloudant.client.internal.util.CloudFoundryService$CloudFoundryServiceCredentials"/>
+        <Field name="url"/>
     </Match>
 
 </FindBugsFilter>

--- a/cloudant-client/src/main/java/com/cloudant/client/internal/util/CloudFoundryService.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/internal/util/CloudFoundryService.java
@@ -15,18 +15,12 @@
 package com.cloudant.client.internal.util;
 
 import java.net.URL;
-import java.util.List;
 
 
-public class CloudFoundryServices {
+public class CloudFoundryService {
 
-    public List<CloudFoundryService> cloudantNoSQLDB;
-
-    public static class CloudFoundryService {
-
-        public String name;
-        public CloudFoundryServiceCredentials credentials;
-    }
+    public String name;
+    public CloudFoundryServiceCredentials credentials;
 
     public static class CloudFoundryServiceCredentials {
 

--- a/cloudant-client/src/test/java/com/cloudant/tests/CloudFoundryServiceTest.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/CloudFoundryServiceTest.java
@@ -33,9 +33,13 @@ public class CloudFoundryServiceTest {
         private List<HashMap<String, Object>> cloudantServices;
 
         VCAPGenerator() {
+            this("cloudantNoSQLDB");
+        }
+
+        VCAPGenerator(String serviceName) {
             vcap = new HashMap<String, Object>();
             cloudantServices = new ArrayList<HashMap<String, Object>>();
-            vcap.put("cloudantNoSQLDB", cloudantServices);
+            vcap.put(serviceName, cloudantServices);
         }
 
         private void addService(String name, String url, String username, String password) {
@@ -74,6 +78,34 @@ public class CloudFoundryServiceTest {
         public String toJson() {
             return new GsonBuilder().create().toJson(vcap);
         }
+    }
+
+    @Test
+    public void vcapValidServiceNameSpecified() {
+        String serviceName = "serviceFoo";
+        VCAPGenerator vcap = new CloudFoundryServiceTest.VCAPGenerator(serviceName);
+        vcap.createNewService("test_bluemix_service_1",
+                CloudantClientHelper.SERVER_URI_WITH_USER_INFO,
+                CloudantClientHelper.COUCH_USERNAME, CloudantClientHelper.COUCH_PASSWORD);
+        ClientBuilder.bluemix(vcap.toJson(), serviceName, "test_bluemix_service_1").build().serverVersion();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void vcapMissingServiceNameSpecified() {
+        VCAPGenerator vcap = new CloudFoundryServiceTest.VCAPGenerator();
+        vcap.createNewService("test_bluemix_service_1",
+                CloudantClientHelper.SERVER_URI_WITH_USER_INFO,
+                CloudantClientHelper.COUCH_USERNAME, CloudantClientHelper.COUCH_PASSWORD);
+        ClientBuilder.bluemix(vcap.toJson(), "missingService", "test_bluemix_service_1").build();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void vcapNullServiceNameSpecified() {
+        VCAPGenerator vcap = new CloudFoundryServiceTest.VCAPGenerator();
+        vcap.createNewService("test_bluemix_service_1",
+                CloudantClientHelper.SERVER_URI_WITH_USER_INFO,
+                CloudantClientHelper.COUCH_USERNAME, CloudantClientHelper.COUCH_PASSWORD);
+        ClientBuilder.bluemix(vcap.toJson(), null, "test_bluemix_service_1").build();
     }
 
     @Test


### PR DESCRIPTION
Thanks for your hard work, please ensure all items are complete before opening.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://github.com/cloudant/java-cloudant/blob/master/DCO1.1.txt)
- [x] You have added tests for any code changes
- [x] You have updated the [CHANGES.md](https://github.com/cloudant/java-cloudant/blob/master/CHANGES.md) 
- [x] You have completed the PR template below:

## What
Previously the service name was hard coded as 'cloudantNoSQLDB'. This can now be
customised by passing a `serviceName` parameter to the `ClientBuilder.bluemix`
method.

## Testing
Includes additional unit tests.

## Issues
Fixes #391.
