### PR TITLE
Partitioned databases

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 # UNRELEASED
+- [NEW] Added partitioned database support.
 - [NEW] Added option for client to authenticate with IAM token server.
 - [FIXED] Updated the default IAM token server URL.
 

--- a/cloudant-client/findbugs_excludes.xml
+++ b/cloudant-client/findbugs_excludes.xml
@@ -16,7 +16,7 @@ A list of known findbugs issues that we cannot fix at this time.
 For example because it requires an API change
 -->
 <FindBugsFilter>
-    
+
     <!-- This bug is because com.cloudant.client.api.model.Document extends
      com.cloudant.org.lightcouch.Document. Eventually we may roll them into one class and then this
      exclude can be removed.
@@ -25,7 +25,7 @@ For example because it requires an API change
         <Bug code="Nm" pattern="NM_SAME_SIMPLE_NAME_AS_SUPERCLASS"/>
         <Class name="com.cloudant.client.api.model.Document"/>
     </Match>
-    
+
     <!-- This bug is because addAttachment in com.cloudant.client.api.model.Document does not
      override the addAttachment in com.cloudant.org.lightcouch.Document. This is because of the two
      different Attachment classes. This leads to the confusing situation where there are two
@@ -38,19 +38,6 @@ For example because it requires an API change
         <Class name="com.cloudant.client.api.model.Document"/>
         <Method name="addAttachment"/>
     </Match>
-
-    <!-- Some private fields are flagged as never being written to. This fails to take into account
-    the GSON deserialization which reflectively sets the fields, so these findbugs can be ignored.
-    -->
-    <Match>
-        <Bug code="UwF" pattern="UWF_UNWRITTEN_FIELD"/>
-        <Class name="com.cloudant.client.org.lightcouch.Attachment"/>
-    </Match>
-    <Match>
-        <Bug code="UwF" pattern="UWF_UNWRITTEN_FIELD"/>
-        <Class name="com.cloudant.client.api.model.ChangesResult$Row$Rev"/>
-    </Match>
-
 
     <!-- Returning null instead of a zero length array has special meaning in these cases.
      Firstly, null indicates that no keys have been added to the query so we should not write a
@@ -95,8 +82,17 @@ For example because it requires an API change
         <Method name="readNextRow"/>
     </Match>
 
-    <!-- This bug is because com.cloudant.client.internal.util.CloudFoundryService is populated via
-    GSON. -->
+    <!-- Some private fields are flagged as never being written to. This fails to take into account
+    the GSON deserialization which reflectively sets the fields, so these findbugs can be ignored.
+    -->
+    <Match>
+        <Bug code="UwF" pattern="UWF_UNWRITTEN_FIELD"/>
+        <Class name="com.cloudant.client.org.lightcouch.Attachment"/>
+    </Match>
+    <Match>
+        <Bug code="UwF" pattern="UWF_UNWRITTEN_FIELD"/>
+        <Class name="com.cloudant.client.api.model.ChangesResult$Row$Rev"/>
+    </Match>
     <Match>
         <Bug code="UwF" pattern="UWF_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD"/>
         <Class name="com.cloudant.client.internal.util.CloudFoundryService"/>
@@ -112,7 +108,6 @@ For example because it requires an API change
         <Class name="com.cloudant.client.internal.util.CloudFoundryService$CloudFoundryServiceCredentials"/>
         <Field name="url"/>
     </Match>
-    <!-- Populated via GSON -->
     <Match>
         <Bug code="UwF" pattern="UWF_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD"/>
         <Class name="com.cloudant.client.api.scheduler.SchedulerJobsResponse$History"/>
@@ -122,6 +117,16 @@ For example because it requires an API change
         <Bug code="UwF" pattern="UWF_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD"/>
         <Class name="com.cloudant.client.api.scheduler.SchedulerJobsResponse$History"/>
         <Field name="type"/>
+    </Match>
+    <Match>
+        <Bug code="UwF" pattern="UWF_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD"/>
+        <Class name="com.cloudant.client.api.model.PartitionInfo$Sizes"/>
+        <Field name="active"/>
+    </Match>
+    <Match>
+        <Bug code="UwF" pattern="UWF_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD"/>
+        <Class name="com.cloudant.client.api.model.PartitionInfo$Sizes"/>
+        <Field name="external"/>
     </Match>
 
     <!-- This is likely a false positive in Findbugs, the IDE doesn't complain an unchecked cast.

--- a/cloudant-client/overview.html
+++ b/cloudant-client/overview.html
@@ -50,6 +50,7 @@ There is no need to add a head/title as that is provided by Javadoc.
             <LI><a href="#Cloudant Search">Cloudant Search</a></LI>
         </OL>
     </LI>
+    <LI><a href="#Partitioned Databases">Partitioned Databases</a></LI>
     <LI><a href="#Advanced Configuration">Advanced Configuration</a>
         <OL>
             <LI><a href="#Connection options">Connection options</a></LI>
