### PR TITLE
Fixed including body parameters with multi view requests

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+# Unreleased
+- [FIXED] Regression that prevented `keys` being included as part of a `ViewMultipleRequest`.
+
 # 2.13.0 (2018-06-06)
 - [NEW] Add `CloudantClient.metaInformation()` to get meta information from the welcome page.
 - [NEW] Add methods for interacting with the replicator `_scheduler` endpoint:

--- a/cloudant-client/src/main/java/com/cloudant/client/internal/views/ViewQueryParameters.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/internal/views/ViewQueryParameters.java
@@ -324,6 +324,8 @@ public class ViewQueryParameters<K, V> extends ParameterAnnotationProcessor impl
 
     JsonElement asJson() {
         Map<String, Object> parameters = processParameters(Parameter.Type.QUERY_PARAMETER);
+        // Add the body parameters too
+        parameters.putAll(processParameters(Parameter.Type.BODY_PARAMETER));
         return gson.toJsonTree(parameters);
     }
 

--- a/cloudant-client/src/test/java/com/cloudant/tests/ViewsTest.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/ViewsTest.java
@@ -54,8 +54,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.function.Executable;
 
-import okhttp3.mockwebserver.MockWebServer;
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -1024,14 +1022,20 @@ public class ViewsTest extends TestWithDbPerTest {
                 .keys("key-1").add()
                 .keys("key-2").add()
                 .keys("key-3").add()
+                .keys("key-1","key-3").add()
                 .build();
         int i = 1;
         List<ViewResponse<String, Object>> responses = multi.getViewResponses();
-        assertEquals(3, responses.size(), "There should be 3 responses for 3 requests");
+        assertEquals(4, responses.size(), "There should be 4 responses for 4 requests");
         for (ViewResponse<String, Object> response : responses) {
-            assertEquals(1, response.getRows().size(), "There should be 1 row in each response");
-            assertEquals("key-" + i, response.getKeys().get(0), "The returned key should be key-"
-                    + i);
+            if (i <= 3) {
+                assertEquals(1, response.getRows().size(), "There should be 1 row in each response");
+                assertEquals("key-" + i, response.getKeys().get(0), "The returned key should be key-"
+                        + i);
+            } else {
+                assertEquals(2, response.getRows().size(), "There should be 2 rows in the response");
+                assertEquals(Arrays.asList("key-1", "key-3"), response.getKeys(), "The returned keys should match");
+            }
             i++;
         }
     }


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description

Fixed including body parameters with multi view requests.

Fixes #458 

## Approach

When the `BODY_PARAMETER` type was added it was only added to the `ViewQueryParameters#asRequest()` method and hence they were omitted from the conversion to JSON used by necessity for generating a JSON body for the view multi request POST.

Added `BODY_PARAMETER` type to `ViewQueryParameters#asJson()` map generation.

## Schema & API Changes

- "No change"

## Security and Privacy

- "No change"

## Testing

- Modified existing `multiRequest` test to incldude multiple keys in a request to exercise this path. 

## Monitoring and Logging

- "No change"
