### PR TITLE
Allow retrieval of deleted flag on all_docs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,18 +1,17 @@
 # Unreleased
-
 - [NEW] Add `CloudantClient.metaInformation()` to get meta information from the welcome page.
 - [NEW] Add methods for interacting with the replicator's `_scheduler` endpoint:
   - `CloudantClient.schedulerJobs()`,
   - `CloudantClient.schedulerDocs()`,
   - `CloudantClient.schedulerDoc(docId)`.
-- [NEW] Add `ComplexKey.addHighSentinel()` to allow matching of all
-  values as part of a complex key range.
-- [FIXED] An issue where `getReason()` returned an incorrect value for
-  `Response` objects returned by `Database.bulk()`.
-- [IMPROVED] When making view requests (including `_all_docs`), set
-  `keys` in the `POST` body rather than in `GET` query
-  parameters. This is because a large number of keys could previously
-  exceed the maximum URL length, causing errors.
+- [NEW] Add `ComplexKey.addHighSentinel()` to allow matching of all values as part of a complex key
+  range.
+- [IMPROVED] When making view requests (including `_all_docs`), set `keys` in the `POST` body rather
+  than in `GET` query parameters. This is because a large number of keys could previously exceed the
+  maximum URL length, causing errors.
+- [FIXED] An issue where `getReason()` returned an incorrect value for `Response` objects returned
+  by `Database.bulk()`.
+- [FIXED] Issues retrieving deleted documents using an `AllDocsRequest`.
 
 # 2.12.0 (2018-02-08)
 - [NEW] Index creation APIs and builders including support for text and partial indexes.

