### PR TITLE
Add extra scheduler endpoints and fix tests

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,11 @@
 # Unreleased
 
 - [NEW] Add `CloudantClient.metaInformation()`.
+- [NEW] Add the following methods:
+  - `CloudantClient.metaInformation()`,
+  - `CloudantClient.schedulerJobs()`,
+  - `CloudantClient.schedulerDocs()`,
+  - `CloudantClient.schedulerDocs(docId)`.
 - [FIXED] An issue where `getReason()` returned an incorrect value for
   `Response` objects returned by `Database.bulk()`.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,7 @@
   - `CloudantClient.metaInformation()`,
   - `CloudantClient.schedulerJobs()`,
   - `CloudantClient.schedulerDocs()`,
-  - `CloudantClient.schedulerDocs(docId)`.
+  - `CloudantClient.schedulerDoc(docId)`.
 - [FIXED] An issue where `getReason()` returned an incorrect value for
   `Response` objects returned by `Database.bulk()`.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,6 @@
 
 - [NEW] Add `CloudantClient.metaInformation()` to get meta information from the welcome page.
 - [NEW] Add methods for interacting with the replicator's `_scheduler` endpoint:
-  - `CloudantClient.metaInformation()`,
   - `CloudantClient.schedulerJobs()`,
   - `CloudantClient.schedulerDocs()`,
   - `CloudantClient.schedulerDoc(docId)`.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,7 @@
 # Unreleased
 
-- [NEW] Add `CloudantClient.metaInformation()`.
-- [NEW] Add the following methods:
+- [NEW] Add `CloudantClient.metaInformation()` to get meta information from the welcome page.
+- [NEW] Add methods for interacting with the replicator's `_scheduler` endpoint:
   - `CloudantClient.metaInformation()`,
   - `CloudantClient.schedulerJobs()`,
   - `CloudantClient.schedulerDocs()`,

--- a/cloudant-client/findbugs_excludes.xml
+++ b/cloudant-client/findbugs_excludes.xml
@@ -112,7 +112,17 @@ For example because it requires an API change
         <Class name="com.cloudant.client.internal.util.CloudFoundryService$CloudFoundryServiceCredentials"/>
         <Field name="url"/>
     </Match>
-
+    <!-- Populated via GSON -->
+    <Match>
+        <Bug code="UwF" pattern="UWF_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD"/>
+        <Class name="com.cloudant.client.api.scheduler.SchedulerJobsResponse$History"/>
+        <Field name="timestamp"/>
+    </Match>
+    <Match>
+        <Bug code="UwF" pattern="UWF_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD"/>
+        <Class name="com.cloudant.client.api.scheduler.SchedulerJobsResponse$History"/>
+        <Field name="type"/>
+    </Match>
 
     <!-- This is likely a false positive in Findbugs, the IDE doesn't complain an unchecked cast.
     See https://sourceforge.net/p/findbugs/bugs/1242/

