### PR TITLE
Add ComplexKey.addHighSentinel()

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,8 @@
   - `CloudantClient.schedulerJobs()`,
   - `CloudantClient.schedulerDocs()`,
   - `CloudantClient.schedulerDoc(docId)`.
+- [NEW] Add `ComplexKey.addHighSentinel()` to allow matching of all
+  values as part of a complex key range.
 - [FIXED] An issue where `getReason()` returned an incorrect value for
   `Response` objects returned by `Database.bulk()`.
 


### PR DESCRIPTION
## What

Syntactic sugar to allow use of complex key high sentinel value.

## How

`Add ComplexKey.addHighSentinel()`.

## Testing

Added
`queryPageWithComplexStartEndKeyAndJsonObjectValueUsingEndKey`
`addingAfterEndKeyThrowsError`

## Issues

#147 