@@ -470,6 +471,64 @@ library to query a view.
 <P>
     To query this index, use an instance of {@link com.cloudant.client.api.Search} by calling
     {@link com.cloudant.client.api.Database#search}.
+</P>
+
+<h1 id="Partitioned Databases">Partitioned Databases</h1>
+
+<P>
+    Partitioned databases introduce the ability for a user to create logical groups of documents
+    called partitions by providing a partition key with each document. A partitioned database offers
+    significant performance and cost advantages but requires you to specify a logical partitioning
+    of your data. IBM Cloudant strongly recommends using partitioned database where the data model
+    allows for logical partitioning of documents.
+</P>
+
+<P>
+    Creating a new partitioned database (see {@link
+    com.cloudant.client.api.CloudantClient#createPartitionedDB(String)}):
+</P>
+<pre>
+    {@code
+    CloudantClient client = ClientBuilder.account("example")
+                                         .username("exampleUser")
+                                         .password("examplePassword")
+                                         .build();
+
+    client.createPartitionedDB("myPartitionedDb");
+    }
+</pre>
+
+</P>
+    A partitioned database offers both partitioned and global querying. Partitioned querying takes
+    advantage of the data layout within the database cluster to deliver improved and more scalable
+    query performance. In addition, partition queries are often cheaper than global queries.
+</P>
+
+<P>
+    Executing a partition view query (see {@link
+    com.cloudant.client.api.views.SettableViewParameters.Common#partition(String)}:
+</P>
+<pre>
+    {@code
+    Database db = client.database("myPartitionedDb", false);
+
+    ViewRequest<String, String> viewRequest = db.getViewRequestBuilder(ddocId, "myView")
+                                                .newRequest(Key.Type.STRING, String.class)
+                                                .partition("partitionKey-123456")
+                                                .build();
+    }
+</pre>
+
+<P>
+    See {@link com.cloudant.client.api.Database#query(String, String, Class)} and {@link
+    com.cloudant.client.api.Database#search(String, String)} for executing partitioned IBM Cloudant
+    Query and Search queries, respectively.
+</P>
+
+<P>
+    For more information see
+    the <a href="https://console.bluemix.net/docs/services/Cloudant/guides/database_partitioning.html#database-partitioning"
+    target="_blank">IBM Cloud Docs</a>.
 </P>
 
 <h1 id="Advanced Configuration">Advanced Configuration</h1>

--- a/cloudant-client/src/main/java/com/cloudant/client/api/CloudantClient.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/CloudantClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015, 2018 IBM Corp. All rights reserved.
+ * Copyright © 2015, 2019 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -248,6 +248,29 @@ public class CloudantClient {
      */
     public void createDB(String dbName) {
         couchDbClient.createDB(dbName);
+    }
+
+    /**
+     * Request to create a new partitioned database with the specified name.
+     *
+     * A partitioned database introduces the ability for a user to create logical groups of
+     * documents called partitions by providing a partition key with each document. Operations on
+     * the database, specifically querying, will be extended to take partition keys as part of the
+     * request in order to constrain the operation (e.g., result set) to a specific partition.
+     *
+     * @param dbName the database name
+     * @throws com.cloudant.client.org.lightcouch.PreconditionFailedException if a database with
+     *                                                                        the same name
+     *                                                                        already exists
+     * @see <a target="_blank"
+     * href="https://console.bluemix.net/docs/services/Cloudant/api/database.html#create">
+     * Databases - create</a>
+     * @see com.cloudant.client.api.Database#query(String, String, Class)
+     * @see com.cloudant.client.api.Database#search(String, String)
+     * @see com.cloudant.client.api.views.SettableViewParameters.Common#partition(String)
+     */
+    public void createPartitionedDB(String dbName) {
+        couchDbClient.createPartitionedDB(dbName);
     }
 
     /**

--- a/cloudant-client/src/main/java/com/cloudant/client/api/Database.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/Database.java
@@ -27,6 +27,7 @@ import com.cloudant.client.api.model.FindByIndexOptions;
 import com.cloudant.client.api.model.Index;
 import com.cloudant.client.api.model.IndexField;
 import com.cloudant.client.api.model.Params;
+import com.cloudant.client.api.model.PartitionInfo;
 import com.cloudant.client.api.model.Permissions;
 import com.cloudant.client.api.query.QueryResult;
 import com.cloudant.client.api.model.Shard;
@@ -494,14 +495,52 @@ public class Database {
      */
     public <T> QueryResult<T> query(String query, final Class<T> classOfT) {
         URI uri = new DatabaseURIHelper(db.getDBUri()).path("_find").build();
+        return this.query(uri, query, classOfT);
+    }
+
+    /**
+     * Execute a partitioned query using an index and a query selector.
+     *
+     * Only available in partitioned databases. To verify a database is partitioned call
+     * {@link Database#info()} and check that {@link DbInfo.Props#getPartitioned()} returns
+     * {@code true}.
+     *
+     * <p>Example usage:</p>
+     * <pre>
+     * {@code
+     * // Query database partition 'Coppola'.
+     * QueryResult<Movie> movies = db.query("Coppola", new QueryBuilder(and(
+     *   gt("Movie_year", 1960),
+     *   eq("Person_name", "Al Pacino"))).
+     *   fields("Movie_name", "Movie_year").
+     *   build(), Movie.class);
+     * }
+     * </pre>
+     *
+     * @param partitionKey Database partition to query.
+     * @param query        String representation of a JSON object describing criteria used to
+     *                     select documents.
+     * @param classOfT     The class of Java objects to be returned in the {@code docs} field of
+     *                     result.
+     * @param <T>          The type of the Java object to be returned in the {@code docs} field of
+     *                     result.
+     * @return             A {@link QueryResult} object, containing the documents matching the query
+     *                     in the {@code docs} field.
+     * @see com.cloudant.client.api.Database#query(String, Class)
+     */
+    public <T> QueryResult<T> query(String partitionKey, String query, final Class<T> classOfT) {
+        URI uri = new DatabaseURIHelper(db.getDBUri()).partition(partitionKey).path("_find").build();
+        return this.query(uri, query, classOfT);
+    }
+
+    private <T> QueryResult<T> query(URI uri, String query, final Class<T> classOfT) {
         InputStream stream = null;
         try {
             stream = client.couchDbClient.executeToInputStream(createPost(uri, query,
                     "application/json"));
             Reader reader = new InputStreamReader(stream, "UTF-8");
             Type type = TypeToken.getParameterized(QueryResult.class, classOfT).getType();
-            QueryResult<T> result = client.getGson().fromJson(reader, type);
-            return result;
+            return client.getGson().fromJson(reader, type);
         } catch (UnsupportedEncodingException e) {
             // This should never happen as every implementation of the java platform is required
             // to support UTF-8.
@@ -602,7 +641,35 @@ public class Database {
      * target="_blank">Search</a>
      */
     public Search search(String searchIndexId) {
-        return new Search(client, this, searchIndexId);
+        return new Search(client, this, null, searchIndexId);
+    }
+
+    /**
+     * Provides access to partitioned Cloudant <tt>Search</tt> APIs.
+     *
+     * Only available in partitioned databases. To verify a database is partitioned call
+     * {@link Database#info()} and check that {@link DbInfo.Props#getProps()} returns
+     * {@code true}.
+     *
+     * <p>Example usage:</p>
+     * <pre>
+     * {@code
+     *  // Search query over partition 'aves' using design document _id '_design/views101' and
+     *  // search index 'partitioned_animals'.
+     *  List<Bird> birds = db.search("aves", "views101/partitioned_animals")
+     * 	.query("name:puffin", Bird.class);
+     * 	}
+     * </pre>
+     *
+     * @param partitionKey database partition key
+     * @param searchIndexId the design document with the name of the index to search
+     * @return Search object for searching the index
+     * @see <a
+     * href="https://console.bluemix.net/docs/services/Cloudant/api/search.html#search"
+     * target="_blank">Search</a>
+     */
+    public Search search(String partitionKey, String searchIndexId) {
+        return new Search(client, this, partitionKey, searchIndexId);
     }
 
     /**
@@ -646,7 +713,7 @@ public class Database {
                 AllDocsRequestResponse.AllDocsValue>(client, this, "", "", String.class,
                 AllDocsRequestResponse.AllDocsValue.class) {
             protected DatabaseURIHelper getViewURIBuilder() {
-                return new DatabaseURIHelper(db.getDBUri()).path("_all_docs");
+                return new DatabaseURIHelper(db.getDBUri()).partition(partition).path("_all_docs");
             }
         });
     }

--- a/cloudant-client/src/main/java/com/cloudant/client/api/Database.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/Database.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016, 2018 IBM Corp. All rights reserved.
+ * Copyright © 2016, 2019 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -1332,6 +1332,21 @@ public class Database {
     public DbInfo info() {
         return client.couchDbClient.get(new DatabaseURIHelper(db.getDBUri()).getDatabaseUri(),
                 DbInfo.class);
+    }
+
+    /**
+     * Get information about a partition in this database.
+     *
+     * @param partitionKey database partition key
+     * @return {@link com.cloudant.client.api.model.PartitionInfo} encapsulating the database partition info.
+     * @throws UnsupportedOperationException if called with {@code null} partition key.
+     */
+    public PartitionInfo partitionInfo(String partitionKey) {
+        if (partitionKey == null) {
+            throw new UnsupportedOperationException("Cannot get partition information for null partition key.");
+        }
+        URI uri = new DatabaseURIHelper(db.getDBUri()).partition(partitionKey).build();
+        return client.couchDbClient.get(uri, PartitionInfo.class);
     }
 
     /**

--- a/cloudant-client/src/main/java/com/cloudant/client/api/Search.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/Search.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017 IBM Corp. All rights reserved.
+ * Copyright © 2015, 2019 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -95,18 +95,19 @@ public class Search {
     private String bookmark;
     private CloudantClient client;
     private DatabaseURIHelper databaseHelper;
+    private final String partitionKey;
 
-
-    Search(CloudantClient client, Database db, String searchIndexId) {
+    Search(CloudantClient client, Database db, String partitionKey, String searchIndexId) {
         assertNotEmpty(searchIndexId, "searchIndexId");
         this.client = client;
+        this.partitionKey = partitionKey;
         String search = searchIndexId;
+        this.databaseHelper = new DatabaseURIHelper(db.getDBUri()).partition(partitionKey);
         if (searchIndexId.contains("/")) {
             String[] v = searchIndexId.split("/");
-            this.databaseHelper = new DatabaseURIHelper(db.getDBUri()).path("_design")
-                .path(v[0]).path("_search").path(v[1]);
+            this.databaseHelper.path("_design").path(v[0]).path("_search").path(v[1]);
         } else {
-            this.databaseHelper = new DatabaseURIHelper(db.getDBUri()).path(search);
+            this.databaseHelper.path(search);
         }
     }
 

--- a/cloudant-client/src/main/java/com/cloudant/client/api/model/DbInfo.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/model/DbInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015, 2018 IBM Corp. All rights reserved.
+ * Copyright © 2015, 2019 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -25,6 +25,24 @@ import com.google.gson.annotations.SerializedName;
  * @author Ganesh K Choudhary
  */
 public class DbInfo {
+
+    /**
+     * Encapsulates database properties.
+     */
+    public static class Props {
+
+        private boolean partitioned = false;
+
+        /**
+         * Get the database partitioned property.
+         *
+         * @return database partition property
+         */
+        public boolean getPartitioned() {
+            return partitioned;
+        }
+    }
+
     @SerializedName("db_name")
     private String dbName;
     @SerializedName("doc_count")
@@ -43,6 +61,7 @@ public class DbInfo {
     private long instanceStartTime;
     @SerializedName("disk_format_version")
     private int diskFormatVersion;
+    private Props props;
 
     public String getDbName() {
         return dbName;
@@ -107,6 +126,15 @@ public class DbInfo {
 
     public int getDiskFormatVersion() {
         return diskFormatVersion;
+    }
+
+    /**
+     * Get the database properties.
+     *
+     * @return database properties
+     */
+    public Props getProps() {
+        return props;
     }
 
     @Override

--- a/cloudant-client/src/main/java/com/cloudant/client/api/model/DesignDocument.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/model/DesignDocument.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2011 lightcouch.org
- * Copyright (c) 2015 IBM Corp. All rights reserved.
+ * Copyright © 2015, 2019 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -69,6 +69,32 @@ import java.util.Map;
  */
 public class DesignDocument extends com.cloudant.client.org.lightcouch.Document {
 
+    /**
+     * Encapsulates design document options.
+     */
+    public static class Options {
+
+        private boolean partitioned;
+
+        /**
+         * Get partitioned option for this design document.
+         *
+         * @return partitioned option
+         */
+        public boolean getPartitioned() {
+            return partitioned;
+        }
+
+        /**
+         * Set the partitioned option for this design document.
+         *
+         * @param partitioned partitioned option
+         */
+        public void setPartitioned(boolean partitioned) {
+            this.partitioned = partitioned;
+        }
+    }
+
     private static final String LANG_QUERY = "query";
     // Default GSON instance for serializing/deserializing JsonElements of views
     private static final Gson GSON = new Gson();
@@ -81,6 +107,7 @@ public class DesignDocument extends com.cloudant.client.org.lightcouch.Document 
     private Map<String, String> shows;
     private Map<String, String> lists;
     private Map<String, String> updates;
+    private Options options;
     private JsonArray rewrites;
     private JsonObject fulltext;
     private JsonObject indexes;
@@ -200,6 +227,15 @@ public class DesignDocument extends com.cloudant.client.org.lightcouch.Document 
     }
 
     /**
+     * Get the options defined in this design document.
+     *
+     * @return design document options, or {@code null} if no options are defined
+     */
+    public Options getOptions() {
+        return options;
+    }
+
+    /**
      * Set the language of the design document.
      *
      * @param language typically {@code "javascript"}
@@ -309,6 +345,15 @@ public class DesignDocument extends com.cloudant.client.org.lightcouch.Document 
      */
     public void setUpdates(Map<String, String> updates) {
         this.updates = updates;
+    }
+
+    /**
+     * Set design document options.
+     *
+     * @param options design document options
+     */
+    public void setOptions(Options options) {
+        this.options = options;
     }
 
     @Override

--- a/cloudant-client/src/main/java/com/cloudant/client/api/model/PartitionInfo.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/model/PartitionInfo.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright © 2019 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.client.api.model;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * Created by samsmith on 24/01/2019.
+ */
+public class PartitionInfo {
+
+    public static class Sizes {
+
+        private long active;
+        private long external;
+
+        /**
+         * Get the size of live data inside the database, in bytes.
+         *
+         * @return The size of live data in bytes.
+         */
+        public long getActive() {
+            return active;
+        }
+
+        /**
+         * Get the uncompressed size of database contents, in bytes.
+         *
+         * @return The uncompressed size of database contents in bytes.
+         */
+        public long getExternal() {
+            return external;
+        }
+
+    }
+
+    @SerializedName("doc_count")
+    private long docCount;
+    @SerializedName("doc_del_count")
+    private long docDelCount;
+    private String partition;
+    private Sizes sizes;
+
+    /**
+     * Get a count of the documents in the specified database partition.
+     *
+     * @return The document count.
+     */
+    public long getDocCount() {
+        return docCount;
+    }
+
+    /**
+     * Get a count of the deleted documents in the specified database partition.
+     *
+     * @return The deleted document count.
+     */
+    public long getDocDelCount() {
+        return docDelCount;
+    }
+
+    /**
+     * Get the database partition key.
+     *
+     * @return The database partition key.
+     */
+    public String getPartition() {
+        return partition;
+    }
+
+    /**
+     * Get the {@link com.cloudant.client.api.model.PartitionInfo.Sizes} object for this database
+     * partition.
+     *
+     * @return The {@link com.cloudant.client.api.model.PartitionInfo.Sizes} object, containing data
+     * size information for this database partition.
+     */
+    public Sizes getSizes() {
+        return sizes;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("PartitionInfo [docCount=%s, docDelCount=%s, partition=%s, " +
+                        "sizes=Sizes [external=%s, active=%s]]",
+                        docCount, docDelCount, partition, sizes.getActive(), sizes.getExternal());
+    }
+
+}

--- a/cloudant-client/src/main/java/com/cloudant/client/api/views/SettableViewParameters.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/views/SettableViewParameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 IBM Corp. All rights reserved.
+ * Copyright © 2015, 2019 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -13,6 +13,9 @@
  */
 
 package com.cloudant.client.api.views;
+
+import com.cloudant.client.api.Database;
+import com.cloudant.client.api.model.DbInfo;
 
 /**
  * Describes the parameters that can be set when building view requests.
@@ -231,6 +234,20 @@ public interface SettableViewParameters {
          */
 
         RB update(String update);
+
+        /**
+         * A partition key can be specified when querying data so that results can be constrained
+         * to a specific database partition.
+         *
+         * Only available in partitioned databases. To verify a database is partitioned call
+         * {@link Database#info()} and check that {@link DbInfo.Props#getPartitioned()} returns
+         * {@code true}.
+         *
+         * @param partition database partition key
+         * @return the builder to compose additional parameters or build the request
+         * @since 2.15.0
+         */
+        RB partition(String partition);
     }
 
     /**

--- a/cloudant-client/src/main/java/com/cloudant/client/internal/DatabaseURIHelper.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/internal/DatabaseURIHelper.java
@@ -1,7 +1,6 @@
 /**
- * Copyright (C) 2013 Cloudant
- *
  * Copyright (C) 2011 Ahmed Yehia (ahmed.yehia.m@gmail.com)
+ * Copyright © 2013, 2019 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -189,6 +188,16 @@ public class DatabaseURIHelper extends URIBaseMethods<DatabaseURIHelper> {
 
     public DatabaseURIHelper query(Params params) {
         this.qParams = params;
+        return returnThis();
+    }
+
+    /**
+     * Set the database partition for the URI (iff partition key is non-null).
+     */
+    public DatabaseURIHelper partition(String partitionKey) {
+        if (partitionKey != null) {
+            this.path("_partition").path(partitionKey);
+        }
         return returnThis();
     }
 

--- a/cloudant-client/src/main/java/com/cloudant/client/internal/views/CommonViewRequestBuilder.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/internal/views/CommonViewRequestBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 IBM Corp. All rights reserved.
+ * Copyright (c) 2015, 2019 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -150,6 +150,12 @@ public abstract class CommonViewRequestBuilder<K, V, RB extends RequestBuilder<R
     @Override
     public RB update(String update) {
         viewQueryParameters.setUpdate(update);
+        return returnThis();
+    }
+
+    @Override
+    public RB partition(String partition) {
+        viewQueryParameters.setPartition(partition);
         return returnThis();
     }
 

--- a/cloudant-client/src/main/java/com/cloudant/client/internal/views/ViewQueryParameters.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/internal/views/ViewQueryParameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 IBM Corp. All rights reserved.
+ * Copyright © 2015, 2019 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -37,6 +37,8 @@ public class ViewQueryParameters<K, V> extends ParameterAnnotationProcessor impl
     private final Class<V> valueType;
     private final Gson gson;
     private Integer rowsPerPage = null;
+
+    public String partition = null;
 
     /* Query Parameters
     * Note that null is used for unset parameters and in those cases the default will be applied
@@ -184,6 +186,14 @@ public class ViewQueryParameters<K, V> extends ParameterAnnotationProcessor impl
         this.inclusive_end = inclusive_end;
     }
 
+    public String getPartition() {
+        return partition;
+    }
+
+    public void setPartition(String partition_key) {
+        this.partition = partition_key;
+    }
+
     @SuppressWarnings("unchecked")
     public K[] getKeys() {
         if (key != null) {
@@ -318,8 +328,8 @@ public class ViewQueryParameters<K, V> extends ParameterAnnotationProcessor impl
     }
 
     protected DatabaseURIHelper getViewURIBuilder() {
-        return new DatabaseURIHelper(db.getDBUri()).path("_design").path(designDoc).path("_view")
-                .path(viewName);
+        return new DatabaseURIHelper(db.getDBUri()).partition(partition).path("_design")
+                .path(designDoc).path("_view").path(viewName);
     }
 
     JsonElement asJson() {

--- a/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/CouchDbClient.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/CouchDbClient.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2011 lightcouch.org
- * Copyright © 2015, 2018 IBM Corp. All rights reserved.
+ * Copyright © 2015, 2019 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -206,13 +206,30 @@ public class CouchDbClient {
     }
 
     /**
-     * Requests CouchDB creates a new database; if one doesn't exist.
+     * Requests CouchDB creates a new, non-partitioned database; if one doesn't exist.
      *
      * @param dbName The Database name
      */
     public void createDB(String dbName) {
+        this.createDB(dbName, false);
+    }
+
+    /**
+     * Requests CouchDB creates a new, partitioned database; if one doesn't exist.
+     *
+     * @param dbName The Database name
+     */
+    public void createPartitionedDB(String dbName) {
+        this.createDB(dbName, true);
+    }
+
+    private void createDB(String dbName, Boolean partitioned) {
         assertNotEmpty(dbName, "dbName");
-        final URI uri = new DatabaseURIHelper(getBaseUri(), dbName).getDatabaseUri();
+        DatabaseURIHelper uriHelper = new DatabaseURIHelper(getBaseUri(), dbName);
+        if (partitioned) {
+            uriHelper.query("partitioned", true);
+        }
+        final URI uri = uriHelper.build();
         executeToResponse(Http.PUT(uri, "application/json"));
         log.info(String.format("Created Database: '%s'", dbName));
     }

--- a/cloudant-client/src/test/java/com/cloudant/tests/DatabaseURIHelperTest.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/DatabaseURIHelperTest.java
@@ -277,4 +277,20 @@ public class DatabaseURIHelperTest {
         Assertions.assertEquals(expectedQuery.toASCIIString(), actualQuery.toASCIIString());
     }
 
+    @TestTemplate
+    public void buildPartitionedDatabaseDocumentUri(String path) throws Exception {
+        URI expected = new URI(uriBase + "/test/_partition/partitionKey/documentId");
+
+        URI actual = helper(path + "/test").partition("partitionKey").documentId("documentId").build();
+        Assertions.assertEquals(expected, actual);
+    }
+
+    @TestTemplate
+    public void buildPartitionedDatabaseDocumentUriWithNullPartitionKey(String path) throws Exception {
+        URI expected = new URI(uriBase + "/test/documentId");
+
+        URI actual = helper(path + "/test").partition(null).documentId("documentId").build();
+        Assertions.assertEquals(expected, actual);
+    }
+
 }

--- a/cloudant-client/src/test/java/com/cloudant/tests/PartitionInfoMockTests.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/PartitionInfoMockTests.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright © 2019 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.tests;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.cloudant.client.api.CloudantClient;
+import com.cloudant.client.api.Database;
+import com.cloudant.tests.base.TestWithMockedServer;
+
+import org.junit.jupiter.api.Test;
+
+import okhttp3.mockwebserver.MockResponse;
+
+/**
+ * Created by samsmith on 28/01/2019.
+ */
+public class PartitionInfoMockTests extends TestWithMockedServer {
+
+    @Test
+    public void getDbPartitionDocCount() {
+        String partitionKey = "myPartitionKey";
+        CloudantClient c = CloudantClientHelper.newMockWebServerClientBuilder(server).build();
+        Database db = c.database("animaldb", false);
+
+        MockResponse response = new MockResponse()
+                .setResponseCode(200)
+                .setBody("{\"doc_count\":123}");
+        server.enqueue(response);
+
+        assertEquals(123, db.partitionInfo(partitionKey).getDocCount());
+    }
+
+    @Test
+    public void getDbPartitionDeletedDocCount() {
+        String partitionKey = "myPartitionKey";
+        CloudantClient c = CloudantClientHelper.newMockWebServerClientBuilder(server).build();
+        Database db = c.database("animaldb", false);
+
+        MockResponse response = new MockResponse()
+                .setResponseCode(200)
+                .setBody("{\"doc_del_count\":456}");
+        server.enqueue(response);
+
+        assertEquals(456, db.partitionInfo(partitionKey).getDocDelCount());
+    }
+
+    @Test
+    public void getDbPartitionPartitionKey() {
+        String partitionKey = "myPartitionKey";
+        CloudantClient c = CloudantClientHelper.newMockWebServerClientBuilder(server).build();
+        Database db = c.database("animaldb", false);
+
+        MockResponse response = new MockResponse()
+                .setResponseCode(200)
+                .setBody("{\"partition\":\"" + partitionKey + "\"}");
+        server.enqueue(response);
+
+        assertEquals(partitionKey, db.partitionInfo(partitionKey).getPartition());
+    }
+
+    @Test
+    public void getDbPartitionSizesActive() {
+        String partitionKey = "myPartitionKey";
+        CloudantClient c = CloudantClientHelper.newMockWebServerClientBuilder(server).build();
+        Database db = c.database("animaldb", false);
+
+        MockResponse response = new MockResponse()
+                .setResponseCode(200)
+                .setBody("{\"sizes\":{\"active\":1234}}");
+        server.enqueue(response);
+
+        assertEquals(1234, db.partitionInfo(partitionKey).getSizes().getActive());
+    }
+
+    @Test
+    public void getDbPartitionSizesExternal() {
+        String partitionKey = "myPartitionKey";
+        CloudantClient c = CloudantClientHelper.newMockWebServerClientBuilder(server).build();
+        Database db = c.database("animaldb", false);
+
+        MockResponse response = new MockResponse()
+                .setResponseCode(200)
+                .setBody("{\"sizes\":{\"external\":5678}}");
+        server.enqueue(response);
+
+        assertEquals(5678, db.partitionInfo(partitionKey).getSizes().getExternal());
+    }
+
+}

--- a/cloudant-client/src/test/java/com/cloudant/tests/PartitionedDatabaseTest.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/PartitionedDatabaseTest.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright © 2019 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.tests;
+
+import static com.cloudant.client.api.query.Expression.eq;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.cloudant.client.api.DesignDocumentManager;
+import com.cloudant.client.api.model.DesignDocument;
+import com.cloudant.client.api.model.Document;
+import com.cloudant.client.api.model.SearchResult;
+import com.cloudant.client.api.query.QueryBuilder;
+import com.cloudant.client.api.query.QueryResult;
+import com.cloudant.client.api.views.AllDocsRequest;
+import com.cloudant.client.api.views.Key;
+import com.cloudant.client.api.views.ViewRequest;
+import com.cloudant.client.api.views.ViewResponse;
+import com.cloudant.test.main.RequiresCloudant;
+import com.cloudant.tests.base.TestWithDbPerClass;
+import com.google.gson.JsonObject;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@RequiresCloudant
+@Tag("partitioned")
+public class PartitionedDatabaseTest extends TestWithDbPerClass {
+
+    private static class PartitionDocument extends Document {
+        private String foo = "bar";
+    }
+
+    @BeforeAll
+    public static void setUp() throws Exception {
+        // Create partitioned data set for testing.
+        List<PartitionDocument> docs = new ArrayList<>();
+        List<String> partitionKeys = Arrays.asList("keyA", "keyB", "keyC");
+        for (int i = 0; i < 30; i++) {
+            PartitionDocument doc = new PartitionDocument();
+            doc.setId(partitionKeys.get(i % 3) + ":doc" + Integer.toString(i));
+            docs.add(doc);
+        }
+        db.bulk(docs);
+
+        for (String partitionKey : partitionKeys) {
+            assertEquals(10, db.partitionInfo(partitionKey).getDocCount());
+        }
+    }
+
+    @Test
+    public void testIsPartitionedDatabase() {
+        assertEquals(true, db.info().getProps().getPartitioned());
+    }
+
+    @Test
+    public void testCreatePartitionedDesignDocument() {
+        String ddocId = "partitioned_ddoc_empty";
+
+        // Create partitioned design document and save to remote server.
+        DesignDocument ddoc = new DesignDocument();
+        ddoc.setId(ddocId);
+
+        DesignDocument.Options options = new DesignDocument.Options();
+        options.setPartitioned(true);
+        ddoc.setOptions(options);
+
+        DesignDocumentManager ddocManager = db.getDesignDocumentManager();
+        ddocManager.put(ddoc);
+
+        // Fetch design document from remote server.
+        DesignDocument ddoc2 = ddocManager.get(ddocId);
+        DesignDocument.Options options2 = ddoc2.getOptions();
+
+        assertNotNull(options2);
+        assertTrue(options2.getPartitioned());
+    }
+
+    @Test
+    public void testPartitionedAllDocs() throws IOException {
+        String partitionKey = "keyA";
+        AllDocsRequest allDocs = db.getAllDocsRequestBuilder().partition(partitionKey).build();
+
+        int count = 0;
+        for (String docId : allDocs.getResponse().getDocIds()) {
+            assertTrue(docId.startsWith(partitionKey));
+            count++;
+        }
+        assertEquals(10, count);
+    }
+
+    @Test
+    public void testPartitionedQuery() throws IOException {
+        String ddocId = "partitioned_ddoc_query";
+
+        // Create index.
+        db.createIndex("{\"index\": {\"fields\": [\"foo\"]}, \"partitioned\": true, \"name\": " +
+                "\"foo-index\", \"ddoc\": \"" + ddocId + "\", \"type\": \"json\"}");
+
+        String partitionKey = "keyC";
+        QueryResult<PartitionDocument> results = db
+                .query(partitionKey, new QueryBuilder(eq("foo", "bar"))
+                        .useIndex(ddocId).build(), PartitionDocument.class);
+
+        // Ensure query runs against partitioned index created above.
+        assertNull(results.getWarning());
+
+        int count = 0;
+        for (PartitionDocument i : results.getDocs()) {
+            assertTrue(i.getId().startsWith(partitionKey));
+            count++;
+        }
+        assertEquals(10, count);
+    }
+
+    @Test
+    public void testPartitionedSearch() throws IOException {
+        String ddocId = "partitioned_ddoc_search";
+
+        // Create design document.
+        DesignDocument ddoc = new DesignDocument();
+        ddoc.setId(ddocId);
+
+        DesignDocument.Options options = new DesignDocument.Options();
+        options.setPartitioned(true);
+        ddoc.setOptions(options);
+
+        JsonObject index = new JsonObject();
+        index.addProperty("index", "function(doc) { index(\"id\", doc._id, {\"store\": true}); }");
+        JsonObject search = new JsonObject();
+        search.add("search", index);
+        ddoc.setIndexes(search);
+
+        DesignDocumentManager ddocManager = db.getDesignDocumentManager();
+        ddocManager.put(ddoc);
+
+        String partitionKey = "keyB";
+        SearchResult<PartitionDocument> results = db
+                .search(partitionKey, "partitioned_ddoc_search/search")
+                .querySearchResult("*:*", PartitionDocument.class);
+
+        int count = 0;
+        for (SearchResult.SearchResultRow i : results.getRows()) {
+            assertTrue(i.getId().startsWith(partitionKey));
+            count++;
+        }
+        assertEquals(10, count);
+    }
+
+    @Test
+    public void testPartitionedView() throws IOException {
+        String ddocId = "partitioned_ddoc_view";
+
+        // Create design document.
+        DesignDocument ddoc = new DesignDocument();
+        ddoc.setId(ddocId);
+
+        DesignDocument.Options options = new DesignDocument.Options();
+        options.setPartitioned(true);
+        ddoc.setOptions(options);
+
+        DesignDocument.MapReduce mr = new DesignDocument.MapReduce();
+        mr.setMap("function(doc) { emit(doc._id, 1); }");
+        Map<String, DesignDocument.MapReduce> view = new HashMap<>();
+        view.put("view", mr);
+        ddoc.setViews(view);
+
+        DesignDocumentManager ddocManager = db.getDesignDocumentManager();
+        ddocManager.put(ddoc);
+
+        String partitionKey = "keyA";
+        ViewRequest<String, String> viewRequest = db.getViewRequestBuilder(ddocId, "view")
+                .newRequest(Key.Type.STRING, String.class)
+                .partition(partitionKey)
+                .build();
+
+        int count = 0;
+        for (ViewResponse.Row<String, String> i : viewRequest.getResponse().getRows()) {
+            assertTrue(i.getKey().startsWith(partitionKey));
+            count++;
+        }
+        assertEquals(10, count);
+    }
+
+}

--- a/cloudant-client/src/test/java/com/cloudant/tests/extensions/DatabaseExtension.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/extensions/DatabaseExtension.java
@@ -101,7 +101,12 @@ public class DatabaseExtension {
         databaseName = sanitizeDbName(String.format("%s-%s", context.getUniqueId(), uniqueSuffix));
         client = clientResource.get();
         if (!mock) {
-            database = client.database(databaseName, true);
+            if (context.getTags().contains("partitioned")) {
+                client.createPartitionedDB(databaseName);
+                database = client.database(databaseName, false);
+            } else {
+                database = client.database(databaseName, true);
+            }
         } else {
             database = client.database(databaseName, false);
         }


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description
Adds partitioned database support.

## Approach
Inject `_partition/<partitionKey>` into the request URI when a partition key is specified for the following operations:
- All docs.
- View queries.
- Search queries.
- Find queries.

Also, adds an additional method on the database class to fetch database partition metadata.

## Schema & API Changes

_No breaking API changes_.

New API:

- `CloudantClient.createPartitionedDB(String dbName)`
- `Database.query(String partitionKey, String query, final Class<T> classOfT)`
- `Database.search(String partitionKey, String searchIndexId)`
- `Database.partitionInfo(String partitionKey)`

## Security and Privacy
No change.

## Testing

Added additional tests:

- `PartitionedDatabaseTest.java`: Exercises the new partition querying features against a real Cloudant instance.
- `PartitionInfoMockTests.java`: Verifies mock partition metadata can be correctly deserialised.

## Monitoring and Logging
No change.