--- a/cloudant-client/src/main/java/com/cloudant/client/api/CloudantClient.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/CloudantClient.java
@@ -355,8 +355,8 @@ public class CloudantClient {
      * @param docId The replication document ID
      * @return Replication document state
      */
-    public SchedulerDocsResponse.Doc schedulerDocs(String docId) {
-        return couchDbClient.schedulerDocs(docId);
+    public SchedulerDocsResponse.Doc schedulerDoc(String docId) {
+        return couchDbClient.schedulerDoc(docId);
     }
 
     /**

--- a/cloudant-client/src/main/java/com/cloudant/client/api/CloudantClient.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/CloudantClient.java
@@ -22,6 +22,8 @@ import com.cloudant.client.api.model.ApiKey;
 import com.cloudant.client.api.model.IndexField;
 import com.cloudant.client.api.model.Membership;
 import com.cloudant.client.api.model.Task;
+import com.cloudant.client.api.scheduler.SchedulerDocsResponse;
+import com.cloudant.client.api.scheduler.SchedulerJobsResponse;
 import com.cloudant.client.internal.URIBase;
 import com.cloudant.client.internal.util.DeserializationTypes;
 import com.cloudant.client.org.lightcouch.CouchDbClient;
@@ -321,6 +323,40 @@ public class CloudantClient {
         com.cloudant.client.api.Replicator replicator = new com.cloudant.client.api.Replicator
                 (couchDbReplicator);
         return replicator;
+    }
+
+    /**
+     * Lists replication jobs. Includes replications created via /_replicate endpoint as well as
+     * those created from replication documents. Does not include replications which have
+     * completed or have failed to start because replication documents were malformed. Each job
+     * description will include source and target information, replication id, a history of
+     * recent event, and a few other things.
+     *
+     * @return List of replication jobs
+     */
+    public SchedulerJobsResponse schedulerJobs() {
+        return couchDbClient.schedulerJobs();
+    }
+
+    /**
+     * Lists replication document states. Includes information about all the documents, even in
+     * completed and failed states. For each document it returns the document ID, the database,
+     * the replication ID, source and target, and other information.
+     *
+     * @return List of replication document states
+     */
+    public SchedulerDocsResponse schedulerDocs() {
+        return couchDbClient.schedulerDocs();
+    }
+
+    /**
+     * Get replication document state for a given replication document ID.
+     *
+     * @param docId The replication document ID
+     * @return Replication document state
+     */
+    public SchedulerDocsResponse.Doc schedulerDocs(String docId) {
+        return couchDbClient.schedulerDocs(docId);
     }
 
     /**

--- a/cloudant-client/src/main/java/com/cloudant/client/api/CloudantClient.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/CloudantClient.java
@@ -332,18 +332,18 @@ public class CloudantClient {
      * description will include source and target information, replication id, a history of
      * recent event, and a few other things.
      *
-     * @return List of replication jobs
+     * @return All current replication jobs
      */
     public SchedulerJobsResponse schedulerJobs() {
         return couchDbClient.schedulerJobs();
     }
 
     /**
-     * Lists replication document states. Includes information about all the documents, even in
+     * Lists replication documents. Includes information about all the documents, even in
      * completed and failed states. For each document it returns the document ID, the database,
      * the replication ID, source and target, and other information.
      *
-     * @return List of replication document states
+     * @return All replication documents
      */
     public SchedulerDocsResponse schedulerDocs() {
         return couchDbClient.schedulerDocs();
@@ -353,7 +353,7 @@ public class CloudantClient {
      * Get replication document state for a given replication document ID.
      *
      * @param docId The replication document ID
-     * @return Replication document state
+     * @return Replication document for {@code docId}
      */
     public SchedulerDocsResponse.Doc schedulerDoc(String docId) {
         return couchDbClient.schedulerDoc(docId);

--- a/cloudant-client/src/main/java/com/cloudant/client/api/Database.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/Database.java
@@ -32,7 +32,6 @@ import com.cloudant.client.api.query.QueryResult;
 import com.cloudant.client.api.model.Shard;
 import com.cloudant.client.api.query.Indexes;
 import com.cloudant.client.api.query.JsonIndex;
-import com.cloudant.client.api.scheduler.SchedulerDocsResponse;
 import com.cloudant.client.api.views.AllDocsRequestBuilder;
 import com.cloudant.client.api.views.ViewRequestBuilder;
 import com.cloudant.client.internal.DatabaseURIHelper;

--- a/cloudant-client/src/main/java/com/cloudant/client/api/Database.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/Database.java
@@ -32,6 +32,7 @@ import com.cloudant.client.api.query.QueryResult;
 import com.cloudant.client.api.model.Shard;
 import com.cloudant.client.api.query.Indexes;
 import com.cloudant.client.api.query.JsonIndex;
+import com.cloudant.client.api.scheduler.SchedulerDocsResponse;
 import com.cloudant.client.api.views.AllDocsRequestBuilder;
 import com.cloudant.client.api.views.ViewRequestBuilder;
 import com.cloudant.client.internal.DatabaseURIHelper;

--- a/cloudant-client/src/main/java/com/cloudant/client/api/scheduler/SchedulerDocsResponse.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/scheduler/SchedulerDocsResponse.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright © 2018 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
 package com.cloudant.client.api.scheduler;
 
 import com.google.gson.annotations.SerializedName;

--- a/cloudant-client/src/main/java/com/cloudant/client/api/scheduler/SchedulerDocsResponse.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/scheduler/SchedulerDocsResponse.java
@@ -16,7 +16,9 @@ package com.cloudant.client.api.scheduler;
 
 import com.google.gson.annotations.SerializedName;
 
+import java.util.Date;
 import java.util.List;
+import java.util.Map;
 
 public class SchedulerDocsResponse {
 
@@ -45,14 +47,14 @@ public class SchedulerDocsResponse {
         @SerializedName("error_count")
         private long errorCount;
         private String id;
-        private Object info;
+        private Map<String, Object> info;
         @SerializedName("last_updated")
-        private String lastUpdated;
+        private Date lastUpdated;
         private String node;
         private String proxy;
         private String source;
         @SerializedName("start_time")
-        private String startTime;
+        private Date startTime;
         private String state;
         private String target;
 
@@ -72,11 +74,11 @@ public class SchedulerDocsResponse {
             return id;
         }
 
-        public Object getInfo() {
+        public Map<String, Object> getInfo() {
             return info;
         }
 
-        public String getLastUpdated() {
+        public Date getLastUpdated() {
             return lastUpdated;
         }
 
@@ -92,7 +94,7 @@ public class SchedulerDocsResponse {
             return source;
         }
 
-        public String getStartTime() {
+        public Date getStartTime() {
             return startTime;
         }
 

--- a/cloudant-client/src/main/java/com/cloudant/client/api/scheduler/SchedulerDocsResponse.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/scheduler/SchedulerDocsResponse.java
@@ -1,0 +1,117 @@
+package com.cloudant.client.api.scheduler;
+
+import com.google.gson.annotations.SerializedName;
+
+import java.util.List;
+
+public class SchedulerDocsResponse {
+
+    private List<Doc> docs;
+    private long offset;
+    @SerializedName("total_rows")
+    private long totalRows;
+
+    public SchedulerDocsResponse(List<Doc> docs, long offset, long totalRows) {
+        this.docs = docs;
+        this.offset = offset;
+        this.totalRows = totalRows;
+    }
+
+    public List<Doc> getDocs() {
+        return docs;
+    }
+
+    public long getOffset() {
+        return offset;
+    }
+
+    public long getTotalRows() {
+        return totalRows;
+    }
+
+    public class Doc {
+
+        public Doc(String database, String docId, long errorCount, String id, Object info,
+                   String lastUpdated, String node, String proxy, String source, String
+                           startTime, String state, String target) {
+            this.database = database;
+            this.docId = docId;
+            this.errorCount = errorCount;
+            this.id = id;
+            this.info = info;
+            this.lastUpdated = lastUpdated;
+            this.node = node;
+            this.proxy = proxy;
+            this.source = source;
+            this.startTime = startTime;
+            this.state = state;
+            this.target = target;
+        }
+
+        public String getDatabase() {
+            return database;
+        }
+
+        public String getDocId() {
+            return docId;
+        }
+
+        public long getErrorCount() {
+            return errorCount;
+        }
+
+        public String getId() {
+            return id;
+        }
+
+        public Object getInfo() {
+            return info;
+        }
+
+        public String getLastUpdated() {
+            return lastUpdated;
+        }
+
+        public String getNode() {
+            return node;
+        }
+
+        public String getProxy() {
+            return proxy;
+        }
+
+        public String getSource() {
+            return source;
+        }
+
+        public String getStartTime() {
+            return startTime;
+        }
+
+        public String getState() {
+            return state;
+        }
+
+        public String getTarget() {
+            return target;
+        }
+
+        private String database;
+        @SerializedName("doc_id")
+        private String docId;
+        @SerializedName("error_count")
+        private long errorCount;
+        private String id;
+        private Object info;
+        @SerializedName("last_updated")
+        private String lastUpdated;
+        private String node;
+        private String proxy;
+        private String source;
+        @SerializedName("start_time")
+        private String startTime;
+        private String state;
+        private String target;
+    }
+
+}

--- a/cloudant-client/src/main/java/com/cloudant/client/api/scheduler/SchedulerDocsResponse.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/scheduler/SchedulerDocsResponse.java
@@ -79,7 +79,7 @@ public class SchedulerDocsResponse {
         }
 
         public Date getLastUpdated() {
-            return lastUpdated;
+            return (Date)lastUpdated.clone();
         }
 
         public String getNode() {
@@ -95,7 +95,7 @@ public class SchedulerDocsResponse {
         }
 
         public Date getStartTime() {
-            return startTime;
+            return (Date)startTime.clone();
         }
 
         public String getState() {

--- a/cloudant-client/src/main/java/com/cloudant/client/api/scheduler/SchedulerDocsResponse.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/scheduler/SchedulerDocsResponse.java
@@ -25,12 +25,6 @@ public class SchedulerDocsResponse {
     @SerializedName("total_rows")
     private long totalRows;
 
-    public SchedulerDocsResponse(List<Doc> docs, long offset, long totalRows) {
-        this.docs = docs;
-        this.offset = offset;
-        this.totalRows = totalRows;
-    }
-
     public List<Doc> getDocs() {
         return docs;
     }
@@ -43,24 +37,24 @@ public class SchedulerDocsResponse {
         return totalRows;
     }
 
-    public class Doc {
+    public static class Doc {
 
-        public Doc(String database, String docId, long errorCount, String id, Object info,
-                   String lastUpdated, String node, String proxy, String source, String
-                           startTime, String state, String target) {
-            this.database = database;
-            this.docId = docId;
-            this.errorCount = errorCount;
-            this.id = id;
-            this.info = info;
-            this.lastUpdated = lastUpdated;
-            this.node = node;
-            this.proxy = proxy;
-            this.source = source;
-            this.startTime = startTime;
-            this.state = state;
-            this.target = target;
-        }
+        private String database;
+        @SerializedName("doc_id")
+        private String docId;
+        @SerializedName("error_count")
+        private long errorCount;
+        private String id;
+        private Object info;
+        @SerializedName("last_updated")
+        private String lastUpdated;
+        private String node;
+        private String proxy;
+        private String source;
+        @SerializedName("start_time")
+        private String startTime;
+        private String state;
+        private String target;
 
         public String getDatabase() {
             return database;
@@ -110,22 +104,6 @@ public class SchedulerDocsResponse {
             return target;
         }
 
-        private String database;
-        @SerializedName("doc_id")
-        private String docId;
-        @SerializedName("error_count")
-        private long errorCount;
-        private String id;
-        private Object info;
-        @SerializedName("last_updated")
-        private String lastUpdated;
-        private String node;
-        private String proxy;
-        private String source;
-        @SerializedName("start_time")
-        private String startTime;
-        private String state;
-        private String target;
     }
 
 }

--- a/cloudant-client/src/main/java/com/cloudant/client/api/scheduler/SchedulerDocsResponse.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/scheduler/SchedulerDocsResponse.java
@@ -79,7 +79,11 @@ public class SchedulerDocsResponse {
         }
 
         public Date getLastUpdated() {
-            return (Date)lastUpdated.clone();
+            if (lastUpdated != null) {
+                return (Date) lastUpdated.clone();
+            } else {
+                return null;
+            }
         }
 
         public String getNode() {
@@ -95,7 +99,11 @@ public class SchedulerDocsResponse {
         }
 
         public Date getStartTime() {
-            return (Date)startTime.clone();
+            if (startTime != null) {
+                return (Date) startTime.clone();
+            } else {
+                return null;
+            }
         }
 
         public String getState() {

--- a/cloudant-client/src/main/java/com/cloudant/client/api/scheduler/SchedulerJobsResponse.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/scheduler/SchedulerJobsResponse.java
@@ -1,0 +1,102 @@
+package com.cloudant.client.api.scheduler;
+
+import com.google.gson.annotations.SerializedName;
+
+import java.util.List;
+
+public class SchedulerJobsResponse {
+
+    private long offset;
+    @SerializedName("total_rows")
+    private long totalRows;
+    private String id;
+    private String database;
+    @SerializedName("doc_id")
+    private String docId;
+    private List<History> history;
+    private String pid;
+    private String node;
+    private String source;
+    private String target;
+    @SerializedName("total_rows")
+    private String startTime;
+
+    public SchedulerJobsResponse(long offset, long totalRows, String id, String database, String
+            docId, List<History> history, String pid, String node, String source, String target,
+                                 String startTime) {
+        this.offset = offset;
+        this.totalRows = totalRows;
+        this.id = id;
+        this.database = database;
+        this.docId = docId;
+        this.history = history;
+        this.pid = pid;
+        this.node = node;
+        this.source = source;
+        this.target = target;
+        this.startTime = startTime;
+    }
+
+    public long getOffset() {
+        return offset;
+    }
+
+    public long getTotalRows() {
+        return totalRows;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getDatabase() {
+        return database;
+    }
+
+    public String getDocId() {
+        return docId;
+    }
+
+    public List<History> getHistory() {
+        return history;
+    }
+
+    public String getPid() {
+        return pid;
+    }
+
+    public String getNode() {
+        return node;
+    }
+
+    public String getSource() {
+        return source;
+    }
+
+    public String getTarget() {
+        return target;
+    }
+
+    public String getStartTime() {
+        return startTime;
+    }
+
+    static class History {
+        private String timestamp;
+        private String type;
+
+        public History(String timestamp, String type) {
+            this.timestamp = timestamp;
+            this.type = type;
+        }
+
+        public String getTimestamp() {
+            return timestamp;
+        }
+
+        public String getType() {
+            return type;
+        }
+    }
+
+}

--- a/cloudant-client/src/main/java/com/cloudant/client/api/scheduler/SchedulerJobsResponse.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/scheduler/SchedulerJobsResponse.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright © 2018 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
 package com.cloudant.client.api.scheduler;
 
 import com.google.gson.annotations.SerializedName;

--- a/cloudant-client/src/main/java/com/cloudant/client/api/scheduler/SchedulerJobsResponse.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/scheduler/SchedulerJobsResponse.java
@@ -16,24 +16,14 @@ package com.cloudant.client.api.scheduler;
 
 import com.google.gson.annotations.SerializedName;
 
+import java.util.Date;
 import java.util.List;
 
 public class SchedulerJobsResponse {
-
     private long offset;
     @SerializedName("total_rows")
     private long totalRows;
-    private String id;
-    private String database;
-    @SerializedName("doc_id")
-    private String docId;
-    private List<History> history;
-    private String pid;
-    private String node;
-    private String source;
-    private String target;
-    @SerializedName("total_rows")
-    private String startTime;
+    private List<Job> jobs;
 
     public long getOffset() {
         return offset;
@@ -43,47 +33,71 @@ public class SchedulerJobsResponse {
         return totalRows;
     }
 
-    public String getId() {
-        return id;
+    public List<Job> getJobs() {
+        return jobs;
     }
 
-    public String getDatabase() {
-        return database;
-    }
+    public static class Job {
+        private String id;
+        private String database;
+        @SerializedName("doc_id")
+        private String docId;
+        private List<History> history;
+        private String pid;
+        private String node;
+        private String source;
+        private String target;
+        private String user;
+        @SerializedName("start_time")
+        private Date startTime;
 
-    public String getDocId() {
-        return docId;
-    }
+        public String getId() {
+            return id;
+        }
 
-    public List<History> getHistory() {
-        return history;
-    }
+        public String getDatabase() {
+            return database;
+        }
 
-    public String getPid() {
-        return pid;
-    }
+        public String getDocId() {
+            return docId;
+        }
 
-    public String getNode() {
-        return node;
-    }
+        public List<History> getHistory() {
+            return history;
+        }
 
-    public String getSource() {
-        return source;
-    }
+        public String getPid() {
+            return pid;
+        }
 
-    public String getTarget() {
-        return target;
-    }
+        public String getNode() {
+            return node;
+        }
 
-    public String getStartTime() {
-        return startTime;
+        public String getSource() {
+            return source;
+        }
+
+        public String getTarget() {
+            return target;
+        }
+
+        public String getUser() {
+            return user;
+        }
+
+        public Date getStartTime() {
+            return startTime;
+        }
+
     }
 
     public static class History {
-        private String timestamp;
+        private Date timestamp;
         private String type;
 
-        public String getTimestamp() {
+        public Date getTimestamp() {
             return timestamp;
         }
 

--- a/cloudant-client/src/main/java/com/cloudant/client/api/scheduler/SchedulerJobsResponse.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/scheduler/SchedulerJobsResponse.java
@@ -35,22 +35,6 @@ public class SchedulerJobsResponse {
     @SerializedName("total_rows")
     private String startTime;
 
-    public SchedulerJobsResponse(long offset, long totalRows, String id, String database, String
-            docId, List<History> history, String pid, String node, String source, String target,
-                                 String startTime) {
-        this.offset = offset;
-        this.totalRows = totalRows;
-        this.id = id;
-        this.database = database;
-        this.docId = docId;
-        this.history = history;
-        this.pid = pid;
-        this.node = node;
-        this.source = source;
-        this.target = target;
-        this.startTime = startTime;
-    }
-
     public long getOffset() {
         return offset;
     }
@@ -95,14 +79,9 @@ public class SchedulerJobsResponse {
         return startTime;
     }
 
-    static class History {
+    public static class History {
         private String timestamp;
         private String type;
-
-        public History(String timestamp, String type) {
-            this.timestamp = timestamp;
-            this.type = type;
-        }
 
         public String getTimestamp() {
             return timestamp;

--- a/cloudant-client/src/main/java/com/cloudant/client/api/scheduler/SchedulerJobsResponse.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/scheduler/SchedulerJobsResponse.java
@@ -88,7 +88,11 @@ public class SchedulerJobsResponse {
         }
 
         public Date getStartTime() {
-            return (Date)startTime.clone();
+            if (startTime != null) {
+                return (Date) startTime.clone();
+            } else {
+                return null;
+            }
         }
 
     }
@@ -98,7 +102,11 @@ public class SchedulerJobsResponse {
         private String type;
 
         public Date getTimestamp() {
-            return (Date)timestamp.clone();
+            if (timestamp != null) {
+                return (Date) timestamp.clone();
+            } else {
+                return null;
+            }
         }
 
         public String getType() {

--- a/cloudant-client/src/main/java/com/cloudant/client/api/scheduler/SchedulerJobsResponse.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/scheduler/SchedulerJobsResponse.java
@@ -88,7 +88,7 @@ public class SchedulerJobsResponse {
         }
 
         public Date getStartTime() {
-            return startTime;
+            return (Date)startTime.clone();
         }
 
     }
@@ -98,7 +98,7 @@ public class SchedulerJobsResponse {
         private String type;
 
         public Date getTimestamp() {
-            return timestamp;
+            return (Date)timestamp.clone();
         }
 
         public String getType() {

--- a/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/CouchDbClient.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/CouchDbClient.java
@@ -312,7 +312,7 @@ public class CouchDbClient {
      * @param docId The replication document ID
      * @return Replication document state
      */
-    public SchedulerDocsResponse.Doc schedulerDocs(String docId) {
+    public SchedulerDocsResponse.Doc schedulerDoc(String docId) {
         assertNotEmpty(docId, "docId");
         return this.get(new DatabaseURIHelper(getBaseUri()).
                         path("_scheduler").path("docs").path("_replicator").path(docId).build(),

--- a/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/CouchDbClient.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/CouchDbClient.java
@@ -287,7 +287,7 @@ public class CouchDbClient {
      * description will include source and target information, replication id, a history of
      * recent event, and a few other things.
      *
-     * @return List of replication jobs
+     * @return All current replication jobs
      */
     public SchedulerJobsResponse schedulerJobs() {
         return this.get(new DatabaseURIHelper(getBaseUri()).path("_scheduler").path("jobs").build(),
@@ -295,11 +295,11 @@ public class CouchDbClient {
     }
 
     /**
-     * Lists replication document states. Includes information about all the documents, even in
+     * Lists replication documents. Includes information about all the documents, even in
      * completed and failed states. For each document it returns the document ID, the database,
      * the replication ID, source and target, and other information.
      *
-     * @return List of replication document states
+     * @return All replication documents
      */
     public SchedulerDocsResponse schedulerDocs() {
         return this.get(new DatabaseURIHelper(getBaseUri()).path("_scheduler").path("docs").build(),
@@ -310,7 +310,7 @@ public class CouchDbClient {
      * Get replication document state for a given replication document ID.
      *
      * @param docId The replication document ID
-     * @return Replication document state
+     * @return Replication document for {@code docId}
      */
     public SchedulerDocsResponse.Doc schedulerDoc(String docId) {
         assertNotEmpty(docId, "docId");

--- a/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/CouchDbClient.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/CouchDbClient.java
@@ -22,6 +22,8 @@ import static com.cloudant.client.org.lightcouch.internal.CouchDbUtil.getAsStrin
 import static com.cloudant.client.org.lightcouch.internal.CouchDbUtil.getResponse;
 
 import com.cloudant.client.api.model.MetaInformation;
+import com.cloudant.client.api.scheduler.SchedulerDocsResponse;
+import com.cloudant.client.api.scheduler.SchedulerJobsResponse;
 import com.cloudant.client.internal.DatabaseURIHelper;
 import com.cloudant.client.internal.URIBase;
 import com.cloudant.client.internal.util.DeserializationTypes;
@@ -275,6 +277,46 @@ public class CouchDbClient {
      */
     public Replicator replicator() {
         return new Replicator(this);
+    }
+
+
+    /**
+     * Lists replication jobs. Includes replications created via /_replicate endpoint as well as
+     * those created from replication documents. Does not include replications which have
+     * completed or have failed to start because replication documents were malformed. Each job
+     * description will include source and target information, replication id, a history of
+     * recent event, and a few other things.
+     *
+     * @return List of replication jobs
+     */
+    public SchedulerJobsResponse schedulerJobs() {
+        return this.get(new DatabaseURIHelper(getBaseUri()).path("_scheduler").path("jobs").build(),
+                SchedulerJobsResponse.class);
+    }
+
+    /**
+     * Lists replication document states. Includes information about all the documents, even in
+     * completed and failed states. For each document it returns the document ID, the database,
+     * the replication ID, source and target, and other information.
+     *
+     * @return List of replication document states
+     */
+    public SchedulerDocsResponse schedulerDocs() {
+        return this.get(new DatabaseURIHelper(getBaseUri()).path("_scheduler").path("docs").build(),
+                SchedulerDocsResponse.class);
+    }
+
+    /**
+     * Get replication document state for a given replication document ID.
+     *
+     * @param docId The replication document ID
+     * @return Replication document state
+     */
+    public SchedulerDocsResponse.Doc schedulerDocs(String docId) {
+        assertNotEmpty(docId, "docId");
+        return this.get(new DatabaseURIHelper(getBaseUri()).
+                        path("_scheduler").path("docs").path("_replicator").path(docId).build(),
+                SchedulerDocsResponse.Doc.class);
     }
 
     /**

--- a/cloudant-client/src/test/java/com/cloudant/tests/ReplicatorTest.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/ReplicatorTest.java
@@ -58,8 +58,8 @@ public class ReplicatorTest extends TestWithReplication {
                 .save();
 
         // find and remove replicator doc
-        ReplicatorDocument repDoc = Utils.waitForReplicatorToComplete(account, response.getId());
-        assertTrue("completed".equalsIgnoreCase(repDoc.getReplicationState()), "The replicator " +
+        String state = Utils.waitForReplicatorToComplete(account, response.getId());
+        assertTrue("completed".equalsIgnoreCase(state), "The replicator " +
                 "should reach completed state");
     }
 
@@ -78,8 +78,8 @@ public class ReplicatorTest extends TestWithReplication {
                 .save();
 
         // find and remove replicator doc
-        ReplicatorDocument repDoc = Utils.waitForReplicatorToComplete(account, response.getId());
-        assertTrue("completed".equalsIgnoreCase(repDoc.getReplicationState()), "The replicator " +
+        String state = Utils.waitForReplicatorToComplete(account, response.getId());
+        assertTrue("completed".equalsIgnoreCase(state), "The replicator " +
                 "should reach completed state");
     }
 

--- a/cloudant-client/src/test/java/com/cloudant/tests/SchedulerTests.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/SchedulerTests.java
@@ -1,0 +1,133 @@
+package com.cloudant.tests;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import com.cloudant.client.api.scheduler.SchedulerDocsResponse;
+import com.cloudant.client.api.scheduler.SchedulerJobsResponse;
+import com.cloudant.tests.base.TestWithMockedServer;
+
+import org.junit.jupiter.api.Test;
+
+import okhttp3.mockwebserver.MockResponse;
+
+public class SchedulerTests extends TestWithMockedServer {
+
+    @Test
+    public void schedulerJobsTest() {
+        String schedulerJobsPayload = "{\"total_rows\":1,\"offset\":0," +
+                "\"jobs\":[{\"database\":null," +
+                "\"id\":\"f11105eaaded4981d21ff8ebf846f48b+create_target\"," +
+                "\"pid\":\"<0.5866.6800>\"," +
+                "\"source\":\"https://clientlibs-test:*****@clientlibs-test.cloudant" +
+                ".com/largedb1g/\",\"target\":\"https://tomblench:*****@tomblench.cloudant" +
+                ".com/largedb1g/\",\"user\":\"tomblench\",\"doc_id\":null," +
+                "\"history\":[{\"timestamp\":\"2018-04-12T13:06:20Z\",\"type\":\"started\"}," +
+                "{\"timestamp\":\"2018-04-12T13:06:20Z\",\"type\":\"added\"}]," +
+                "\"node\":\"dbcore@db2.bigblue.cloudant.net\"," +
+                "\"start_time\":\"2018-04-12T13:06:20Z\"}]}";
+        server.enqueue(new MockResponse().setResponseCode(200).setBody(schedulerJobsPayload));
+        SchedulerJobsResponse response = client.schedulerJobs();
+        assertNotNull(response.getJobs());
+        assertThat(response.getTotalRows(), is(1L));
+        assertThat(response.getJobs(), hasSize(1));
+        for (SchedulerJobsResponse.Job job : response.getJobs()) {
+            assertNotNull(job.getHistory());
+            assertNotNull(job.getId());
+            assertNotNull(job.getNode());
+            assertNotNull(job.getPid());
+            assertNotNull(job.getSource());
+            assertNotNull(job.getStartTime());
+            assertNotNull(job.getTarget());
+            assertNotNull(job.getUser());
+        }
+    }
+
+    @Test
+    public void schedulerDocsTest() {
+        String schedulerDocsPayload = "{\"total_rows\":6,\"offset\":0,\"docs\":[\n" +
+                "{\"database\":\"tomblench/_replicator\"," +
+                "\"doc_id\":\"296e48244e003eba8764b2156b3bf302\",\"id\":null," +
+                "\"source\":\"https://tomblench.cloudant.com/animaldb/\"," +
+                "\"target\":\"https://tomblench.cloudant.com/animaldb_copy/\"," +
+                "\"state\":\"completed\",\"error_count\":0,\"info\":{\"revisions_checked\":15," +
+                "\"missing_revisions_found\":2,\"docs_read\":2,\"docs_written\":2," +
+                "\"changes_pending\":null,\"doc_write_failures\":0," +
+                "\"checkpointed_source_seq\":\"19" +
+                "-g1AAAAGjeJyVz10KwjAMB_BoJ4KX8AZF2tWPJ3eVpqnO0XUg27PeTG9Wa_VhwmT6kkDIPz_iACArGcGS0DRnWxDmHE9HdJ3lxjUdad9yb1sXF6cacB9CqEqmZ3UczKUh2uGhHxeD8U9i_Z3AIla8vJVJUlBIZYTqX5A_KMM7SfFZrHCNLUK3p7RIkl5tSRD-K6kx6f6S0k8sScpYJTb5uFQ9AI9Ch9c\"},\"start_time\":null,\"last_updated\":\"2017-04-13T14:53:50+00:00\"},\n" +
+                "{\"database\":\"tomblench/_replicator\"," +
+                "\"doc_id\":\"3b749f320867d703550b0f758a4000ae\",\"id\":null," +
+                "\"source\":\"https://examples.cloudant.com/animaldb/\"," +
+                "\"target\":\"https://tomblench.cloudant.com/animaldb/\",\"state\":\"completed\"," +
+                "\"error_count\":0,\"info\":{\"revisions_checked\":15," +
+                "\"missing_revisions_found\":15,\"docs_read\":15,\"docs_written\":15," +
+                "\"changes_pending\":null,\"doc_write_failures\":0," +
+                "\"checkpointed_source_seq\":\"56" +
+                "-g1AAAAGveJzLYWBgYMlgTmFQSElKzi9KdUhJstDLTS3KLElMT9VLzskvTUnMK9HLSy3JAapkSmRIsv___39WBnMiby5QgN04JS3FLDUJWb8Jdv0gSxThigyN8diS5AAkk-qhFvFALEo2MTEwMSXGDDSbTPHYlMcCJBkagBTQsv0g28TBtpkbGCQapaF4C4cxJFt2AGIZ2GscYMuMDEzMUizMkC0zw25MFgBKoovi\"},\"start_time\":null,\"last_updated\":\"2017-04-27T12:28:44+00:00\"},\n" +
+                "{\"database\":\"tomblench/_replicator\"," +
+                "\"doc_id\":\"ad8f7896480b8081c8f0a2267ffd1859\",\"id\":null," +
+                "\"source\":\"https://tortytherlediffecareette:*****@mikerhodestesty008.cloudant" +
+                ".com/moviesdb/\",\"target\":\"https://tomblench.cloudant.com/moviesdb_rep/\"," +
+                "\"state\":\"completed\",\"error_count\":0,\"info\":{\"revisions_checked\":5997," +
+                "\"missing_revisions_found\":5997,\"docs_read\":5997,\"docs_written\":5997," +
+                "\"changes_pending\":null,\"doc_write_failures\":0," +
+                "\"checkpointed_source_seq\":\"5997" +
+                "-g1AAAANreJy10UEKwjAQAMBgBcVP2BeUpEm1PdmfaDYJSKkVtB486U_0J_oBTz5AHyAI3jxIjUml1x7ayy67LDssmyKE-nNHIleCWK5ULIF6uVrnW4xDT6TLjeRZ7mUqT_VkhyMYFkWRzB3Q1XOhez3iczKKghor6jvg6giTiroYiuNQYYqbpeIfNa2oh72KhQGosFlq9qN2FfUyFPgUCKONUllXR7TXSWuHkvsYjjEWjQVvgTta7lRyV_szKgmRbVx3ttzNcs7AcEoKCHAb3N1y_9-9DYeBYzEiNTYlX3EcE0s\"},\"start_time\":null,\"last_updated\":\"2016-08-23T13:11:26+00:00\"},\n" +
+                "{\"database\":\"tomblench/_replicator\"," +
+                "\"doc_id\":\"b63c053ecd95a4047b55ed8847b046f1\",\"id\":null," +
+                "\"source\":\"https://tomblench.cloudant.com/atestdb2/\"," +
+                "\"target\":\"https://tomblench.cloudant.com/atestdb1/\",\"state\":\"completed\"," +
+                "\"error_count\":0,\"info\":{\"revisions_checked\":1," +
+                "\"missing_revisions_found\":1,\"docs_read\":1,\"docs_written\":1," +
+                "\"changes_pending\":null,\"doc_write_failures\":0," +
+                "\"checkpointed_source_seq\":\"2" +
+                "-g1AAAAFHeJyNjkEOgjAQRSdAYjyFN2jSFCtdyVU6nSKQWhJC13ozvVktsoEF0c2fTPL_" +
+                "-98BQNHmBCdCM4y2JuQMuxu6YJlxQyDtJ-bt5JIx04DXGGOvYRsR-xGsk" +
+                "-JjTrW5hnv6Dg0XplRngmPwZJvOW9ry5D7PF0nhmU5CvmZm9mVKVVacLr8pfy9fmt5L02q9qEhJbtbr" +
+                "-w-AQmfD\"},\"start_time\":null,\"last_updated\":\"2017-05-16T16:25:22+00:00\"}," +
+                "\n" +
+                "{\"database\":\"tomblench/_replicator\"," +
+                "\"doc_id\":\"c71c9e69e30a182dc91d8938277bc85e\",\"id\":null," +
+                "\"source\":\"https://tomblench.cloudant.com/animaldb/\"," +
+                "\"target\":\"https://tomblench.cloudant.com/animaldb_copy/\"," +
+                "\"state\":\"completed\",\"error_count\":0,\"info\":{\"revisions_checked\":15," +
+                "\"missing_revisions_found\":15,\"docs_read\":15,\"docs_written\":15," +
+                "\"changes_pending\":null,\"doc_write_failures\":0," +
+                "\"checkpointed_source_seq\":\"14" +
+                "-g1AAAAEueJzLYWBgYMlgTmGQSUlKzi9KdUhJMtTLTU1M0UvOyS9NScwr0ctLLckBqmJKZEiy____f1YGUyJrLlCAPdHEPCktJZk43UkOQDKpHmoAI9gAw2STxCTzJOIMyGMBkgwNQApoxv6sDGaoK0yN04wsk80IGEGKHQcgdoAdygxxaIplklFaWhYAu2FdOA\"},\"start_time\":null,\"last_updated\":\"2015-05-12T11:47:33+00:00\"},\n" +
+                "{\"database\":\"tomblench/_replicator\"," +
+                "\"doc_id\":\"e6242d1e9ce059b0388fc75af3116a39\",\"id\":null," +
+                "\"source\":\"https://tomblench.cloudant.com/atestdb1/\"," +
+                "\"target\":\"https://tomblench.cloudant.com/atestdb2/\",\"state\":\"completed\"," +
+                "\"error_count\":0,\"info\":{\"revisions_checked\":1," +
+                "\"missing_revisions_found\":1,\"docs_read\":1,\"docs_written\":1," +
+                "\"changes_pending\":null,\"doc_write_failures\":0," +
+                "\"checkpointed_source_seq\":\"1" +
+                "-g1AAAAFheJyFzkEOgjAQBdBRSIyn8AZNgEJgJVeZ6bQCqSUhdK0305th1Q1dEDYzyWTy_rcAkHYJw4VJjZNumQpB_Y2s10LZ0TO6WTg92_B4RKDrsixDlyDcw-FUVUiFahjO3rE2vdMcY9k2Rm2Y9Ig8bWqspdz25Lbn0jDhGVYgX1_z8DMblnlp8n0lTir3kt7_pFV7NE2WYbluP3wATr5vQA\"},\"start_time\":null,\"last_updated\":\"2017-05-16T16:24:02+00:00\"}\n" +
+                "]}\n";
+        server.enqueue(new MockResponse().setResponseCode(200).setBody(schedulerDocsPayload));
+        SchedulerDocsResponse response = client.schedulerDocs();
+        assertNotNull(response.getDocs());
+        assertThat(response.getTotalRows(), is(6L));
+        assertThat(response.getDocs(), hasSize(6));
+        for (SchedulerDocsResponse.Doc doc : response.getDocs()) {
+            assertNotNull(doc.getDatabase());
+            assertNotNull(doc.getDocId());
+            assertNotNull(doc.getInfo());
+            assertNotNull(doc.getLastUpdated());
+            assertNotNull(doc.getSource());
+            assertNotNull(doc.getState());
+            assertNotNull(doc.getTarget());
+            assertNotNull(doc.getInfo().get("revisions_checked"));
+            assertNotNull(doc.getInfo().get("missing_revisions_found"));
+            assertNotNull(doc.getInfo().get("docs_read"));
+            assertNotNull(doc.getInfo().get("docs_written"));
+            assertNotNull(doc.getInfo().get("doc_write_failures"));
+            assertNotNull(doc.getInfo().get("checkpointed_source_seq"));
+        }
+
+    }
+
+}

--- a/cloudant-client/src/test/java/com/cloudant/tests/util/Utils.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/util/Utils.java
@@ -115,7 +115,7 @@ public class Utils {
 
             if (account.metaInformation().getFeatures() != null &&
                     account.metaInformation().getFeatures().contains("scheduler")) {
-                SchedulerDocsResponse.Doc doc = account.schedulerDocs(replicatorDocId);
+                SchedulerDocsResponse.Doc doc = account.schedulerDoc(replicatorDocId);
                 state = doc != null ? doc.getState() : null;
             } else {
                 replicatorDoc = account.replicator()

--- a/cloudant-client/src/test/java/com/cloudant/tests/util/Utils.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/util/Utils.java
@@ -106,7 +106,6 @@ public class Utils {
         //initial wait of 100 ms
         long delay = 100;
 
-        boolean finished = false;
         while (System.currentTimeMillis() < timeout) {
             //Sleep before finding replication document
             Thread.sleep(delay);


### PR DESCRIPTION
## What

Add support for `/_scheduler/docs` and `/_scheduler/jobs` endpoints.

Tests will now run correctly on Couch 2.0 with update_docs=false.

## Testing

Fixed tests in `ReplicatorTest`.