--- a/cloudant-client/src/main/java/com/cloudant/client/api/Database.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/Database.java
@@ -643,8 +643,8 @@ public class Database {
      */
     public AllDocsRequestBuilder getAllDocsRequestBuilder() {
         return new AllDocsRequestBuilderImpl(new ViewQueryParameters<String,
-                AllDocsRequestResponse.Revision>(client, this, "", "", String.class,
-                AllDocsRequestResponse.Revision.class) {
+                AllDocsRequestResponse.AllDocsValue>(client, this, "", "", String.class,
+                AllDocsRequestResponse.AllDocsValue.class) {
             protected DatabaseURIHelper getViewURIBuilder() {
                 return new DatabaseURIHelper(db.getDBUri()).path("_all_docs");
             }

--- a/cloudant-client/src/main/java/com/cloudant/client/api/views/AllDocsResponse.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/views/AllDocsResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 IBM Corp. All rights reserved.
+ * Copyright © 2015, 2018 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at

--- a/cloudant-client/src/main/java/com/cloudant/client/api/views/AllDocsResponse.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/views/AllDocsResponse.java
@@ -30,14 +30,30 @@ import java.util.Map;
 public interface AllDocsResponse {
 
     /**
+     * <P>
+     * Get the document information from an _all_docs request.
+     * </P>
+     * <P>
+     * Note that if requesting docs using {@link AllDocsRequestBuilder#keys(Object[])} the list of
+     * documents may include <b>deleted</b> documents that have one of the specified ids.
+     * </P>
+     * <P>
+     * Note if {@link AllDocsRequestBuilder#includeDocs(boolean)} is false then attachment metadata
+     * will not be present.
+     * </P>
      * @return a list of Document objects from the _all_docs request
-     * @throws IllegalStateException if include_docs was {@code false}
      * @since 2.0.0
      */
     List<Document> getDocs();
 
     /**
+     * <P>
      * Gets a map of the document id and revision for each result in the _all_docs request.
+     * </P>
+     * <P>
+     * Note that if requesting docs using {@link AllDocsRequestBuilder#keys(Object[])} the ids and
+     * revs may include <b>deleted</b> documents that have one of the specified ids.
+     * </P>
      *
      * @return a map with an entry for each document, key of _id and value of _rev
      * @since 2.0.0
@@ -45,7 +61,14 @@ public interface AllDocsResponse {
     Map<String, String> getIdsAndRevs();
 
     /**
+     * <P>
      * Deserializes the included full content of result documents to a list of the specified type.
+     * </P>
+     * <P>
+     * Note that if requesting docs using {@link AllDocsRequestBuilder#keys(Object[])} the list of
+     * documents may include <b>deleted</b> documents that have one of the specified ids. You may
+     * want to ensure that your document type can support checking of the deleted flag.
+     * </P>
      *
      * @param docType the class type to deserialize the JSON document to
      * @param <D>     the type of the document

--- a/cloudant-client/src/main/java/com/cloudant/client/api/views/ViewResponse.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/views/ViewResponse.java
@@ -119,6 +119,13 @@ public interface ViewResponse<K, V> extends Iterable<ViewResponse<K, V>> {
          * @since 2.10.0
          */
         String getError();
+
+        /**
+         * Returns a "sparse" document consisting of only the document ID, the revision ID, and the
+         * deleted flag
+         * @return a sparse document
+         */
+        Document getSparseDocument();
     }
 
     /**

--- a/cloudant-client/src/main/java/com/cloudant/client/api/views/ViewResponse.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/views/ViewResponse.java
@@ -119,13 +119,6 @@ public interface ViewResponse<K, V> extends Iterable<ViewResponse<K, V>> {
          * @since 2.10.0
          */
         String getError();
-
-        /**
-         * Returns a "sparse" document consisting of only the document ID, the revision ID, and the
-         * deleted flag
-         * @return a sparse document
-         */
-        Document getSparseDocument();
     }
 
     /**

--- a/cloudant-client/src/main/java/com/cloudant/client/internal/views/AllDocsRequestBuilderImpl.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/internal/views/AllDocsRequestBuilderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 IBM Corp. All rights reserved.
+ * Copyright © 2015, 2018 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at

--- a/cloudant-client/src/main/java/com/cloudant/client/internal/views/AllDocsRequestBuilderImpl.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/internal/views/AllDocsRequestBuilderImpl.java
@@ -18,10 +18,10 @@ import com.cloudant.client.api.views.AllDocsRequest;
 import com.cloudant.client.api.views.AllDocsRequestBuilder;
 
 public class AllDocsRequestBuilderImpl extends CommonViewRequestBuilder<String,
-        AllDocsRequestResponse.Revision,
+        AllDocsRequestResponse.AllDocsValue,
         AllDocsRequestBuilder> implements AllDocsRequestBuilder {
 
-    public AllDocsRequestBuilderImpl(ViewQueryParameters<String, AllDocsRequestResponse.Revision>
+    public AllDocsRequestBuilderImpl(ViewQueryParameters<String, AllDocsRequestResponse.AllDocsValue>
                                              parameters) {
         super(parameters);
     }

--- a/cloudant-client/src/main/java/com/cloudant/client/internal/views/AllDocsRequestImpl.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/internal/views/AllDocsRequestImpl.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2018 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.client.internal.views;
+
+import java.io.IOException;
+
+public class AllDocsRequestImpl extends ViewRequestImpl<String, AllDocsRequestResponse
+        .AllDocsValue> {
+
+    AllDocsRequestImpl(ViewQueryParameters<String, AllDocsRequestResponse.AllDocsValue>
+                               viewQueryParameters) {
+        super(viewQueryParameters);
+    }
+
+    @Override
+    protected ViewResponseImpl<String, AllDocsRequestResponse.AllDocsValue> makeResponse
+            (PageMetadata<String, AllDocsRequestResponse.AllDocsValue> metadata) throws
+            IOException {
+        ViewQueryParameters<String, AllDocsRequestResponse.AllDocsValue> requestParameters =
+                (metadata != null) ? metadata.pageRequestParameters : viewQueryParameters;
+        return new AllDocsResponseImpl(viewQueryParameters, ViewRequester.getResponseAsJson
+                (requestParameters), metadata);
+    }
+
+}

--- a/cloudant-client/src/main/java/com/cloudant/client/internal/views/AllDocsRequestResponse.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/internal/views/AllDocsRequestResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 IBM Corp. All rights reserved.
+ * Copyright © 2015, 2018 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at

--- a/cloudant-client/src/main/java/com/cloudant/client/internal/views/AllDocsRequestResponse.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/internal/views/AllDocsRequestResponse.java
@@ -17,7 +17,6 @@ package com.cloudant.client.internal.views;
 import com.cloudant.client.api.model.Document;
 import com.cloudant.client.api.views.AllDocsRequest;
 import com.cloudant.client.api.views.AllDocsResponse;
-import com.cloudant.client.api.views.ViewRequest;
 import com.cloudant.client.api.views.ViewResponse;
 
 import java.io.IOException;
@@ -31,11 +30,11 @@ import java.util.Map;
  */
 public class AllDocsRequestResponse implements AllDocsRequest, AllDocsResponse {
 
-    private final ViewRequest<String, Revision> request;
-    private ViewResponse<String, Revision> response = null;
+    private final AllDocsRequestImpl request;
+    private ViewResponse<String, AllDocsValue> response = null;
 
-    AllDocsRequestResponse(ViewQueryParameters<String, Revision> parameters) {
-        request = new ViewRequestImpl<String, Revision>(parameters);
+    AllDocsRequestResponse(ViewQueryParameters<String, AllDocsValue> parameters) {
+        request = new AllDocsRequestImpl(parameters);
     }
 
 
@@ -53,10 +52,10 @@ public class AllDocsRequestResponse implements AllDocsRequest, AllDocsResponse {
     @Override
     public Map<String, String> getIdsAndRevs() {
         Map<String, String> docIdsAndRevs = new HashMap<String, String>();
-        for (ViewResponse.Row<String, Revision> row : response.getRows()) {
-            Revision rev = row.getValue();
+        for (ViewResponse.Row<String, AllDocsValue> row : response.getRows()) {
+            AllDocsValue rev = row.getValue();
             if (rev != null) {
-                docIdsAndRevs.put(row.getKey(), rev.get());
+                docIdsAndRevs.put(row.getKey(), rev.getRev());
             }
         }
         return docIdsAndRevs;
@@ -75,7 +74,7 @@ public class AllDocsRequestResponse implements AllDocsRequest, AllDocsResponse {
     @Override
     public Map<String, String> getErrors() {
         Map<String, String> errors = new HashMap<String, String>();
-        for (ViewResponse.Row<String, Revision> row : response.getRows()) {
+        for (ViewResponse.Row<String, AllDocsValue> row : response.getRows()) {
             if(row.getError() != null) {
                 errors.put(row.getKey(), row.getError());
             }
@@ -89,15 +88,23 @@ public class AllDocsRequestResponse implements AllDocsRequest, AllDocsResponse {
          * A convenience to allow deserialization of _all_docs JSON revision object data.
          * </P>
          */
-    public static final class Revision {
+    public static final class AllDocsValue {
 
-        private String rev;
+        private String rev = null;
+        private boolean deleted = false;
 
         /**
          * @return the value of the document rev field
          */
-        public String get() {
+        public String getRev() {
             return rev;
+        }
+
+        /**
+         * @return true if deleted
+         */
+        public boolean isDeleted() {
+            return deleted;
         }
     }
 }

--- a/cloudant-client/src/main/java/com/cloudant/client/internal/views/AllDocsResponseImpl.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/internal/views/AllDocsResponseImpl.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright © 2018 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.client.internal.views;
+
+import com.cloudant.client.api.model.Document;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+import java.util.List;
+
+public class AllDocsResponseImpl extends ViewResponseImpl<String, AllDocsRequestResponse
+        .AllDocsValue> {
+
+    AllDocsResponseImpl(ViewQueryParameters<String, AllDocsRequestResponse.AllDocsValue>
+                                initialQueryParameters, JsonObject response, PageMetadata<String,
+            AllDocsRequestResponse.AllDocsValue> pageMetadata) {
+        super(initialQueryParameters, response, pageMetadata);
+    }
+
+    @Override
+    protected Row fromJson(JsonElement row) {
+        return new AllDocsRowImpl(initialQueryParameters, row);
+    }
+
+    static class AllDocsRowImpl extends RowImpl<String, AllDocsRequestResponse.AllDocsValue> {
+
+        AllDocsRowImpl(ViewQueryParameters<String, AllDocsRequestResponse.AllDocsValue>
+                               parameters, JsonElement row) {
+            super(parameters, row);
+        }
+
+        @Override
+        public <D> D getDocumentAsType(Class<D> docType) {
+            D doc = super.getDocumentAsType(docType);
+            if (doc == null) {
+                // The doc could be deleted, or include docs might be false, we can try to generate
+                // a sparse doc for these cases.
+                AllDocsRequestResponse.AllDocsValue v = getValue();
+                if (v != null) {
+                    JsonObject sparse = new JsonObject();
+                    sparse.addProperty("_id", getId());
+                    sparse.addProperty("_rev", v.getRev());
+                    sparse.addProperty("_deleted", v.isDeleted());
+                    doc = gson.fromJson(sparse, docType);
+                }
+            }
+            return doc;
+        }
+    }
+
+    @Override
+    public List<Document> getDocs() {
+        // This overrides the super to bypass the includeDocs check which is not needed for the all
+        // docs case.
+        return internalGetDocs();
+    }
+
+}

--- a/cloudant-client/src/main/java/com/cloudant/client/internal/views/RowImpl.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/internal/views/RowImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 IBM Corp. All rights reserved.
+ * Copyright © 2015, 2018 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at

--- a/cloudant-client/src/main/java/com/cloudant/client/internal/views/RowImpl.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/internal/views/RowImpl.java
@@ -23,7 +23,7 @@ import com.google.gson.JsonObject;
 public class RowImpl<K, V> implements ViewResponse.Row<K, V> {
 
     private final ViewQueryParameters<K, V> parameters;
-    private final Gson gson;
+    protected final Gson gson;
     private final JsonObject row;
 
     RowImpl(ViewQueryParameters<K, V> parameters, JsonElement row) {
@@ -64,27 +64,12 @@ public class RowImpl<K, V> implements ViewResponse.Row<K, V> {
     public <D> D getDocumentAsType(Class<D> docType) {
         D doc = null;
         if(row.has("doc")) {
-            doc = gson.fromJson(row.get("doc"), docType);
+            JsonElement jsonDoc = row.get("doc");
+            if (jsonDoc.isJsonObject()) {
+                doc = gson.fromJson(jsonDoc, docType);
+            }
         }
         return doc;
-    }
-
-    @Override
-    public Document getSparseDocument() {
-        Document sparseDoc = null;
-        if (row.has("value")) {
-            JsonObject obj = row.get("value").getAsJsonObject();
-            String rev = obj.get("rev").getAsString();
-            boolean deleted = false;
-            if (obj.has("deleted")) {
-                deleted = obj.get("deleted").getAsBoolean();
-            }
-            sparseDoc = new Document();
-            sparseDoc.setId(getId());
-            sparseDoc.setRevision(rev);
-            sparseDoc.setDeleted(deleted);
-        }
-        return sparseDoc;
     }
 
     @Override

--- a/cloudant-client/src/main/java/com/cloudant/client/internal/views/RowImpl.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/internal/views/RowImpl.java
@@ -70,6 +70,24 @@ public class RowImpl<K, V> implements ViewResponse.Row<K, V> {
     }
 
     @Override
+    public Document getSparseDocument() {
+        Document sparseDoc = null;
+        if (row.has("value")) {
+            JsonObject obj = row.get("value").getAsJsonObject();
+            String rev = obj.get("rev").getAsString();
+            boolean deleted = false;
+            if (obj.has("deleted")) {
+                deleted = obj.get("deleted").getAsBoolean();
+            }
+            sparseDoc = new Document();
+            sparseDoc.setId(getId());
+            sparseDoc.setRevision(rev);
+            sparseDoc.setDeleted(deleted);
+        }
+        return sparseDoc;
+    }
+
+    @Override
     public String getError() {
         String error = null;
         if(row.has("key") && row.has("error")) {

--- a/cloudant-client/src/main/java/com/cloudant/client/internal/views/ViewMultipleRequester.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/internal/views/ViewMultipleRequester.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 IBM Corp. All rights reserved.
+ * Copyright © 2015, 2018 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at

--- a/cloudant-client/src/main/java/com/cloudant/client/internal/views/ViewMultipleRequester.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/internal/views/ViewMultipleRequester.java
@@ -56,7 +56,7 @@ public class ViewMultipleRequester<K, V> implements ViewMultipleRequest<K, V> {
             int index = 0;
             for (ViewQueryParameters<K, V> params : requestParameters) {
                 JsonObject response = jsonResponses.get(index).getAsJsonObject();
-                responses.add(new ViewResponseImpl<K, V>(params, response));
+                responses.add(new ViewResponseImpl<K, V>(params, response, null));
                 index++;
             }
             return responses;

--- a/cloudant-client/src/main/java/com/cloudant/client/internal/views/ViewRequestImpl.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/internal/views/ViewRequestImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 IBM Corp. All rights reserved.
+ * Copyright © 2015, 2018 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at

--- a/cloudant-client/src/main/java/com/cloudant/client/internal/views/ViewResponseImpl.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/internal/views/ViewResponseImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 IBM Corp. All rights reserved.
+ * Copyright © 2015, 2018 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at

--- a/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/Document.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/Document.java
@@ -35,6 +35,8 @@ public class Document {
     private String revision;
     @SerializedName("_attachments")
     private Map<String, Attachment> attachments;
+    @SerializedName("_deleted")
+    private boolean deleted;
 
     public String getId() {
         return id;
@@ -58,6 +60,14 @@ public class Document {
 
     public void setAttachments(Map<String, Attachment> attachments) {
         this.attachments = attachments;
+    }
+
+    public boolean isDeleted() {
+        return deleted;
+    }
+
+    public void setDeleted(boolean deleted) {
+        this.deleted = deleted;
     }
 
     /**
@@ -84,15 +94,17 @@ public class Document {
 
         Document document = (Document) o;
 
+        if (deleted != document.deleted) {
+            return false;
+        }
         if (id != null ? !id.equals(document.id) : document.id != null) {
             return false;
         }
         if (revision != null ? !revision.equals(document.revision) : document.revision != null) {
             return false;
         }
-        return !(attachments != null ? !attachments.equals(document.attachments) : document
-                .attachments != null);
-
+        return attachments != null ? attachments.equals(document.attachments) : document
+                .attachments == null;
     }
 
     @Override
@@ -100,6 +112,7 @@ public class Document {
         int result = id != null ? id.hashCode() : 0;
         result = 31 * result + (revision != null ? revision.hashCode() : 0);
         result = 31 * result + (attachments != null ? attachments.hashCode() : 0);
+        result = 31 * result + (deleted ? 1 : 0);
         return result;
     }
 }

--- a/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/Document.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/Document.java
@@ -1,6 +1,6 @@
 /*
+ * Copyright © 2015, 2018 IBM Corp. All rights reserved.
  * Copyright (C) 2011 lightcouch.org
- * Copyright (c) 2015 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at

--- a/cloudant-client/src/test/java/com/cloudant/tests/Foo.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/Foo.java
@@ -30,6 +30,7 @@ public class Foo {
 
     private String _id;
     private String _rev;
+    public boolean _deleted;
 
     private String title;
     private String content;

--- a/cloudant-client/src/test/java/com/cloudant/tests/ViewsTest.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/ViewsTest.java
@@ -17,6 +17,7 @@ package com.cloudant.tests;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -28,6 +29,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 import com.cloudant.client.api.CloudantClient;
 import com.cloudant.client.api.Database;
 import com.cloudant.client.api.model.Document;
+import com.cloudant.client.api.model.Response;
 import com.cloudant.client.api.views.AllDocsResponse;
 import com.cloudant.client.api.views.Key;
 import com.cloudant.client.api.views.SettableViewParameters;
@@ -712,6 +714,69 @@ public class ViewsTest extends TestWithDbPerTest {
                 .getDocIds();
         assertThat(allDocIds.size(), is(2));
     }
+
+    // all docs with given keys, one document deleted:
+    // check that with include_docs false we can retrieve "sparse" document info including id, rev,
+    // and deleted flag for the deleted and non-deleted documents
+    @Test
+    public void allDocsWithKeysDocDeleted() throws Exception {
+        init();
+        // delete one object, see that it is retrieved with deleted flag set
+        Foo foo1 = new Foo();
+        Foo foo2 = new Foo();
+        Response response1 = db.save(foo1);
+        Response response2 = db.save(foo2);
+        Response removeResponse = db.remove(response2.getId(), response2.getRev());
+        AllDocsResponse response = db.getAllDocsRequestBuilder().includeDocs(false).keys(response1.getId(), response2.getId()).build().getResponse();
+        assertThat(response.getDocs(), hasSize(2));
+        assertThat(response.getDocs().get(0).isDeleted(), is(false));
+        assertThat(response.getDocs().get(0).getId(), is(response1.getId()));
+        assertThat(response.getDocs().get(0).getRevision(), is(response1.getRev()));
+        assertThat(response.getDocs().get(1).isDeleted(), is(true));
+        assertThat(response.getDocs().get(1).getId(), is(response2.getId()));
+        assertThat(response.getDocs().get(1).getRevision(), is(removeResponse.getRev()));
+    }
+
+    // all docs with given keys, one document deleted:
+    // check that with include_docs true we can retrieve "sparse" document info including id, rev,
+    // and deleted flag for the deleted and non-deleted documents
+    @Test
+    public void allDocsWithKeysDocDeletedIncludeDocs() throws Exception {
+        init();
+        // delete one object, see that it is retrieved with deleted flag set
+        Foo foo1 = new Foo();
+        Foo foo2 = new Foo();
+        Response response1 = db.save(foo1);
+        Response response2 = db.save(foo2);
+        Response removeResponse = db.remove(response2.getId(), response2.getRev());
+        AllDocsResponse response = db.getAllDocsRequestBuilder().includeDocs(true).keys(response1.getId(), response2.getId()).build().getResponse();
+        assertThat(response.getDocs(), hasSize(2));
+        assertThat(response.getDocs().get(0).isDeleted(), is(false));
+        assertThat(response.getDocs().get(0).getId(), is(response1.getId()));
+        assertThat(response.getDocs().get(0).getRevision(), is(response1.getRev()));
+        assertThat(response.getDocs().get(1).isDeleted(), is(true));
+        assertThat(response.getDocs().get(1).getId(), is(response2.getId()));
+        assertThat(response.getDocs().get(1).getRevision(), is(removeResponse.getRev()));
+    }
+
+    // all docs with given keys, one document deleted:
+    // check that with include_docs true we can serialise non-deleted document using getDocsAs and
+    // that the deleted document is excluded from results
+    @Test
+    public void allDocsWithKeysDocDeletedIncludeDocsGetDocsAs() throws Exception {
+        init();
+        // delete one object, see that it is retrieved with deleted flag set
+        Foo foo1 = new Foo();
+        foo1.setContent("some content");
+        Foo foo2 = new Foo();
+        Response response1 = db.save(foo1);
+        Response response2 = db.save(foo2);
+        db.remove(response2.getId(), response2.getRev());
+        List<Foo> foos = db.getAllDocsRequestBuilder().includeDocs(true).keys(response1.getId(), response2.getId()).build().getResponse().getDocsAs(Foo.class);
+        assertThat(foos, hasSize(1));
+        assertThat(foos.get(0).getContent(), is("some content"));
+    }
+
 
     @Test
     public void allDocsWithOneNonExistingKey() throws Exception {

--- a/cloudant-client/src/test/java/com/cloudant/tests/ViewsTest.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/ViewsTest.java
@@ -127,6 +127,19 @@ public class ViewsTest extends TestWithDbPerTest {
     }
 
     @Test
+    public void byKeysIncludeDocsFalse() throws Exception {
+        init();
+        // attempting to call getDocs() for a view with include_docs=false raises the exception
+        // java.lang.IllegalStateException: Cannot getDocs() when include_docs is false.
+        assertThrows(IllegalStateException.class, () -> {
+            db.getViewRequestBuilder("example", "foo").newRequest(Key.Type
+                            .STRING,
+                    Object.class).includeDocs(false).keys("key-1", "key-2").build()
+                    .getResponse().getDocs();
+        });
+    }
+
+    @Test
     public void byNonExistentAndExistingKey() throws Exception {
         init();
         List<ViewResponse.Row<String, Object>> foos = db.getViewRequestBuilder("example", "foo")

--- a/cloudant-client/src/test/java/com/cloudant/tests/ViewsTest.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/ViewsTest.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2011 lightcouch.org
  * Copyright © 2015, 2018 IBM Corp. All rights reserved.
+ * Copyright (C) 2011 lightcouch.org
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at


### PR DESCRIPTION
## What

Allow retrieval of `deleted` flag on `all_docs`

## How

Introduce "sparse document" information which can be retrieved even when `include_docs=false` is
set. This allows for retrieval of `id`, `rev`, and `deleted` flag.

Also, add `null` check to `getDocsAs()`: this ensures that attempting to deserialise deleted documents does not prevent retrieval of non-deleted ones.

## Testing

Added
- `allDocsWithKeysDocDeleted`
- `allDocsWithKeysDocDeletedIncludeDocs`
- `allDocsWithKeysDocDeletedIncludeDocsGetDocsAs`

## Issues

See #427 
See #440 