### PR TITLE
419 support iam auth in replications

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
   - `CloudantClient.schedulerDoc(docId)`.
 - [NEW] Add `ComplexKey.addHighSentinel()` to allow matching of all values as part of a complex key
   range.
+- [NEW] Support IAM authentication in replication documents.
 - [IMPROVED] When making view requests (including `_all_docs`), set `keys` in the `POST` body rather
   than in `GET` query parameters. This is because a large number of keys could previously exceed the
   maximum URL length, causing errors.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@
 - [FIXED] An issue where `getReason()` returned an incorrect value for `Response` objects returned
   by `Database.bulk()`.
 - [FIXED] Issues retrieving deleted documents using an `AllDocsRequest`.
+- [DEPRECATED] OAuth authentication API `targetOauth` on the `Replication` class.
 
 # 2.12.0 (2018-02-08)
 - [NEW] Index creation APIs and builders including support for text and partial indexes.

--- a/cloudant-client/src/main/java/com/cloudant/client/api/Replication.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/Replication.java
@@ -183,6 +183,32 @@ public class Replication {
     }
 
     /**
+     * Sets the
+     * <a href="https://console.bluemix.net/docs/services/Cloudant/guides/iam.html#ibm-cloud-identity-and-access-management"
+     * target="_blank">IAM</a> API key for the replication source.
+     *
+     * @param iamApiKey IAM API Key
+     * @return this Replication instance to set more options or trigger the replication
+     */
+    public Replication sourceIamApiKey(String iamApiKey) {
+        this.replication = replication.sourceIamApiKey(iamApiKey);
+        return this;
+    }
+
+    /**
+     * Sets the
+     * <a href="https://console.bluemix.net/docs/services/Cloudant/guides/iam.html#ibm-cloud-identity-and-access-management"
+     * target="_blank">IAM</a> API key for the replication target.
+     *
+     * @param iamApiKey IAM API Key
+     * @return this Replication instance to set more options or trigger the replication
+     */
+    public Replication targetIamApiKey(String iamApiKey) {
+        this.replication = replication.targetIamApiKey(iamApiKey);
+        return this;
+    }
+
+    /**
      * Set OAuth 1 authentication credentials for the replication target
      *
      * @param consumerSecret client secret

--- a/cloudant-client/src/main/java/com/cloudant/client/api/Replicator.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/Replicator.java
@@ -229,5 +229,14 @@ public class Replicator {
         return this;
     }
 
+    public Replicator sourceIamApiKey(String iamApiKey) {
+        this.replicator = replicator.sourceIamApiKey(iamApiKey);
+        return this;
+    }
+
+    public Replicator targetIamApiKey(String iamApiKey) {
+        this.replicator = replicator.targetIamApiKey(iamApiKey);
+        return this;
+    }
 
 }

--- a/cloudant-client/src/main/java/com/cloudant/client/api/model/ReplicatorDocument.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/model/ReplicatorDocument.java
@@ -151,6 +151,14 @@ public class ReplicatorDocument {
         return replicatorDocument.getRetriesPerRequest();
     }
 
+    public String getSourceIamApiKey() {
+        return replicatorDocument.getSourceIamApiKey();
+    }
+
+    public String getTargetIamApiKey() {
+        return replicatorDocument.getTargetIamApiKey();
+    }
+
     public void setSource(String source) {
         replicatorDocument.setSource(source);
     }
@@ -227,6 +235,13 @@ public class ReplicatorDocument {
         replicatorDocument.setSinceSeq(sinceSeq);
     }
 
+    public void setSourceIamApiKey(String iamApiKey) {
+        replicatorDocument.setSourceIamApiKey(iamApiKey);
+    }
+
+    public void setTargetIamApiKey(String iamApiKey) {
+        replicatorDocument.setTargetIamApiKey(iamApiKey);
+    }
 
     public static class UserCtx {
         private com.cloudant.client.org.lightcouch.ReplicatorDocument.UserCtx userCtx;

--- a/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/Replication.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/Replication.java
@@ -192,10 +192,21 @@ public class Replication {
         return this;
     }
 
+    /**
+     * Authenticate with the target database using OAuth.
+     *
+     * @param consumerSecret consumer secret
+     * @param consumerKey consumer key
+     * @param tokenSecret token secret
+     * @param token token
+     * @return this Replication instance to set more options
+     * @deprecated OAuth 1.0 implementation has been <a href="http://docs.couchdb.org/en/stable/whatsnew/2.1.html?highlight=oauth#upgrade-notes"
+     * target="_blank">removed in CouchDB 2.1</a>
+     */
     public Replication targetOauth(String consumerSecret, String consumerKey, String tokenSecret,
                                    String token) {
         targetOauth = new JsonObject();
-        this.consumerSecret = consumerKey;
+        this.consumerSecret = consumerSecret;
         this.consumerKey = consumerKey;
         this.tokenSecret = tokenSecret;
         this.token = token;

--- a/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/Replicator.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/Replicator.java
@@ -277,4 +277,14 @@ public class Replicator {
         replicatorDoc.setSinceSeq(sinceSeq);
         return this;
     }
+
+    public Replicator sourceIamApiKey(String iamApiKey) {
+        replicatorDoc.setSourceIamApiKey(iamApiKey);
+        return this;
+    }
+
+    public Replicator targetIamApiKey(String iamApiKey) {
+        replicatorDoc.setTargetIamApiKey(iamApiKey);
+        return this;
+    }
 }

