### PR TITLE
Don't over-write reason for bulk()

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 # Unreleased
 
 - [NEW] Add `CloudantClient.metaInformation()`.
+- [FIXED] An issue where `getReason()` returned an incorrect value for
+  `Response` objects returned by `Database.bulk()`.
 
 # 2.12.0 (2018-02-08)
 - [NEW] Index creation APIs and builders including support for text and partial indexes.

--- a/cloudant-client/src/main/java/com/cloudant/client/api/Database.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/Database.java
@@ -1090,6 +1090,22 @@ public class Database {
      * List<Response> responses = db.bulk(newDocs);
      * }
      * </pre>
+     * <p>
+     * Note that the value returned by {@code getStatusCode()} on each {@code Response} object is
+     * the overall status returned from {@code bulk_docs} and will therefore be the same for all
+     * {@code Response} objects.
+     * </p>
+     * <p>
+     * The returned list of {@code Response}s should be examined to ensure that all of the documents submitted
+     * in the original request were successfully added to the database.
+     * </p>
+     * <p>
+     * When a document (or document revision) is not correctly committed to the database because of
+     * an error, you must check the value of {@code getError()} to determine error type and course
+     * of action. See
+     * <a href="https://console.bluemix.net/docs/services/Cloudant/api/document.html#bulk-document-validation-and-conflict-errors" target="_blank">
+     * Bulk Document Validation and Conflict Errors</a> for more information.
+     * </p>
      *
      * @param objects the {@link List} of objects
      * @return {@code List<Response>} one per object

--- a/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/CouchDatabaseBase.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/CouchDatabaseBase.java
@@ -287,7 +287,6 @@ public abstract class CouchDatabaseBase {
                     DeserializationTypes.LC_RESPONSES);
             for(Response response : bulkResponses) {
                 response.setStatusCode(connection.getConnection().getResponseCode());
-                response.setReason(connection.getConnection().getResponseMessage());
             }
             return bulkResponses;
         }

--- a/cloudant-client/src/test/java/com/cloudant/tests/BulkDocumentTest.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/BulkDocumentTest.java
@@ -15,11 +15,16 @@
 package com.cloudant.tests;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.isOneOf;
 
+import com.cloudant.client.api.model.DesignDocument;
 import com.cloudant.client.api.model.Response;
 import com.cloudant.test.main.RequiresDB;
 import com.cloudant.tests.base.TestWithDbPerClass;
+import com.cloudant.tests.base.TestWithDbPerTest;
 import com.google.gson.JsonObject;
 
 import org.junit.jupiter.api.Test;
@@ -28,7 +33,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @RequiresDB
-public class BulkDocumentTest extends TestWithDbPerClass {
+public class BulkDocumentTest extends TestWithDbPerTest {
 
     @Test
     public void bulkModifyDocs() {
@@ -39,6 +44,42 @@ public class BulkDocumentTest extends TestWithDbPerClass {
         List<Response> responses = db.bulk(newDocs);
 
         assertThat(responses.size(), is(2));
+    }
+
+    @Test
+    public void bulkRejectedByValidation() {
+        // create validation fn
+        DesignDocument ddoc = new DesignDocument();
+        ddoc.setId("_design/validationDesignDoc");
+        ddoc.setValidateDocUpdate("function (newDoc, oldDoc, userCtx, secObj) {\n" +
+                "    if (newDoc['title'] == 'forbidden') {\n" +
+                "        throw({forbidden: 'field cannot be forbidden' });\n" +
+                "    }\n" +
+                "}\n");
+        db.save(ddoc);
+        // create docs, one which will fail validation
+        List<Object> newDocs = new ArrayList<Object>();
+        newDocs.add(new Foo("doc1", "This is the document title"));
+        newDocs.add(new Foo("doc2", "forbidden"));
+        List<Response> responses = db.bulk(newDocs);
+        assertThat(responses, hasSize(2));
+        // Note that the CouchDB documents seem to be contradictory here, 201 always appears to be
+        // returned even if there are documents which fail validation.
+        // The documentation initially states
+        // "417 Expectation Failed – Occurs when at least one document was rejected by a validation
+        // function", but then later states
+        // "The return type from a bulk insertion will be 201 Created, with the content of the
+        // returned structure indicating specific success or otherwise messages on a per-document basis."
+        // Also note that the IBM Cloudant documentation makes no mention of a 417 status code in
+        // the documentation for _bulk_docs.
+        // We check for 201 or 202: "Note: If the write quorum cannot be met during an attempt to
+        // create a document, a 202 response is returned."
+        assertThat(responses.get(0).getStatusCode(), isOneOf(201, 202));
+        assertThat(responses.get(0).getReason(), is(nullValue()));
+        assertThat(responses.get(0).getError(), is(nullValue()));
+        assertThat(responses.get(1).getStatusCode(), isOneOf(201, 202));
+        assertThat(responses.get(1).getReason(), is("field cannot be forbidden"));
+        assertThat(responses.get(1).getError(), is("forbidden"));
     }
 
     @Test


### PR DESCRIPTION
## What

Preserve the original value of the `reason` value from the response array in the json returned from `_bulk_docs`. This can be queried through `getReason()`

This allows users to retrieve the message from failed validation functions, etc.

Note that the overall HTTP status code is still preserved in each result document and can be queried through `getStatusCode()`. It is therefore the same across all result documents. It should not be relied upon to detect failure:

"The return code from a successful bulk insertion is 201. The content of the returned structure indicates success or other information messages on a per-document basis." (from the IBM Cloudant documentation).

## Testing

New test `bulkRejectedByValidation`

## Issues

See #428