### PR TITLE
Add option for client to authenticate with IAM token server.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+# UNRELEASED
+- [NEW] Added option for client to authenticate with IAM token server.
+
 # 2.14.0 (2018-12-18)
 - [NEW] Add `purge_seq` getter on `DbInfo` class that returns sequence value as `String`.
 - [DEPRECATED] `com.cloudant.client.api.model.DbInfo#getPurgeSeq()`.

--- a/cloudant-client/src/main/java/com/cloudant/client/api/ClientBuilder.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/ClientBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015, 2018 IBM Corp. All rights reserved.
+ * Copyright © 2015, 2019 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -28,6 +28,7 @@ import com.cloudant.http.HttpConnectionRequestInterceptor;
 import com.cloudant.http.HttpConnectionResponseInterceptor;
 import com.cloudant.http.internal.interceptors.CookieInterceptor;
 import com.cloudant.http.internal.interceptors.IamCookieInterceptor;
+import com.cloudant.http.internal.interceptors.IamServerBasicAuthInterceptor;
 import com.cloudant.http.internal.interceptors.ProxyAuthInterceptor;
 import com.cloudant.http.internal.interceptors.SSLCustomizerInterceptor;
 import com.cloudant.http.internal.interceptors.TimeoutCustomizationInterceptor;