--- a/cloudant-client/src/test/java/com/cloudant/tests/HttpIamTest.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/HttpIamTest.java
@@ -17,6 +17,7 @@ package com.cloudant.tests;
 import static com.cloudant.tests.HttpTest.takeN;
 import static com.cloudant.tests.util.MockWebServerResources.EXPECTED_OK_COOKIE;
 import static com.cloudant.tests.util.MockWebServerResources.EXPECTED_OK_COOKIE_2;
+import static com.cloudant.tests.util.MockWebServerResources.IAM_API_KEY;
 import static com.cloudant.tests.util.MockWebServerResources.IAM_TOKEN;
 import static com.cloudant.tests.util.MockWebServerResources.IAM_TOKEN_2;
 import static com.cloudant.tests.util.MockWebServerResources.OK_IAM_COOKIE;
@@ -61,7 +62,6 @@ public class HttpIamTest {
     public MockWebServerExtension mockIamServerExt = new MockWebServerExtension();
 
     final static String hello = "{\"hello\":\"world\"}\r\n";
-    final static String iamApiKey = "iam";
     final static String iamTokenEndpoint = "/identity/token";
 
     public MockWebServer mockWebServer;
@@ -108,7 +108,7 @@ public class HttpIamTest {
         mockIamServer.enqueue(new MockResponse().setResponseCode(200).setBody(IAM_TOKEN));
 
         CloudantClient c = CloudantClientHelper.newMockWebServerClientBuilder(mockWebServer)
-                .iamApiKey(iamApiKey)
+                .iamApiKey(IAM_API_KEY)
                 .build();
 
         String response = c.executeRequest(Http.GET(c.getBaseUri())).responseAsString();
@@ -140,7 +140,7 @@ public class HttpIamTest {
                         "/identity/token");
         assertThat("The request body should contain the IAM API key",
                 recordedIamRequests[0].getBody().readString(Charset.forName("UTF-8")),
-                containsString("apikey=" + iamApiKey));
+                containsString("apikey=" + IAM_API_KEY));
     }
 
     /**
@@ -164,7 +164,7 @@ public class HttpIamTest {
         CloudantClient c = CloudantClientHelper.newMockWebServerClientBuilder(mockWebServer)
                 .username("username")
                 .password("password")
-                .iamApiKey(iamApiKey)
+                .iamApiKey(IAM_API_KEY)
                 .build();
 
         String response = c.executeRequest(Http.GET(c.getBaseUri())).responseAsString();
@@ -196,7 +196,7 @@ public class HttpIamTest {
                         "/identity/token");
         assertThat("The request body should contain the IAM API key",
                 recordedIamRequests[0].getBody().readString(Charset.forName("UTF-8")),
-                containsString("apikey=" + iamApiKey));
+                containsString("apikey=" + IAM_API_KEY));
     }
 
     /**
@@ -231,7 +231,7 @@ public class HttpIamTest {
         mockIamServer.enqueue(new MockResponse().setResponseCode(200).setBody(IAM_TOKEN_2));
 
         CloudantClient c = CloudantClientHelper.newMockWebServerClientBuilder(mockWebServer)
-                .iamApiKey(iamApiKey)
+                .iamApiKey(IAM_API_KEY)
                 .build();
 
         String response = c.executeRequest(Http.GET(c.getBaseUri())).responseAsString();
@@ -292,7 +292,7 @@ public class HttpIamTest {
                         "/identity/token");
         assertThat("The request body should contain the IAM API key",
                 recordedIamRequests[0].getBody().readString(Charset.forName("UTF-8")),
-                containsString("apikey=" + iamApiKey));
+                containsString("apikey=" + IAM_API_KEY));
         // second time, refresh because the cloudant session cookie has expired
         assertEquals(iamTokenEndpoint,
                 recordedIamRequests[1].getPath(), "The request should have been for " +
@@ -328,7 +328,7 @@ public class HttpIamTest {
         mockIamServer.enqueue(new MockResponse().setResponseCode(500));
 
         CloudantClient c = CloudantClientHelper.newMockWebServerClientBuilder(mockWebServer)
-                .iamApiKey(iamApiKey)
+                .iamApiKey(IAM_API_KEY)
                 .build();
 
         String response = c.executeRequest(Http.GET(c.getBaseUri())).responseAsString();
@@ -381,7 +381,7 @@ public class HttpIamTest {
                         "/identity/token");
         assertThat("The request body should contain the IAM API key",
                 recordedIamRequests[0].getBody().readString(Charset.forName("UTF-8")),
-                containsString("apikey=" + iamApiKey));
+                containsString("apikey=" + IAM_API_KEY));
         // second time, refresh (but gets 500) because the cloudant session cookie has expired
         assertEquals(iamTokenEndpoint,
                 recordedIamRequests[1].getPath(), "The request should have been for " +
@@ -418,7 +418,7 @@ public class HttpIamTest {
         mockIamServer.enqueue(new MockResponse().setResponseCode(200).setBody(IAM_TOKEN_2));
 
         CloudantClient c = CloudantClientHelper.newMockWebServerClientBuilder(mockWebServer)
-                .iamApiKey(iamApiKey)
+                .iamApiKey(IAM_API_KEY)
                 .build();
 
         String response = c.executeRequest(Http.GET(c.getBaseUri())).responseAsString();
@@ -477,7 +477,7 @@ public class HttpIamTest {
                         "/identity/token");
         assertThat("The request body should contain the IAM API key",
                 recordedIamRequests[0].getBody().readString(Charset.forName("UTF-8")),
-                containsString("apikey=" + iamApiKey));
+                containsString("apikey=" + IAM_API_KEY));
         // second time, refresh because the cloudant session cookie has expired
         assertEquals(iamTokenEndpoint,
                 recordedIamRequests[1].getPath(), "The request should have been for " +

--- a/cloudant-client/src/test/java/com/cloudant/tests/ReplicationMockTest.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/ReplicationMockTest.java
@@ -15,8 +15,8 @@
 package com.cloudant.tests;
 
 import static com.cloudant.tests.HttpTest.takeN;
-import static com.cloudant.tests.util.MockWebServerResources.EXPECTED_OK_COOKIE;
-import static com.cloudant.tests.util.MockWebServerResources.EXPECTED_OK_COOKIE_2;
+import static com.cloudant.tests.util.MockWebServerResources.IAM_API_KEY;
+import static com.cloudant.tests.util.MockWebServerResources.IAM_API_KEY_2;
 import static com.cloudant.tests.util.MockWebServerResources.JSON_OK;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -75,7 +75,7 @@ public class ReplicationMockTest extends TestWithMockedServer {
 
         c.replication()
                 .source(sourceDbUrl)
-                .sourceIamApiKey(EXPECTED_OK_COOKIE)
+                .sourceIamApiKey(IAM_API_KEY)
                 .target(targetDbUrl)
                 .trigger();
 
@@ -86,7 +86,7 @@ public class ReplicationMockTest extends TestWithMockedServer {
         String body = requests[0].getBody().readUtf8();
 
         assertThat("The replication document should contain the source IAM API key",
-                body, containsString(authJson + EXPECTED_OK_COOKIE));
+                body, containsString(authJson + IAM_API_KEY));
 
         assertThat("The replication document should contain the correct target",
                 body, containsString("\"target\":\"" + targetDbUrl + "\""));
@@ -102,7 +102,7 @@ public class ReplicationMockTest extends TestWithMockedServer {
         c.replication()
                 .source(sourceDbUrl)
                 .target(targetDbUrl)
-                .targetIamApiKey(EXPECTED_OK_COOKIE_2)
+                .targetIamApiKey(IAM_API_KEY)
                 .trigger();
 
         RecordedRequest[] requests = takeN(server, 1);
@@ -115,7 +115,7 @@ public class ReplicationMockTest extends TestWithMockedServer {
                 body, containsString("\"source\":\"" + sourceDbUrl + "\""));
 
         assertThat("The replication document should contain the correct target",
-                body, containsString(authJson + EXPECTED_OK_COOKIE_2));
+                body, containsString(authJson + IAM_API_KEY));
     }
 
     @Test
@@ -127,9 +127,9 @@ public class ReplicationMockTest extends TestWithMockedServer {
 
         c.replication()
                 .source(sourceDbUrl)
-                .sourceIamApiKey(EXPECTED_OK_COOKIE)
+                .sourceIamApiKey(IAM_API_KEY)
                 .target(targetDbUrl)
-                .targetIamApiKey(EXPECTED_OK_COOKIE_2)
+                .targetIamApiKey(IAM_API_KEY_2)
                 .trigger();
 
         RecordedRequest[] requests = takeN(server, 1);
@@ -139,9 +139,9 @@ public class ReplicationMockTest extends TestWithMockedServer {
         String body = requests[0].getBody().readUtf8();
 
         assertThat("The replication document should contain the source IAM API key",
-                body, containsString(authJson + EXPECTED_OK_COOKIE));
+                body, containsString(authJson + IAM_API_KEY));
 
         assertThat("The replication document should contain the target IAM API key",
-                body, containsString(authJson + EXPECTED_OK_COOKIE_2));
+                body, containsString(authJson + IAM_API_KEY_2));
     }
 }

--- a/cloudant-client/src/test/java/com/cloudant/tests/ReplicationMockTest.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/ReplicationMockTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright © 2018 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.tests;
+
+import static com.cloudant.tests.HttpTest.takeN;
+import static com.cloudant.tests.util.MockWebServerResources.EXPECTED_OK_COOKIE;
+import static com.cloudant.tests.util.MockWebServerResources.EXPECTED_OK_COOKIE_2;
+import static com.cloudant.tests.util.MockWebServerResources.JSON_OK;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+
+import com.cloudant.client.api.CloudantClient;
+
+import com.cloudant.tests.base.TestWithMockedServer;
+import org.junit.jupiter.api.Test;
+
+import okhttp3.mockwebserver.RecordedRequest;
+
+import java.nio.charset.Charset;
+
+/**
+ * Created by samsmith on 09/03/2018.
+ */
+
+public class ReplicationMockTest extends TestWithMockedServer {
+
+    final private static String authJson = "\"auth\":{\"iam\":{\"api_key\":\"";
+    final private static String sourceDbUrl = "https://foo.cloudant.com/source";
+    final private static String targetDbUrl = "https://bar.cloudant.com/target";
+
+    @Test
+    public void createAndTriggerReplicationWithNoIamAuth() throws Exception {
+        server.enqueue(JSON_OK);
+
+        CloudantClient c = CloudantClientHelper.newMockWebServerClientBuilder(server)
+                .build();
+
+        c.replication()
+                .source(sourceDbUrl)
+                .target(targetDbUrl)
+                .trigger();
+
+        RecordedRequest[] requests = takeN(server, 1);
+
+        assertEquals(requests[0].getPath(), "/_replicate");
+
+        String body = requests[0].getBody().readUtf8();
+
+        assertThat("The replication document should contain the correct source",
+                body, containsString("\"source\":\"" + sourceDbUrl + "\""));
+
+        assertThat("The replication document should contain the correct target",
+                body, containsString("\"target\":\"" + targetDbUrl + "\""));
+    }
+
+    @Test
+    public void createAndTriggerReplicationWithSourceIamAuth() throws Exception {
+        server.enqueue(JSON_OK);
+
+        CloudantClient c = CloudantClientHelper.newMockWebServerClientBuilder(server)
+                .build();
+
+        c.replication()
+                .source(sourceDbUrl)
+                .sourceIamApiKey(EXPECTED_OK_COOKIE)
+                .target(targetDbUrl)
+                .trigger();
+
+        RecordedRequest[] requests = takeN(server, 1);
+
+        assertEquals(requests[0].getPath(), "/_replicate");
+
+        String body = requests[0].getBody().readUtf8();
+
+        assertThat("The replication document should contain the source IAM API key",
+                body, containsString(authJson + EXPECTED_OK_COOKIE));
+
+        assertThat("The replication document should contain the correct target",
+                body, containsString("\"target\":\"" + targetDbUrl + "\""));
+    }
+
+    @Test
+    public void createAndTriggerReplicationWithTargetIamAuth() throws Exception {
+        server.enqueue(JSON_OK);
+
+        CloudantClient c = CloudantClientHelper.newMockWebServerClientBuilder(server)
+                .build();
+
+        c.replication()
+                .source(sourceDbUrl)
+                .target(targetDbUrl)
+                .targetIamApiKey(EXPECTED_OK_COOKIE_2)
+                .trigger();
+
+        RecordedRequest[] requests = takeN(server, 1);
+
+        assertEquals(requests[0].getPath(), "/_replicate");
+
+        String body = requests[0].getBody().readUtf8();
+
+        assertThat("The replication document should contain the source IAM API key",
+                body, containsString("\"source\":\"" + sourceDbUrl + "\""));
+
+        assertThat("The replication document should contain the correct target",
+                body, containsString(authJson + EXPECTED_OK_COOKIE_2));
+    }
+
+    @Test
+    public void createAndTriggerReplicationWithSourceAndTargetIamAuth() throws Exception {
+        server.enqueue(JSON_OK);
+
+        CloudantClient c = CloudantClientHelper.newMockWebServerClientBuilder(server)
+                .build();
+
+        c.replication()
+                .source(sourceDbUrl)
+                .sourceIamApiKey(EXPECTED_OK_COOKIE)
+                .target(targetDbUrl)
+                .targetIamApiKey(EXPECTED_OK_COOKIE_2)
+                .trigger();
+
+        RecordedRequest[] requests = takeN(server, 1);
+
+        assertEquals(requests[0].getPath(), "/_replicate");
+
+        String body = requests[0].getBody().readUtf8();
+
+        assertThat("The replication document should contain the source IAM API key",
+                body, containsString(authJson + EXPECTED_OK_COOKIE));
+
+        assertThat("The replication document should contain the target IAM API key",
+                body, containsString(authJson + EXPECTED_OK_COOKIE_2));
+    }
+}

