### PR TITLE
Added null check for URL in ClientBuilder

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,6 @@
 # UNRELEASED
+- [IMPROVED] Throw an `IllegalArgumentException` with a better message if trying to build the client
+  with a `null` URL instead of a `NullPointerException`.
 
 # 2.11.0 (2017-11-21)
 - [NEW] Added an extra bluemix method to the client builder allowing a custom service name to be

--- a/cloudant-client/src/main/java/com/cloudant/client/api/ClientBuilder.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/ClientBuilder.java
@@ -22,6 +22,7 @@ import com.cloudant.client.internal.util.SecurityDeserializer;
 import com.cloudant.client.internal.util.ShardDeserializer;
 import com.cloudant.client.org.lightcouch.CouchDbException;
 import com.cloudant.client.org.lightcouch.CouchDbProperties;
+import com.cloudant.client.org.lightcouch.internal.CouchDbUtil;
 import com.cloudant.http.HttpConnectionInterceptor;
 import com.cloudant.http.HttpConnectionRequestInterceptor;
 import com.cloudant.http.HttpConnectionResponseInterceptor;
@@ -195,6 +196,7 @@ public class ClientBuilder {
      * @return a new ClientBuilder for the account
      */
     public static ClientBuilder url(URL url) {
+        CouchDbUtil.assertNotNull(url, "Cloudant URL");
         return new ClientBuilder(url);
     }
 

--- a/cloudant-client/src/test/java/com/cloudant/tests/CloudantClientTests.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/CloudantClientTests.java
@@ -521,4 +521,14 @@ public class CloudantClientTests {
         // test.
         c.getAllDbs();
     }
+
+    /**
+     * Asser that a {@code null} URL causes an IllegalArgumentException to be thrown.
+     *
+     * @throws Exception
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void nullURLThrowsIAE() throws Exception {
+        ClientBuilder.url(null);
+    }
 }

--- a/cloudant-client/src/test/java/com/cloudant/tests/CloudantClientTests.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/CloudantClientTests.java
@@ -523,7 +523,7 @@ public class CloudantClientTests {
     }
 
     /**
-     * Asser that a {@code null} URL causes an IllegalArgumentException to be thrown.
+     * Assert that a {@code null} URL causes an IllegalArgumentException to be thrown.
      *
      * @throws Exception
      */


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://github.com/cloudant/java-cloudant/blob/master/DCO1.1.txt)
- [x] You have added tests for any code changes
- [x] You have updated the [CHANGES.md](https://github.com/cloudant/java-cloudant/blob/master/CHANGES.md) 
- [x] You have completed the PR template below:

## What

Added `null` check for `ClientBuilder.url(...)`

## How

Called `CouchDbUtil.assertNotNull`.

## Testing

Added new unit test for `ClientBuilder.url(null)`.

## Issues

N/A