@@ -168,6 +169,8 @@ public class ClientBuilder {
     private long readTimeout = DEFAULT_READ_TIMEOUT;
     private TimeUnit readTimeoutUnit = TimeUnit.MINUTES;
     private String iamApiKey;
+    private String iamServerClientId;
+    private String iamServerClientSecret;
 
     /**
      * Constructs a new ClientBuilder for building a CloudantClient instance to connect to the
@@ -259,6 +262,11 @@ public class ClientBuilder {
             props.addRequestInterceptors(cookieInterceptor);
             props.addResponseInterceptors(cookieInterceptor);
             logger.config("Added IAM cookie interceptor");
+
+            if (this.iamServerClientId != null && this.iamServerClientSecret != null) {
+                props.addRequestInterceptors(new IamServerBasicAuthInterceptor(
+                        cookieInterceptor.getIamServerUrl(), iamServerClientId, iamServerClientSecret));
+            }
 
         }
         //Create cookie interceptor
@@ -792,6 +800,24 @@ public class ClientBuilder {
      */
     public ClientBuilder iamApiKey(String iamApiKey) {
         this.iamApiKey = iamApiKey;
+        return this;
+    }
+
+    /**
+     * Sets the
+     * <a href="https://console.bluemix.net/docs/services/Cloudant/guides/iam.html#ibm-cloud-identity-and-access-management"
+     * target="_blank">IAM</a> API key for the client connection.
+     *
+     * @param iamApiKey the IAM API key for the session
+     * @param iamServerClientId Client ID used to authenticate with IAM token server
+     * @param iamServerClientSecret Client secret used to authenticate with IAM token server
+     * @return this ClientBuilder object for setting additional options
+     */
+    public ClientBuilder iamApiKey(String iamApiKey, String iamServerClientId,
+                                   String iamServerClientSecret) {
+        this.iamApiKey = iamApiKey;
+        this.iamServerClientId = iamServerClientId;
+        this.iamServerClientSecret = iamServerClientSecret;
         return this;
     }
 

--- a/cloudant-client/src/test/java/com/cloudant/tests/util/MockWebServerResources.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/util/MockWebServerResources.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015, 2018 IBM Corp. All rights reserved.
+ * Copyright © 2015, 2019 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -220,10 +220,14 @@ public class MockWebServerResources {
 
     public static void assertMockIamRequests(MockWebServer mockWebServer, MockWebServer mockIamServer)
         throws Exception {
-        // cloudant mock server
-        // assert that there were 2 calls
-        RecordedRequest[] recordedRequests = takeN(mockWebServer, 2);
+        assertMockIamCloudantRequests(takeN(mockWebServer, 2));
+        assertMockIamServerRequests(takeN(mockIamServer, 1)[0]);
+    }
 
+    public static void assertMockIamCloudantRequests(RecordedRequest[] recordedRequests) throws Exception {
+        // assert that there were 2 calls
+        assertEquals(recordedRequests.length, 2, "There should be exactly 2 session requests");
+        // asserts on Cloudant server
         assertEquals("/_iam_session",
                 recordedRequests[0].getPath(), "The request should have been for /_iam_session");
         assertThat("The request body should contain the IAM token",
@@ -238,16 +242,15 @@ public class MockWebServerResources {
                 anyOf(containsString(iamSession(EXPECTED_OK_COOKIE)),
                         containsString(iamSessionUnquoted(EXPECTED_OK_COOKIE))));
         assertEquals("GET", recordedRequests[1].getMethod(), "The request method should be GET");
+    }
 
-
+    public static void assertMockIamServerRequests(RecordedRequest recordedRequest) throws Exception {
         // asserts on the IAM server
-        // assert that there was 1 call
-        RecordedRequest[] recordedIamRequests = takeN(mockIamServer, 1);
         assertEquals(iamTokenEndpoint,
-                recordedIamRequests[0].getPath(), "The request should have been for " +
+                recordedRequest.getPath(), "The request should have been for " +
                         "/identity/token");
         assertThat("The request body should contain the IAM API key",
-                recordedIamRequests[0].getBody().readUtf8(),
+                recordedRequest.getBody().readUtf8(),
                 containsString("apikey=" + IAM_API_KEY));
     }
 }

--- a/cloudant-http/src/main/java/com/cloudant/http/internal/interceptors/IamCookieInterceptor.java
+++ b/cloudant-http/src/main/java/com/cloudant/http/internal/interceptors/IamCookieInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017, 2018 IBM Corp. All rights reserved.
+ * Copyright © 2017, 2019 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -59,6 +59,15 @@ public class IamCookieInterceptor extends CookieInterceptorBase {
             //all JVMs should support UTF-8, so this should not happen
             throw new RuntimeException(e);
         }
+    }
+
+    /**
+     * Get IAM server URL.
+     *
+     * @return IAM server URL
+     */
+    public URL getIamServerUrl() {
+        return iamServerUrl;
     }
 
     // helper to store the bearer into a reference from an http connection response

--- a/cloudant-http/src/main/java/com/cloudant/http/internal/interceptors/IamServerBasicAuthInterceptor.java
+++ b/cloudant-http/src/main/java/com/cloudant/http/internal/interceptors/IamServerBasicAuthInterceptor.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2019 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.http.internal.interceptors;
+
+import com.cloudant.http.HttpConnectionInterceptorContext;
+import com.cloudant.http.interceptors.BasicAuthInterceptor;
+
+import java.net.URL;
+
+/**
+ * Created by samsmith on 10/01/2019.
+ */
+public class IamServerBasicAuthInterceptor extends BasicAuthInterceptor {
+
+    private final URL iamServerUrl;
+
+    /**
+     * Add basic access authentication to all requests matching the
+     * {@code iamServerUrl}.
+     *
+     * @param iamServerUrl IAM token server URL
+     * @param iamServerClientId Client ID used to authenticate with IAM token server
+     * @param iamServerClientSecret Client secret used to authenticate with IAM token server
+     */
+    public IamServerBasicAuthInterceptor(URL iamServerUrl, String iamServerClientId,
+                                         String iamServerClientSecret) {
+        super(iamServerClientId + ":" + iamServerClientSecret);
+        this.iamServerUrl = iamServerUrl;
+    }
+
+    @Override
+    public HttpConnectionInterceptorContext interceptRequest(HttpConnectionInterceptorContext
+                                                                     context) {
+        if (this.iamServerUrl != context.connection.url) {
+            return context; // noop
+        }
+        return super.interceptRequest(context);
+    }
+}


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description
Add option for client to authenticate with IAM token server.

Fixes #471.
<!--
Provide a short description; saving the detail for the `Approach` section

Also EITHER:
Link to issue this PR is resolving, use the Fixes #nnn form so that the
issue closes automatically when the PR merges e.g.:

Fixes #23

OR

For PRs without an associated issue and/or test/build issues

### 1. Steps to reproduce and the simplest code sample possible to demonstrate the issue
### 2. What you expected to happen
### 3. What actually happened
-->

## Approach
Overload the `iamApiKey` method in the client builder so that a client ID and secret can be specified.
<!--
Be brief: which component(s) of the code base does the fix focus on.

A place to note whether the part of the code base that is being worked is
particularly sensitive.
-->

## Schema & API Changes
No breaking API changes.
<!--
EITHER:

- "No change"

OR

For public API (as opposed to internal) changes

- "Fixing bug in API, will change x in such-and-such way"
-->

## Security and Privacy
No change.
<!--
EITHER:

- "No change"

OR

"Making changes in e.g. auth|https|encryption|io
need to be careful about..."

-->

## Testing
Includes additional mock unit test.
<!--
EITHER:

- Added new tests:
    - test x
    - test y
    - test z

OR

- Modified existing tests because ...

OR

- N/A build or packaging only changes

OR

In exceptional circumstances there may be a good reason we can't add automated
tests, for example if a specific device is required to reproduce a problem.

- No new tests because...
-->

## Monitoring and Logging
No change.
<!--
EITHER:

- "No change"

OR

- "Added new log line X..."
-->