--- a/cloudant-client/src/test/java/com/cloudant/tests/ReplicatorMockTest.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/ReplicatorMockTest.java
@@ -1,0 +1,235 @@
+/*
+ * Copyright © 2018 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.tests;
+
+import static com.cloudant.tests.HttpTest.takeN;
+import static com.cloudant.tests.util.MockWebServerResources.EXPECTED_OK_COOKIE;
+import static com.cloudant.tests.util.MockWebServerResources.EXPECTED_OK_COOKIE_2;
+import static com.cloudant.tests.util.MockWebServerResources.JSON_OK;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+
+import com.cloudant.client.api.CloudantClient;
+import com.cloudant.client.api.model.ReplicatorDocument;
+import com.cloudant.tests.util.Utils;
+
+import com.cloudant.tests.base.TestWithMockedServer;
+import org.junit.jupiter.api.Test;
+
+import okhttp3.mockwebserver.RecordedRequest;
+
+import java.nio.charset.Charset;
+
+/**
+ * Created by samsmith on 08/03/2018.
+ */
+
+public class ReplicatorMockTest extends TestWithMockedServer {
+
+    final private static String authJson = "\"auth\":{\"iam\":{\"api_key\":\"";
+    final private static String replicatorDocId = Utils.generateUUID();
+
+    final private static String sourceDbUrl = "https://foo.cloudant.com/source";
+    final private static String targetDbUrl = "https://bar.cloudant.com/target";
+
+    @Test
+    public void createReplicationDocumentReconfigureSource() throws Exception {
+        ReplicatorDocument rep = new ReplicatorDocument();
+
+        rep.setSource(sourceDbUrl);
+        assertEquals(rep.getSource(), sourceDbUrl);
+
+        rep.setSourceIamApiKey(EXPECTED_OK_COOKIE);
+        assertEquals(rep.getSource(), sourceDbUrl);
+        assertEquals(rep.getSourceIamApiKey(), EXPECTED_OK_COOKIE);
+
+        // reconfigure source
+
+        rep.setSource(targetDbUrl);
+        assertEquals(rep.getSource(), targetDbUrl);
+
+        rep.setSourceIamApiKey(EXPECTED_OK_COOKIE_2);
+        assertEquals(rep.getSourceIamApiKey(), EXPECTED_OK_COOKIE_2);
+    }
+
+    @Test
+    public void createReplicationDocumentReconfigureTarget() throws Exception {
+        ReplicatorDocument rep = new ReplicatorDocument();
+
+        rep.setTarget(targetDbUrl);
+        assertEquals(rep.getTarget(), targetDbUrl);
+
+        rep.setTargetIamApiKey(EXPECTED_OK_COOKIE);
+        assertEquals(rep.getTarget(), targetDbUrl);
+        assertEquals(rep.getTargetIamApiKey(), EXPECTED_OK_COOKIE);
+
+        // reconfigure target
+
+        rep.setTarget(sourceDbUrl);
+        assertEquals(rep.getTarget(), sourceDbUrl);
+
+        rep.setTargetIamApiKey(EXPECTED_OK_COOKIE_2);
+        assertEquals(rep.getTargetIamApiKey(), EXPECTED_OK_COOKIE_2);
+    }
+
+    @Test
+    public void createReplicationReconfigureSourceSetIamApiKeyFirst() throws Exception {
+        ReplicatorDocument rep = new ReplicatorDocument();
+
+        rep.setSourceIamApiKey(EXPECTED_OK_COOKIE);
+        assertEquals(rep.getSourceIamApiKey(), EXPECTED_OK_COOKIE);
+
+        rep.setSource(sourceDbUrl);
+        assertEquals(rep.getSource(), sourceDbUrl);
+        assertEquals(rep.getSourceIamApiKey(), EXPECTED_OK_COOKIE);
+
+        // reconfigure source
+
+        rep.setSourceIamApiKey(EXPECTED_OK_COOKIE_2);
+        assertEquals(rep.getSourceIamApiKey(), EXPECTED_OK_COOKIE_2);
+
+        rep.setSource(targetDbUrl);
+        assertEquals(rep.getSource(), targetDbUrl);
+    }
+
+    @Test
+    public void createReplicationReconfigureTargetSetIamApiKeyFirst() throws Exception {
+        ReplicatorDocument rep = new ReplicatorDocument();
+
+        rep.setTargetIamApiKey(EXPECTED_OK_COOKIE);
+        assertEquals(rep.getTargetIamApiKey(), EXPECTED_OK_COOKIE);
+
+        rep.setTarget(targetDbUrl);
+        assertEquals(rep.getTarget(), targetDbUrl);
+        assertEquals(rep.getTargetIamApiKey(), EXPECTED_OK_COOKIE);
+
+        // reconfigure target
+
+        rep.setTarget(sourceDbUrl);
+        assertEquals(rep.getTarget(), sourceDbUrl);
+
+        rep.setTargetIamApiKey(EXPECTED_OK_COOKIE_2);
+        assertEquals(rep.getTargetIamApiKey(), EXPECTED_OK_COOKIE_2);
+    }
+
+    @Test
+    public void createAndSaveReplicatorDocumentWithNoIamAuth() throws Exception {
+        server.enqueue(JSON_OK);
+
+        CloudantClient c = CloudantClientHelper.newMockWebServerClientBuilder(server)
+                .build();
+
+        c.replicator()
+                .replicatorDocId(replicatorDocId)
+                .source(sourceDbUrl)
+                .target(targetDbUrl)
+                .save();
+
+        RecordedRequest[] requests = takeN(server, 1);
+
+        assertEquals(requests[0].getPath(), "/_replicator/" + replicatorDocId);
+
+        String body = requests[0].getBody().readUtf8();
+
+        assertThat("The replication document should contain the correct source",
+               body, containsString("\"source\":\"" + sourceDbUrl + "\""));
+
+        assertThat("The replication document should contain the correct target",
+                body, containsString("\"target\":\"" + targetDbUrl + "\""));
+    }
+
+    @Test
+    public void createAndSaveReplicatorDocumentWithSourceIamAuth() throws Exception {
+        server.enqueue(JSON_OK);
+
+        CloudantClient c = CloudantClientHelper.newMockWebServerClientBuilder(server)
+                .build();
+
+        c.replicator()
+                .replicatorDocId(replicatorDocId)
+                .source(sourceDbUrl)
+                .sourceIamApiKey(EXPECTED_OK_COOKIE)
+                .target(targetDbUrl)
+                .save();
+
+        RecordedRequest[] requests = takeN(server, 1);
+
+        assertEquals(requests[0].getPath(), "/_replicator/" + replicatorDocId);
+
+        String body = requests[0].getBody().readUtf8();
+
+        assertThat("The replication document should contain the source IAM API key",
+                body, containsString(authJson + EXPECTED_OK_COOKIE));
+
+        assertThat("The replication document should contain the correct target",
+                body, containsString("\"target\":\"" + targetDbUrl + "\""));
+    }
+
+    @Test
+    public void createAndSaveReplicatorDocumentWithTargetIamAuth() throws Exception {
+        server.enqueue(JSON_OK);
+
+        CloudantClient c = CloudantClientHelper.newMockWebServerClientBuilder(server)
+                .build();
+
+        c.replicator()
+                .replicatorDocId(replicatorDocId)
+                .source(sourceDbUrl)
+                .target(targetDbUrl)
+                .targetIamApiKey(EXPECTED_OK_COOKIE_2)
+                .save();
+
+        RecordedRequest[] requests = takeN(server, 1);
+
+        assertEquals(requests[0].getPath(), "/_replicator/" + replicatorDocId);
+
+        String body = requests[0].getBody().readUtf8();
+
+        assertThat("The replication document should contain the source IAM API key",
+                body, containsString("\"source\":\"" + sourceDbUrl + "\""));
+
+        assertThat("The replication document should contain the correct target",
+                body, containsString(authJson + EXPECTED_OK_COOKIE_2));
+    }
+
+    @Test
+    public void createAndSaveReplicatorDocumentWithSourceAndTargetIamAuth() throws Exception {
+        server.enqueue(JSON_OK);
+
+        CloudantClient c = CloudantClientHelper.newMockWebServerClientBuilder(server)
+                .build();
+
+        c.replicator()
+                .replicatorDocId(replicatorDocId)
+                .source(sourceDbUrl)
+                .sourceIamApiKey(EXPECTED_OK_COOKIE)
+                .target(targetDbUrl)
+                .targetIamApiKey(EXPECTED_OK_COOKIE_2)
+                .save();
+
+        RecordedRequest[] requests = takeN(server, 1);
+
+        assertEquals(requests[0].getPath(), "/_replicator/" + replicatorDocId);
+
+        String body = requests[0].getBody().readUtf8();
+
+        assertThat("The replication document should contain the source IAM API key",
+                body, containsString(authJson + EXPECTED_OK_COOKIE));
+
+        assertThat("The replication document should contain the target IAM API key",
+                body, containsString(authJson + EXPECTED_OK_COOKIE_2));
+    }
+}

