### PR TITLE
Add `purge_seq` getter on `DbInfo` class that returns seq as `String`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# UNRELEASED
+- [NEW] Add `purge_seq` getter on `DbInfo` class that returns sequence value as `String`.
+- [DEPRECATED] `com.cloudant.client.api.model.DbInfo#getPurgeSeq()`.
+
 # 2.13.1 (2018-09-05)
 - [FIXED] Regression that prevented `keys` being included as part of a `ViewMultipleRequest`.
 

--- a/cloudant-client/src/main/java/com/cloudant/client/api/model/DbInfo.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/model/DbInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 IBM Corp. All rights reserved.
+ * Copyright © 2015, 2018 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -16,6 +16,7 @@ package com.cloudant.client.api.model;
 
 
 import com.google.gson.JsonElement;
+import com.google.gson.JsonPrimitive;
 import com.google.gson.annotations.SerializedName;
 
 /**
@@ -33,7 +34,7 @@ public class DbInfo {
     @SerializedName("update_seq")
     private JsonElement updateSeq;
     @SerializedName("purge_seq")
-    private long purgeSeq;
+    private JsonElement purgeSeq;
     @SerializedName("compact_running")
     private boolean compactRunning;
     @SerializedName("disk_size")
@@ -59,8 +60,37 @@ public class DbInfo {
         return updateSeq.toString();
     }
 
+    /**
+     * Use {@link #getStringPurgeSeq()} instead.
+     *
+     * The value 0 is returned if the {@code purged_seq} field cannot be cast as a primitive long.
+     * In later versions of CouchDB (&gt;=2.3.x) {@code purged_seq} is an opaque string.
+     *
+     * @return Number of purge operations on the database.
+     */
+    @Deprecated
     public long getPurgeSeq() {
-        return purgeSeq;
+        try {
+            JsonPrimitive purgeSeqPrim = purgeSeq.getAsJsonPrimitive();
+            return purgeSeqPrim.getAsLong();
+        } catch (IllegalStateException e) {
+            // Suppress exception if the element is of type JsonArray but contains more than a
+            // single element.
+        } catch (NumberFormatException e) {
+            // Suppress exception if the element is not a JsonPrimitive and is not a valid long
+            // value.
+        }
+        // Return 0 when value cannot be cast as a primitive long value.
+        return 0;
+    }
+
+    /**
+     * An opaque string that describes the state of purge operations across the database.
+     *
+     * @return Purge sequence.
+     */
+    public String getStringPurgeSeq() {
+        return purgeSeq.toString();
     }
 
     public boolean isCompactRunning() {

--- a/cloudant-client/src/test/java/com/cloudant/tests/DbInfoMockTests.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/DbInfoMockTests.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright © 2018 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.tests;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.cloudant.client.api.CloudantClient;
+import com.cloudant.client.api.Database;
+import com.cloudant.tests.base.TestWithMockedServer;
+
+import org.junit.jupiter.api.Test;
+
+import okhttp3.mockwebserver.MockResponse;
+
+/**
+ * Created by samsmith on 13/12/2018.
+ */
+
+public class DbInfoMockTests extends TestWithMockedServer {
+
+    @Test
+    public void getDbInfoLongPurgeSeqAsLong() {
+        CloudantClient c = CloudantClientHelper.newMockWebServerClientBuilder(server).build();
+        Database db = c.database("animaldb", false);
+
+        MockResponse response = new MockResponse()
+                .setResponseCode(200)
+                .setBody("{\"purge_seq\":123}");
+        server.enqueue(response);
+
+        assertEquals(123, db.info().getPurgeSeq());
+    }
+
+    @Test
+    public void getDbInfoStringPurgeSeqAsLong() {
+        CloudantClient c = CloudantClientHelper.newMockWebServerClientBuilder(server).build();
+        Database db = c.database("animaldb", false);
+
+        String mockPurgeSeq = "\"3-g1AAAABXeJzLYWBgYMpgTmEQTM4vTc5ISXLIyU9OzMnILy7JAUklMiTV____PyuRAY-iPBYgydAApP6D1TJnAQCZtRxv\"";
+        MockResponse response = new MockResponse()
+                .setResponseCode(200)
+                .setBody("{\"purge_seq\":" + mockPurgeSeq + "}");
+        server.enqueue(response);
+
+        assertEquals(0, db.info().getPurgeSeq());
+    }
+
+    @Test
+    public void getDbInfoLongPurgeSeqAsString() {
+        CloudantClient c = CloudantClientHelper.newMockWebServerClientBuilder(server).build();
+        Database db = c.database("animaldb", false);
+
+        MockResponse response = new MockResponse()
+                .setResponseCode(200)
+                .setBody("{\"purge_seq\":123}");
+        server.enqueue(response);
+
+        assertEquals("123", db.info().getStringPurgeSeq());
+    }
+
+    @Test
+    public void getDbInfoStringPurgeSeqAsString() {
+        CloudantClient c = CloudantClientHelper.newMockWebServerClientBuilder(server).build();
+        Database db = c.database("animaldb", false);
+
+        String mockPurgeSeq = "\"3-g1AAAABXeJzLYWBgYMpgTmEQTM4vTc5ISXLIyU9OzMnILy7JAUklMiTV____PyuRAY-iPBYgydAApP6D1TJnAQCZtRxv\"";
+        MockResponse response = new MockResponse()
+                .setResponseCode(200)
+                .setBody("{\"purge_seq\":" + mockPurgeSeq + "}");
+        server.enqueue(response);
+
+        assertEquals(mockPurgeSeq, db.info().getStringPurgeSeq());
+    }
+}


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description
Add `purge_seq` getter on `DbInfo` class that returns seq as `String`.

Fixes #467.
<!--
Provide a short description; saving the detail for the `Approach` section

Also EITHER:
Link to issue this PR is resolving, use the Fixes #nnn form so that the
issue closes automatically when the PR merges e.g.:

Fixes #23

OR

For PRs without an associated issue and/or test/build issues

### 1. Steps to reproduce and the simplest code sample possible to demonstrate the issue
### 2. What you expected to happen
### 3. What actually happened
-->

## Approach
Deprecate `getPurgeSeq()` and add new getter `getStringPurgeSeq()` that returns a `String`.
<!--
Be brief: which component(s) of the code base does the fix focus on.

A place to note whether the part of the code base that is being worked is
particularly sensitive.
-->

## Schema & API Changes
- Deprecate `DbInfo#getPurgeSeq()`.
- New getter `DbInfo#getStringPurgeSeq()`.
<!--
EITHER:

- "No change"

OR

For public API (as opposed to internal) changes

- "Fixing bug in API, will change x in such-and-such way"
-->

## Security and Privacy
No change.
<!--
EITHER:

- "No change"

OR

"Making changes in e.g. auth|https|encryption|io
need to be careful about..."

-->

## Testing
Add additional unit tests mocks.
<!--
EITHER:

- Added new tests:
    - test x
    - test y
    - test z

OR

- Modified existing tests because ...

OR

- N/A build or packaging only changes

OR

In exceptional circumstances there may be a good reason we can't add automated
tests, for example if a specific device is required to reproduce a problem.

- No new tests because...
-->

## Monitoring and Logging
No change.
<!--
EITHER:

- "No change"

OR

- "Added new log line X..."
-->
