### PR TITLE
Fixed CONTRIBUTING.md and README.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,8 +26,6 @@ Please read the agreement and acknowledge it by ticking the appropriate box in t
 
 - [x] Tick to sign-off your agreement to the Developer Certificate of Origin (DCO) 1.1
 
-<!-- Append library specific information here
-
 ## General information
 
 Cloudant-client is written in Java and uses gradle as its build tool.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This is the official Cloudant library for Java.
 * [Related Documentation](#related-documentation)
 * [Development](#development)
     * [Contributing](CONTRIBUTING.md)
-    * [Test Suite](CONTRIBUTING.md#running-the-tests)
+    * [Test Suite](CONTRIBUTING.md#testing)
     * [Using in Other Projects](#using-in-other-projects)
     * [License](#license)
     * [Issues](#issues)


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description
The  `<!--` syntax was left in and commented out several sections.
README's `Test Suite` link was not pointing to the correct section in `CONTRIBUTING.md`.

## Approach
- Deleted the line containing the comment syntax.
- Updated `Test Suite` link to point to `CONTRIBUTING.md#testing`. 
<!--
Be brief: which component(s) of the code base does the fix focus on.

A place to note whether the part of the code base that is being worked is
particularly sensitive.
-->

## Schema & API Changes
- "No change"

<!--
EITHER:

- "No change"

OR

For public API (as opposed to internal) changes

- "Fixing bug in API, will change x in such-and-such way"
-->

## Security and Privacy
- "No change"

<!--
EITHER:

- "No change"

OR

"Making changes in e.g. auth|https|encryption|io
need to be careful about..."

-->

## Testing
- N/A build or packaging only changes

<!--
EITHER:

- Added new tests:
    - test x
    - test y
    - test z

OR

- Modified existing tests because ...

OR

- N/A build or packaging only changes

OR

In exceptional circumstances there may be a good reason we can't add automated
tests, for example if a specific device is required to reproduce a problem.

- No new tests because...
-->

## Monitoring and Logging
- "No change"
<!--
EITHER:

- "No change"

OR

- "Added new log line X..."
-->