--- a/cloudant-client/src/test/java/com/cloudant/tests/ReplicatorMockTest.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/ReplicatorMockTest.java
@@ -15,8 +15,8 @@
 package com.cloudant.tests;
 
 import static com.cloudant.tests.HttpTest.takeN;
-import static com.cloudant.tests.util.MockWebServerResources.EXPECTED_OK_COOKIE;
-import static com.cloudant.tests.util.MockWebServerResources.EXPECTED_OK_COOKIE_2;
+import static com.cloudant.tests.util.MockWebServerResources.IAM_API_KEY;
+import static com.cloudant.tests.util.MockWebServerResources.IAM_API_KEY_2;
 import static com.cloudant.tests.util.MockWebServerResources.JSON_OK;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -52,17 +52,17 @@ public class ReplicatorMockTest extends TestWithMockedServer {
         rep.setSource(sourceDbUrl);
         assertEquals(rep.getSource(), sourceDbUrl);
 
-        rep.setSourceIamApiKey(EXPECTED_OK_COOKIE);
+        rep.setSourceIamApiKey(IAM_API_KEY);
         assertEquals(rep.getSource(), sourceDbUrl);
-        assertEquals(rep.getSourceIamApiKey(), EXPECTED_OK_COOKIE);
+        assertEquals(rep.getSourceIamApiKey(), IAM_API_KEY);
 
         // reconfigure source
 
         rep.setSource(targetDbUrl);
         assertEquals(rep.getSource(), targetDbUrl);
 
-        rep.setSourceIamApiKey(EXPECTED_OK_COOKIE_2);
-        assertEquals(rep.getSourceIamApiKey(), EXPECTED_OK_COOKIE_2);
+        rep.setSourceIamApiKey(IAM_API_KEY_2);
+        assertEquals(rep.getSourceIamApiKey(), IAM_API_KEY_2);
     }
 
     @Test
