### PR TITLE
Prevented some _all_docs cases truncating the response

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,8 @@
 - [IMPROVED] Throw an `IllegalArgumentException` with a better message if trying to build the client
   with a `null` URL instead of a `NullPointerException`.
 - [FIXED] Updated default IBM Cloud Identity and Access Management token URL.
+- [FIXED] An issue where a row was truncated from an `_all_docs` response including deleted docs for
+  a request using `keys` where the server returns a `total_rows` count only for undeleted docs.
 - [DEPRECATED] Old index creation and listing APIs:
     - `com.cloudant.client.api.model.Index`
     - `com.cloudant.client.api.model.IndexField`

--- a/cloudant-client/src/main/java/com/cloudant/client/internal/views/ViewResponseImpl.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/internal/views/ViewResponseImpl.java
@@ -80,12 +80,12 @@ class ViewResponseImpl<K, V> implements ViewResponse<K, V> {
             totalRows = rows.size();
         }
 
-        long rowsPerPage = (initialQueryParameters.getRowsPerPage() != null) ?
-                initialQueryParameters.getRowsPerPage().longValue() : totalRows;
+        Long rowsPerPage = (initialQueryParameters.getRowsPerPage() != null) ?
+                initialQueryParameters.getRowsPerPage().longValue() : null;
 
-        //we expect limit = rowsPerPage + 1 results, if we have rowsPerPage or less we are on the
-        // last page
-        hasNext = resultRows > rowsPerPage;
+        // We expect limit = rowsPerPage + 1 results, if we have rowsPerPage or less,
+        // or if rowsPerPage wasn't set then we are on the last page.
+        hasNext = (rowsPerPage != null) ? (resultRows > rowsPerPage) : false;
 
         if (PageMetadata.PagingDirection.BACKWARD == thisPageDirection) {
             //Result needs reversing because to implement backward paging the view reading
@@ -131,9 +131,14 @@ class ViewResponseImpl<K, V> implements ViewResponse<K, V> {
         }
 
         // calculate paging display info
-        long offset = (this.pageNumber - 1) * rowsPerPage;
-        resultFrom = offset + 1;
-        resultTo = offset + (hasNext ? rowsPerPage : resultRows);
+        if (rowsPerPage != null) {
+            long offset = (this.pageNumber - 1) * rowsPerPage;
+            resultFrom = offset + 1;
+            resultTo = offset + (hasNext ? rowsPerPage : resultRows);
+        } else {
+            resultFrom = 1;
+            resultTo = totalRows;
+        }
     }
 
     @Override


### PR DESCRIPTION
Thanks for your hard work, please ensure all items are complete before opening.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://github.com/cloudant/java-cloudant/blob/master/DCO1.1.txt)
- [x] You have added tests for any code changes
- [x] You have updated the [CHANGES.md](https://github.com/cloudant/java-cloudant/blob/master/CHANGES.md) 
- [x] You have completed the PR template below:

## What

Prevented some `_all_docs` cases truncating the last response row.

## How

Fixed #411 where `total_rows` < `rows` length in an `_all_docs` response fell into the pagination branch causing a truncated response.
Stopped using `total_rows` as `rowsPerPage` in `ViewResponseImpl`.
Updated `CHANGES.md`.

## Testing

Added a test for 2 deleted, 2 undeleted docs returned to a `keys`
`_all_docs` request.

## Issues

Fixes #411
