### PR TITLE
Added support for IAM API key in bluemix method

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
 - [NEW] Add `ComplexKey.addHighSentinel()` to allow matching of all values as part of a complex key
   range.
 - [NEW] Support IAM authentication in replication documents.
+- [IMPROVED] Added support for IAM API key in the client builder `bluemix` method.
 - [IMPROVED] When making view requests (including `_all_docs`), set `keys` in the `POST` body rather
   than in `GET` query parameters. This is because a large number of keys could previously exceed the
   maximum URL length, causing errors.

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,9 +27,10 @@ def runTests(testEnv, isServiceTests) {
 
         //Set up the environment and run the tests
         withEnv(testEnv) {
-            withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: env.CREDS_ID, usernameVariable: 'DB_USER', passwordVariable: 'DB_PASSWORD']]) {
+            withCredentials([usernamePassword(credentialsId: 'clientlibs-test', usernameVariable: 'DB_USER', passwordVariable: 'DB_PASSWORD'),
+                string(credentialsId: 'clientlibs-test-iam', variable: 'DB_IAM_API_KEY')]) {
                 try {
-                    sh './gradlew -Dtest.couch.username=$DB_USER -Dtest.couch.password=$DB_PASSWORD -Dtest.couch.host=$DB_HOST -Dtest.couch.port=$DB_PORT -Dtest.couch.http=$DB_HTTP $GRADLE_TARGET'
+                    sh './gradlew -Dtest.couch.username=$DB_USER -Dtest.couch.password=$DB_PASSWORD -Dtest.couch.host=$DB_HOST -Dtest.couch.port=$DB_PORT -Dtest.couch.http=$DB_HTTP -Dtest.couch.iam.api.key=$DB_IAM_API_KEY $GRADLE_TARGET'
                 } finally {
                     junit '**/build/test-results/**/*.xml'
                 }

--- a/cloudant-client/src/main/java/com/cloudant/client/internal/util/CloudFoundryService.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/internal/util/CloudFoundryService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 IBM Corp. All rights reserved.
+ * Copyright © 2016, 2018 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -14,6 +14,8 @@
 
 package com.cloudant.client.internal.util;
 
+import com.google.gson.annotations.SerializedName;
+
 import java.net.URL;
 
 
@@ -24,6 +26,13 @@ public class CloudFoundryService {
 
     public static class CloudFoundryServiceCredentials {
 
-        public URL url;
+        @SerializedName("apikey")
+        public String apikey;
+        @SerializedName("host")
+        public String host;
+        @SerializedName("username")
+        public String username;
+        @SerializedName("password")
+        public String password;
     }
 }

--- a/cloudant-client/src/test/java/com/cloudant/tests/CloudantClientHelper.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/CloudantClientHelper.java
@@ -31,17 +31,17 @@ public abstract class CloudantClientHelper {
 
     //some tests need access to the URI with user info (e.g. replication)
     public static final String SERVER_URI_WITH_USER_INFO;
-    //some tests need access to the credentials (e.g. auth interceptors)
+    //some tests need access to the credentials (e.g. auth interceptors, vcap)
     public static final String COUCH_USERNAME;
     public static final String COUCH_PASSWORD;
+    public static final String COUCH_HOST;
+    public static final String COUCH_IAM_API_KEY;
 
     protected static final CloudantClient CLIENT_INSTANCE;
 
-    private static final String COUCH_HOST;
     private static final String COUCH_PORT;
     private static final String HTTP_PROTOCOL;
     private static final URL SERVER_URL;
-    private static final String COUCH_IAM_API_KEY;
 
     static {
 
@@ -121,8 +121,7 @@ public abstract class CloudantClientHelper {
     public static ClientBuilder getClientBuilder() {
         return ClientBuilder.url(SERVER_URL)
                 .username(COUCH_USERNAME)
-                .password(COUCH_PASSWORD)
-                .iamApiKey(COUCH_IAM_API_KEY);
+                .password(COUCH_PASSWORD);
     }
 
 }

--- a/cloudant-client/src/test/java/com/cloudant/tests/HttpIamTest.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/HttpIamTest.java
@@ -22,8 +22,10 @@ import static com.cloudant.tests.util.MockWebServerResources.IAM_TOKEN;
 import static com.cloudant.tests.util.MockWebServerResources.IAM_TOKEN_2;
 import static com.cloudant.tests.util.MockWebServerResources.OK_IAM_COOKIE;
 import static com.cloudant.tests.util.MockWebServerResources.OK_IAM_COOKIE_2;
+import static com.cloudant.tests.util.MockWebServerResources.hello;
 import static com.cloudant.tests.util.MockWebServerResources.iamSession;
 import static com.cloudant.tests.util.MockWebServerResources.iamSessionUnquoted;
+import static com.cloudant.tests.util.MockWebServerResources.iamTokenEndpoint;
 import static org.hamcrest.CoreMatchers.anyOf;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -35,6 +37,7 @@ import com.cloudant.client.org.lightcouch.CouchDbException;
 import com.cloudant.http.Http;
 import com.cloudant.tests.extensions.MockWebServerExtension;
 import com.cloudant.tests.util.IamSystemPropertyMock;
+import com.cloudant.tests.util.MockWebServerResources;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -61,12 +64,8 @@ public class HttpIamTest {
     @RegisterExtension
     public MockWebServerExtension mockIamServerExt = new MockWebServerExtension();
 
-    final static String hello = "{\"hello\":\"world\"}\r\n";
-    final static String iamTokenEndpoint = "/identity/token";
-
     public MockWebServer mockWebServer;
     public MockWebServer mockIamServer;
-
 
     /**
      * Before running this test class setup the property mock.
@@ -114,33 +113,7 @@ public class HttpIamTest {
         String response = c.executeRequest(Http.GET(c.getBaseUri())).responseAsString();
         assertEquals(hello, response, "The expected response should be received");
 
-        // cloudant mock server
-        // assert that there were 2 calls
-        RecordedRequest[] recordedRequests = takeN(mockWebServer, 2);
-
-        assertEquals("/_iam_session",
-                recordedRequests[0].getPath(), "The request should have been for /_iam_session");
-        assertThat("The request body should contain the IAM token",
-                recordedRequests[0].getBody().readString(Charset.forName("UTF-8")),
-                containsString(IAM_TOKEN));
-        // the request should have the cookie header
-        assertEquals("/",
-                recordedRequests[1].getPath(), "The request should have been for /");
-        // The cookie may or may not have the session id quoted, so check both
-        assertThat("The Cookie header should contain the expected session value",
-                recordedRequests[1].getHeader("Cookie"),
-                anyOf(containsString(iamSession(EXPECTED_OK_COOKIE)),
-                        containsString(iamSessionUnquoted(EXPECTED_OK_COOKIE))));
-
-        // asserts on the IAM server
-        // assert that there was 1 call
-        RecordedRequest[] recordedIamRequests = takeN(mockIamServer, 1);
-        assertEquals(iamTokenEndpoint,
-                recordedIamRequests[0].getPath(), "The request should have been for " +
-                        "/identity/token");
-        assertThat("The request body should contain the IAM API key",
-                recordedIamRequests[0].getBody().readString(Charset.forName("UTF-8")),
-                containsString("apikey=" + IAM_API_KEY));
+        MockWebServerResources.assertMockIamRequests(mockWebServer, mockIamServer);
     }
 
     /**
@@ -170,33 +143,7 @@ public class HttpIamTest {
         String response = c.executeRequest(Http.GET(c.getBaseUri())).responseAsString();
         assertEquals(hello, response, "The expected response should be received");
 
-        // cloudant mock server
-        // assert that there were 2 calls
-        RecordedRequest[] recordedRequests = takeN(mockWebServer, 2);
-
-        assertEquals("/_iam_session",
-                recordedRequests[0].getPath(), "The request should have been for /_iam_session");
-        assertThat("The request body should contain the IAM token",
-                recordedRequests[0].getBody().readString(Charset.forName("UTF-8")),
-                containsString(IAM_TOKEN));
-        // the request should have the cookie header
-        assertEquals("/",
-                recordedRequests[1].getPath(), "The request should have been for /");
-        // The cookie may or may not have the session id quoted, so check both
-        assertThat("The Cookie header should contain the expected session value",
-                recordedRequests[1].getHeader("Cookie"),
-                anyOf(containsString(iamSession(EXPECTED_OK_COOKIE)),
-                        containsString(iamSessionUnquoted(EXPECTED_OK_COOKIE))));
-
-        // asserts on the IAM server
-        // assert that there was 1 call
-        RecordedRequest[] recordedIamRequests = takeN(mockIamServer, 1);
-        assertEquals(iamTokenEndpoint,
-                recordedIamRequests[0].getPath(), "The request should have been for " +
-                        "/identity/token");
-        assertThat("The request body should contain the IAM API key",
-                recordedIamRequests[0].getBody().readString(Charset.forName("UTF-8")),
-                containsString("apikey=" + IAM_API_KEY));
+        MockWebServerResources.assertMockIamRequests(mockWebServer, mockIamServer);
     }
 
     /**

--- a/cloudant-client/src/test/java/com/cloudant/tests/util/MockWebServerResources.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/util/MockWebServerResources.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015, 2017 IBM Corp. All rights reserved.
+ * Copyright © 2015, 2018 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -14,6 +14,13 @@
 
 package com.cloudant.tests.util;
 
+import static com.cloudant.tests.HttpTest.takeN;
+import static com.cloudant.tests.util.MockWebServerResources.IAM_API_KEY;
+import static org.hamcrest.CoreMatchers.anyOf;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import okhttp3.Cookie;
 import okhttp3.mockwebserver.Dispatcher;
 import okhttp3.mockwebserver.MockResponse;
@@ -21,6 +28,7 @@ import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
 
 import java.io.FileInputStream;
+import java.nio.charset.Charset;
 import java.security.KeyStore;
 import java.util.Locale;
 import java.util.concurrent.TimeUnit;
@@ -50,6 +58,9 @@ public class MockWebServerResources {
             "{\"access_token\":\"eyJraWQiOiIyMDE3MDQwMi0wMDowMDowMCIsImFsZyI6IlJTMjU2In0.eyJpYW1faWQiOiJJQk1pZC0yNzAwMDdHRjBEIiwiaWQiOiJJQk1pZC0yNzAwMDdHRjBEIiwicmVhbG1pZCI6IklCTWlkIiwiaWRlbnRpZmllciI6IjI3MDAwN0dGMEQiLCJnaXZlbl9uYW1lIjoiVG9tIiwiZmFtaWx5X25hbWUiOiJCbGVuY2giLCJuYW1lIjoiVG9tIEJsZW5jaCIsImVtYWlsIjoidGJsZW5jaEB1ay5pYm0uY29tIiwic3ViIjoidGJsZW5jaEB1ay5pYm0uY29tIiwiYWNjb3VudCI6eyJic3MiOiI1ZTM1ZTZhMjlmYjJlZWNhNDAwYWU0YzNlMWZhY2Y2MSJ9LCJpYXQiOjE1MDA0NjcxMDIsImV4cCI6MTUwMDQ3MDcwMiwiaXNzIjoiaHR0cHM6Ly9pYW0ubmcuYmx1ZW1peC5uZXQvb2lkYy90b2tlbiIsImdyYW50X3R5cGUiOiJ1cm46aWJtOnBhcmFtczpvYXV0aDpncmFudC10eXBlOmFwaWtleSIsInNjb3BlIjoib3BlbmlkIiwiY2xpZW50X2lkIjoiZGVmYXVsdCJ9.XAPdb5K4n2nYih-JWTWBGoKkxTXM31c1BB1g-Ciauc2LxuoNXVTyz_mNqf1zQL07FUde1Cb_dwrbotjickNcxVPost6byQztfc0mRF1x2S6VR8tn7SGiRmXBjLofkTh1JQq-jutp2MS315XbTG6K6m16uYzL9qfMnRvQHxsZWErzfPiJx-Trg_j7OX-qNFjdNUGnRpU7FmULy0r7RxLd8mhG-M1yxVzRBAZzvM63s0XXfMnk1oLi-BuUUTqVOdrM0KyYMWfD0Q72PTo4Exa17V-R_73Nq8VPCwpOvZcwKRA2sPTVgTMzU34max8b5kpTzVGJ6SXSItTVOUdAygZBng\",\"refresh_token\":\"MO61FKNvVRWkSa4vmBZqYv_Jt1kkGMUc-XzTcNnR-GnIhVKXHUWxJVV3RddE8Kqh3X_TZRmyK8UySIWKxoJ2t6obUSUalPm90SBpTdoXtaljpNyormqCCYPROnk6JBym72ikSJqKHHEZVQkT0B5ggZCwPMnKagFj0ufs-VIhCF97xhDxDKcIPMWG02xxPuESaSTJJug7e_dUDoak_ZXm9xxBmOTRKwOxn5sTKthNyvVpEYPE7jIHeiRdVDOWhN5LomgCn3TqFCLpMErnqwgNYbyCBd9rNm-alYKDb6Jle4njuIBpXxQPb4euDwLd1osApaSME3nEarFWqRBzhjoqCe1Kv564s_rY7qzD1nHGvKOdpSa0ZkMcfJ0LbXSQPs7gBTSVrBFZqwlg-2F-U3Cto62-9qRR_cEu_K9ZyVwL4jWgOlngKmxV6Ku4L5mHp4KgEJSnY_78_V2nm64E--i2ZA1FhiKwIVHDOivVNhggE9oabxg54vd63glp4GfpNnmZsMOUYG9blJJpH4fDX4Ifjbw-iNBD7S2LRpP8b8vG9pb4WioGzN43lE5CysveKYWrQEZpThznxXlw1snDu_A48JiL3Lrvo1LobLhF3zFV-kQ=\",\"token_type\":\"Bearer\",\"expires_in\":3600,\"expiration\":1500470702}";
     public static final String IAM_TOKEN_2 =
             "{\"access_token\":\"eyJraWQiOiIyMDE3MDQwMi0wMDowMDowMCIsImFsZyI6IlJTMjU2In0.eyJpYW1faWQiOiJJQk1pZC0yNzAwMDdHRjBEIiwiaWQiOiJJQk1pZC0yNzAwMDdHRjBEIiwicmVhbG1pZCI6IklCTWlkIiwiaWRlbnRpZmllciI6IjI3MDAwN0dGMEQiLCJnaXZlbl9uYW1lIjoiVG9tIiwiZmFtaWx5X25hbWUiOiJCbGVuY2giLCJuYW1lIjoiVG9tIEJsZW5jaCIsImVtYWlsIjoidGJsZW5jaEB1ay5pYm0uY29tIiwic3ViIjoidGJsZW5jaEB1ay5pYm0uY29tIiwiYWNjb3VudCI6eyJic3MiOiI1ZTM1ZTZhMjlmYjJlZWNhNDAwYWU0YzNlMWZhY2Y2MSJ9LCJpYXQiOjE1MDA0NjcxMTEsImV4cCI6MTUwMDQ3MDcxMSwiaXNzIjoiaHR0cHM6Ly9pYW0ubmcuYmx1ZW1peC5uZXQvb2lkYy90b2tlbiIsImdyYW50X3R5cGUiOiJ1cm46aWJtOnBhcmFtczpvYXV0aDpncmFudC10eXBlOmFwaWtleSIsInNjb3BlIjoib3BlbmlkIiwiY2xpZW50X2lkIjoiZGVmYXVsdCJ9.wJ5Glsvee3xRbfxr847pNgVj-U_ZLLzOiScHcjkrHk0jQdg8D4KurAV1QGa_MwWzd_QxS55lNqCzi6HV1p3kSyjcdJSGe-l-B3_xjw-7Q3BMoPjcO-X1mNYsKQyCtSAJsuByCYQVPoNKuBifsQcds65mKh87gUtc00vP5J-vzdYpzkrjncFO3lzJJwYSnbqFaAPtNnEYwEEIpS0n9H4mgHiLqletzYs9acggssxZpUl2wdkUaQ_diuTJg-u2o6Oy3aVJCWV78DIc3NVwgQCuJ40as6QpFPWluXJmfgdW5lFkQ_etieI9JDgXk_HQUpYcj0Droec6wTXEGUYWjukhsw\",\"refresh_token\":\"M0oCn5XLXUWAFUSqC7FRv1d83-SOfPvYmKKRdZpT33C81KsTaZx3Y3jMXRGkR1sIAohEm-gkpwGQcm1I_lfs5zlqwaKlsLOv4jvjvjiaPFwoU7QP62bHWGsq0j-RNN-_kHXsp3G1R7AtndZL0XQ4se4Jlgt68Cw3_YyEcxS6E65iTv1hZ9lg1EjJqzFLd4ArQVT6gFCpSaRaH2ilie4hat5ZFI2JALHPzVnBlRBqeIUferQOL6Yw2b_Z9TvYa6AaqOsQzI5ma2yIQTw6tzjrc5xXqnqnkH566pNlY8pKvETvCsdLgEclMoa8zoe9SAXDFEIl7svNMRG9FsoR7G4rwojs2BawDPPwkEcm6aC1K5azX23GbnekhvNfXloASWc2ETerN2RxYRZNnFnO4f0enCNReMhoPCUBObgO6iq0a56VslRTT-BHYBCax_YklBz9acbhJnF-C9PWjyrYwZHFajMhpFjOmY3hlrQXVXtjOqKs5WbMhpQ8BWN5KBUDYY7F7OMvv4bYTF7kfu5Uc_ge9_Nj4EGvPwA6vehvZjSj-0td6D32p2zMDmu_yoTLRpv6N7u5BRA5_PmhH_hsffXSKX5fDNL_CqGaNvcI5tVBry8=\",\"token_type\":\"Bearer\",\"expires_in\":3600,\"expiration\":1500470711}";
+
+    public static final String hello = "{\"hello\":\"world\"}\r\n";
+    public static final String iamTokenEndpoint = "/identity/token";
 
     // helpers for making Cookie responses
     public static final String AUTH_COOKIE_NAME = "AuthSession";
@@ -205,5 +216,38 @@ public class MockWebServerResources {
     public static MockResponse get429() {
         return new MockResponse().setResponseCode(429)
                 .setBody("{\"error\":\"too_many_requests\", \"reason\":\"example reason\"}\r\n");
+    }
+
+    public static void assertMockIamRequests(MockWebServer mockWebServer, MockWebServer mockIamServer)
+        throws Exception {
+        // cloudant mock server
+        // assert that there were 2 calls
+        RecordedRequest[] recordedRequests = takeN(mockWebServer, 2);
+
+        assertEquals("/_iam_session",
+                recordedRequests[0].getPath(), "The request should have been for /_iam_session");
+        assertThat("The request body should contain the IAM token",
+                recordedRequests[0].getBody().readUtf8(),
+                containsString(IAM_TOKEN));
+        // the request should have the cookie header
+        assertEquals("/",
+                recordedRequests[1].getPath(), "The request should have been for /");
+        // The cookie may or may not have the session id quoted, so check both
+        assertThat("The Cookie header should contain the expected session value",
+                recordedRequests[1].getHeader("Cookie"),
+                anyOf(containsString(iamSession(EXPECTED_OK_COOKIE)),
+                        containsString(iamSessionUnquoted(EXPECTED_OK_COOKIE))));
+        assertEquals("GET", recordedRequests[1].getMethod(), "The request method should be GET");
+
+
+        // asserts on the IAM server
+        // assert that there was 1 call
+        RecordedRequest[] recordedIamRequests = takeN(mockIamServer, 1);
+        assertEquals(iamTokenEndpoint,
+                recordedIamRequests[0].getPath(), "The request should have been for " +
+                        "/identity/token");
+        assertThat("The request body should contain the IAM API key",
+                recordedIamRequests[0].getBody().readUtf8(),
+                containsString("apikey=" + IAM_API_KEY));
     }
 }


### PR DESCRIPTION
Thanks for your hard work, please ensure all items are complete before opening.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://github.com/cloudant/java-cloudant/blob/master/DCO1.1.txt)
- [x] You have added tests for any code changes
- [x] You have updated the [CHANGES.md](https://github.com/cloudant/java-cloudant/blob/master/CHANGES.md) 
- [x] You have completed the PR template below:

## What

Added support for IAM API key to `ClientBuilder.bluemix`.

## How

- Added `apikey` and `host` in  `CloudFoundryService.java`  to instantiate IAM client in CloudFoundryServiceCredentials
- Handle cases when IAM or legacy credentials do not exist
- Updated Jenkinsfile to set IAM Key for VCAP testing
- Added CHANGES entry
- Updated copyrights

## Testing

Added mock tests for accessing VCAP with IAM credentials, and tests that assert `IllegalArgumentException` is raised when IAM key is missing.

For reviewers:
- With the added change of pulling the IAM key in Jenkins, should we consider "future-proofing" tests by adding a client extension that has the option to build a Cloudant client with IAM e.g. `CloudantClientExtension(boolean useIAM)`?