@@ -72,34 +72,34 @@ public class ReplicatorMockTest extends TestWithMockedServer {
         rep.setTarget(targetDbUrl);
         assertEquals(rep.getTarget(), targetDbUrl);
 
-        rep.setTargetIamApiKey(EXPECTED_OK_COOKIE);
+        rep.setTargetIamApiKey(IAM_API_KEY);
         assertEquals(rep.getTarget(), targetDbUrl);
-        assertEquals(rep.getTargetIamApiKey(), EXPECTED_OK_COOKIE);
+        assertEquals(rep.getTargetIamApiKey(), IAM_API_KEY);
 
         // reconfigure target
 
         rep.setTarget(sourceDbUrl);
         assertEquals(rep.getTarget(), sourceDbUrl);
 
-        rep.setTargetIamApiKey(EXPECTED_OK_COOKIE_2);
-        assertEquals(rep.getTargetIamApiKey(), EXPECTED_OK_COOKIE_2);
+        rep.setTargetIamApiKey(IAM_API_KEY_2);
+        assertEquals(rep.getTargetIamApiKey(), IAM_API_KEY_2);
     }
 
     @Test
     public void createReplicationReconfigureSourceSetIamApiKeyFirst() throws Exception {
         ReplicatorDocument rep = new ReplicatorDocument();
 
-        rep.setSourceIamApiKey(EXPECTED_OK_COOKIE);
-        assertEquals(rep.getSourceIamApiKey(), EXPECTED_OK_COOKIE);
+        rep.setSourceIamApiKey(IAM_API_KEY);
+        assertEquals(rep.getSourceIamApiKey(), IAM_API_KEY);
 
         rep.setSource(sourceDbUrl);
         assertEquals(rep.getSource(), sourceDbUrl);
-        assertEquals(rep.getSourceIamApiKey(), EXPECTED_OK_COOKIE);
+        assertEquals(rep.getSourceIamApiKey(), IAM_API_KEY);
 
         // reconfigure source
 
-        rep.setSourceIamApiKey(EXPECTED_OK_COOKIE_2);
-        assertEquals(rep.getSourceIamApiKey(), EXPECTED_OK_COOKIE_2);
+        rep.setSourceIamApiKey(IAM_API_KEY_2);
+        assertEquals(rep.getSourceIamApiKey(), IAM_API_KEY_2);
 
         rep.setSource(targetDbUrl);
         assertEquals(rep.getSource(), targetDbUrl);
@@ -109,20 +109,20 @@ public class ReplicatorMockTest extends TestWithMockedServer {
     public void createReplicationReconfigureTargetSetIamApiKeyFirst() throws Exception {
         ReplicatorDocument rep = new ReplicatorDocument();
 
-        rep.setTargetIamApiKey(EXPECTED_OK_COOKIE);
-        assertEquals(rep.getTargetIamApiKey(), EXPECTED_OK_COOKIE);
+        rep.setTargetIamApiKey(IAM_API_KEY);
+        assertEquals(rep.getTargetIamApiKey(), IAM_API_KEY);
 
         rep.setTarget(targetDbUrl);
         assertEquals(rep.getTarget(), targetDbUrl);
-        assertEquals(rep.getTargetIamApiKey(), EXPECTED_OK_COOKIE);
+        assertEquals(rep.getTargetIamApiKey(), IAM_API_KEY);
 
         // reconfigure target
 
         rep.setTarget(sourceDbUrl);
         assertEquals(rep.getTarget(), sourceDbUrl);
 
-        rep.setTargetIamApiKey(EXPECTED_OK_COOKIE_2);
-        assertEquals(rep.getTargetIamApiKey(), EXPECTED_OK_COOKIE_2);
+        rep.setTargetIamApiKey(IAM_API_KEY_2);
+        assertEquals(rep.getTargetIamApiKey(), IAM_API_KEY_2);
     }
 
     @Test
@@ -161,7 +161,7 @@ public class ReplicatorMockTest extends TestWithMockedServer {
         c.replicator()
                 .replicatorDocId(replicatorDocId)
                 .source(sourceDbUrl)
-                .sourceIamApiKey(EXPECTED_OK_COOKIE)
+                .sourceIamApiKey(IAM_API_KEY)
                 .target(targetDbUrl)
                 .save();
 
@@ -172,7 +172,7 @@ public class ReplicatorMockTest extends TestWithMockedServer {
         String body = requests[0].getBody().readUtf8();
 
         assertThat("The replication document should contain the source IAM API key",
-                body, containsString(authJson + EXPECTED_OK_COOKIE));
+                body, containsString(authJson + IAM_API_KEY));
 
         assertThat("The replication document should contain the correct target",
                 body, containsString("\"target\":\"" + targetDbUrl + "\""));
@@ -189,7 +189,7 @@ public class ReplicatorMockTest extends TestWithMockedServer {
                 .replicatorDocId(replicatorDocId)
                 .source(sourceDbUrl)
                 .target(targetDbUrl)
-                .targetIamApiKey(EXPECTED_OK_COOKIE_2)
+                .targetIamApiKey(IAM_API_KEY_2)
                 .save();
 
         RecordedRequest[] requests = takeN(server, 1);
@@ -202,7 +202,7 @@ public class ReplicatorMockTest extends TestWithMockedServer {
                 body, containsString("\"source\":\"" + sourceDbUrl + "\""));
 
         assertThat("The replication document should contain the correct target",
-                body, containsString(authJson + EXPECTED_OK_COOKIE_2));
+                body, containsString(authJson + IAM_API_KEY_2));
     }
 
     @Test
@@ -215,9 +215,9 @@ public class ReplicatorMockTest extends TestWithMockedServer {
         c.replicator()
                 .replicatorDocId(replicatorDocId)
                 .source(sourceDbUrl)
-                .sourceIamApiKey(EXPECTED_OK_COOKIE)
+                .sourceIamApiKey(IAM_API_KEY)
                 .target(targetDbUrl)
-                .targetIamApiKey(EXPECTED_OK_COOKIE_2)
+                .targetIamApiKey(IAM_API_KEY_2)
                 .save();
 
         RecordedRequest[] requests = takeN(server, 1);
@@ -227,9 +227,9 @@ public class ReplicatorMockTest extends TestWithMockedServer {
         String body = requests[0].getBody().readUtf8();
 
         assertThat("The replication document should contain the source IAM API key",
-                body, containsString(authJson + EXPECTED_OK_COOKIE));
+                body, containsString(authJson + IAM_API_KEY));
 
         assertThat("The replication document should contain the target IAM API key",
-                body, containsString(authJson + EXPECTED_OK_COOKIE_2));
+                body, containsString(authJson + IAM_API_KEY_2));
     }
 }

