### PR TITLE
Segregate integration tests

### DIFF
--- a/cloudant-client/build.gradle
+++ b/cloudant-client/build.gradle
@@ -92,7 +92,7 @@ task noDBTest(type: Test) {
 }
 
 task cloudantTest(type: Test) {
-    // Run unit tests that do not need a running database
+    // Run all the tests that work for both Cloudant Local and Cloudant service
     useJUnitPlatform {
         includeEngines 'junit-jupiter'
         excludeTags 'RequiresCloudantService'
@@ -100,7 +100,8 @@ task cloudantTest(type: Test) {
 }
 
 task cloudantServiceTest(type: Test) {
-    // Run unit tests that do not need a running database
+    // Run the unit tests and general DB tests and the DB tests that specifically require the
+    // Cloudant service
     useJUnitPlatform {
         includeEngines 'junit-jupiter'
         excludeTags 'RequiresCloudantLocal', 'RequiresCouch'

--- a/cloudant-client/build.gradle
+++ b/cloudant-client/build.gradle
@@ -108,6 +108,24 @@ task cloudantServiceTest(type: Test) {
     }
 }
 
+task integrationTest(type: Test) {
+    // Special environment variables for integration tests
+    [SERVER_URL:'test.couch.url',
+     SERVER_USER:'test.couch.username',
+     SERVER_PASSWORD:'test.couch.password',
+     TEST_REPLICATION_SOURCE_URL:'test.replication.source.url'].each { k,v ->
+        def e = System.getenv(k)
+        if (e) {
+            systemProperty v, e
+        }
+    }
+    // Run all tests that need a running DB and those for Cloudant, but not unit tests
+    useJUnitPlatform {
+        includeEngines 'junit-jupiter'
+        includeTags 'RequiresDB', 'RequiresCloudant', 'RequiresCloudantService'
+    }
+}
+
 //task for generating a client properties file
 class ClientProperties extends DefaultTask {
 

--- a/cloudant-client/src/test/java/com/cloudant/tests/CloudantClientHelper.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/CloudantClientHelper.java
@@ -57,8 +57,8 @@ public abstract class CloudantClientHelper {
                     COUCH_USERNAME = userInfo.substring(0, userInfo.indexOf(":"));
                     COUCH_PASSWORD = userInfo.substring(userInfo.indexOf(":") + 1);
                 } else {
-                    COUCH_USERNAME = null;
-                    COUCH_PASSWORD = null;
+                    COUCH_USERNAME = System.getProperty("test.couch.username");
+                    COUCH_PASSWORD = System.getProperty("test.couch.password");
                 }
             } else {
                 COUCH_USERNAME = System.getProperty("test.couch.username");

--- a/cloudant-client/src/test/java/com/cloudant/tests/CloudantClientHelper.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/CloudantClientHelper.java
@@ -121,4 +121,27 @@ public abstract class CloudantClientHelper {
                 .password(COUCH_PASSWORD);
     }
 
+    static String REP_SOURCE = null;
+
+    /**
+     * Uses the environment variable TEST_REPLICATION_SOURCE_URL
+     * or system property test.replication.source.url
+     * to determine the source replication URL for the named database.
+     * If neither the environment variable or the property is set, defaults to
+     * https://clientlibs-test.cloudant.com/ as the prefix.
+     * Note the environment variable takes precedence over the system property.
+     *
+     * @param dbName
+     * @return a URL to use as a source for replication
+     */
+    public static String getReplicationSourceUrl(String dbName) {
+        if (REP_SOURCE == null) {
+            REP_SOURCE = System.getProperty("test.replication.source.url", "https://clientlibs-test.cloudant.com/");
+            if (!REP_SOURCE.endsWith("/")) {
+                REP_SOURCE = REP_SOURCE + "/";
+            }
+        }
+        return REP_SOURCE + dbName;
+    }
+
 }

--- a/cloudant-client/src/test/java/com/cloudant/tests/DatabaseTest.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/DatabaseTest.java
@@ -14,6 +14,7 @@
 
 package com.cloudant.tests;
 
+import static com.cloudant.tests.CloudantClientHelper.getReplicationSourceUrl;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -66,7 +67,7 @@ public class DatabaseTest extends TestWithDbPerClass {
     public static void beforeAll() throws Exception {
         //replicate animaldb for tests
         com.cloudant.client.api.Replication r = account.replication();
-        r.source("https://clientlibs-test.cloudant.com/animaldb");
+        r.source(getReplicationSourceUrl("animaldb"));
         r.createTarget(true);
         r.target(dbResource.getDbURIWithUserInfo());
         r.trigger();

--- a/cloudant-client/src/test/java/com/cloudant/tests/IndexTests.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/IndexTests.java
@@ -18,6 +18,7 @@ import static com.cloudant.client.api.query.EmptyExpression.empty;
 import static com.cloudant.client.api.query.Expression.eq;
 import static com.cloudant.client.api.query.Expression.gt;
 import static com.cloudant.client.api.query.Operation.and;
+import static com.cloudant.tests.CloudantClientHelper.getReplicationSourceUrl;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -60,7 +61,7 @@ public class IndexTests extends TestWithDbPerClass {
 
         // create the movies-demo db for our index tests
         com.cloudant.client.api.Replication r = account.replication();
-        r.source("https://clientlibs-test.cloudant.com/movies-demo");
+        r.source(getReplicationSourceUrl("movies-demo"));
         r.createTarget(true);
         r.target(dbResource.getDbURIWithUserInfo());
         r.trigger();

--- a/cloudant-client/src/test/java/com/cloudant/tests/SearchTests.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/SearchTests.java
@@ -14,6 +14,7 @@
 
 package com.cloudant.tests;
 
+import static com.cloudant.tests.CloudantClientHelper.getReplicationSourceUrl;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -46,7 +47,7 @@ public class SearchTests extends TestWithDbPerClass {
     public static void setUp() throws Exception {
         // replicate the animals db for search tests
         com.cloudant.client.api.Replication r = account.replication();
-        r.source("https://clientlibs-test.cloudant.com/animaldb");
+        r.source(getReplicationSourceUrl("animaldb"));
         r.createTarget(true);
         r.target(dbResource.getDbURIWithUserInfo());
         r.trigger();


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description
Added a task for running integration tests separately.

## Approach

A collection of small changes to make it easier to run integration tests outside of Jenkins:
* Corrected test task descriptions identifying which tests run with which task.
* Allowed configuration of credential environment variables plus URL, without having to specify all URL components separately.
* Allow configuration of the replicator source account for tests (i.e. where to replicate `animaldb` and others from).
*Added `integration` task, for all Cloudant database tests.

## Schema & API Changes

- "No change"

## Security and Privacy

- Change to test credential passing, but no external security/privacy changes.

## Testing

- Modified existing tests as above to make it easier to run tests that connect to the database.

## Monitoring and Logging

- "No change"
