### PR TITLE
Changed to global gitTagAndPublish

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -97,7 +97,6 @@ stage('QA') {
 stage('Publish') {
     if (env.BRANCH_NAME == "master") {
         node {
-            checkout scm // re-checkout to be able to git tag
             unstash name: 'built'
             // read the version name and determine if it is a release build
             version = readFile('VERSION').trim()
@@ -107,39 +106,10 @@ stage('Publish') {
             withCredentials([usernamePassword(credentialsId: 'ossrh-creds', passwordVariable: 'OSSRH_PASSWORD', usernameVariable: 'OSSRH_USER'), usernamePassword(credentialsId: 'signing-creds', passwordVariable: 'KEY_PASSWORD', usernameVariable: 'KEY_ID'), file(credentialsId: 'signing-key', variable: 'SIGNING_FILE')]) {
                 sh './gradlew -Dsigning.keyId=$KEY_ID -Dsigning.password=$KEY_PASSWORD -Dsigning.secretKeyRingFile=$SIGNING_FILE -DossrhUsername=$OSSRH_USER -DossrhPassword=$OSSRH_PASSWORD upload'
             }
-
-            // if it is a release build then do the git tagging
-            if (isReleaseVersion) {
-
-                // Read the CHANGES.md to get the tag message
-                changes = """"""
-                changes += readFile('CHANGES.md')
-                tagMessage = """"""
-                for (line in changes.readLines()) {
-                    if (!"".equals(line)) {
-                        // append the line to the tagMessage
-                        tagMessage = "${tagMessage}${line}\n"
-                    } else {
-                        break
-                    }
-                }
-
-                // Use git to tag the release at the version
-                try {
-                    // Awkward workaround until resolution of https://issues.jenkins-ci.org/browse/JENKINS-28335
-                    withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: 'github-token', usernameVariable: 'GIT_USERNAME', passwordVariable: 'GIT_PASSWORD']]) {
-                        sh "git config user.email \"nomail@hursley.ibm.com\""
-                        sh "git config user.name \"Jenkins CI\""
-                        sh "git config credential.username ${env.GIT_USERNAME}"
-                        sh "git config credential.helper '!echo password=\$GIT_PASSWORD; echo'"
-                        sh "git tag -a ${version} -m '${tagMessage}'"
-                        sh "git push origin ${version}"
-                    }
-                } finally {
-                    sh "git config --unset credential.username"
-                    sh "git config --unset credential.helper"
-                }
-            }
         }
+    }
+    gitTagAndPublish {
+        isDraft=true
+        releaseApiUrl='https://api.github.com/repos/cloudant/java-cloudant/releases'
     }
 }


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://github.com/cloudant/java-cloudant/blob/master/DCO1.1.txt)
- [x] You have added tests for any code changes - **Build only changes**
- [x] You have updated the [CHANGES.md](https://github.com/cloudant/java-cloudant/blob/master/CHANGES.md) - **Build only changes**
- [x] You have completed the PR template below:

## What

Changed to use shared global `gitTagAndPublish`.

## How

Removed existing git tagging code and used new `gitTagAndPublish` configuration.

## Testing

Tested on fork.

## Issues

N/A