--- a/cloudant-client/src/test/java/com/cloudant/tests/util/MockWebServerResources.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/util/MockWebServerResources.java
@@ -38,6 +38,9 @@ public class MockWebServerResources {
     public static final long TIMEOUT = 10l;
     public static final TimeUnit TIMEOUT_UNIT = TimeUnit.SECONDS;
 
+    public static String IAM_API_KEY = "UQ6ckeialceOOeK03wsUseVx9WLoZ5o7quexi-hOsQ4X";
+    public static String IAM_API_KEY_2 = "YI9dejocvxsBBfH28yDWsoQx9VEyQ9i5cvdek-qCyU1V";
+
     public static final String EXPECTED_OK_COOKIE =
             "a2ltc3RlYmVsOjUxMzRBQTUzOtiY2_IDUIdsTJEVNEjObAbyhrgz";
     public static final String EXPECTED_OK_COOKIE_2 =


### PR DESCRIPTION
Thanks for your hard work, please ensure all items are complete before opening.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://github.com/cloudant/java-cloudant/blob/master/DCO1.1.txt)
- [x] You have added tests for any code changes
- [x] You have updated the [CHANGES.md](https://github.com/cloudant/java-cloudant/blob/master/CHANGES.md) 
- [x] You have completed the PR template below:

## What
Support IAM authentication in replications. For example:

- Via `replicator` database:
```java
client.replicator()
        .source("https://foo.cloudant.com/src")
        .sourceIamApiKey("mysourcedbiamapikey")
        .target("https://bar.cloudant.com/tgt")
        .targetIamApiKey("mytargetdbiamapikey")
        .save();
```
- Via `/_replicate` endpoint:
```
client.replication()
        .source("https://foo.cloudant.com/src")
        .sourceIamApiKey("mysourcedbiamapikey")
        .target("https://bar.cloudant.com/tgt")
        .targetIamApiKey("mytargetdbiamapikey")
        .trigger();
```

## How
Expose new methods on the underlying replication document classes. These add the required IAM API key fields to the generated replication document JSON.

Example IAM authenticated replication document:
```java
{
  "source": { "url": "...", "auth": { "iam": { "api_key": "<key>" } } },
  "target": { "url": "...", "auth": { "iam": { "api_key": "<key>" } } },
}
```

## Testing
Includes additional mock unit tests.

## Issues
Fixes #419.