### PR TITLE
Add partition Index count to db info response.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+# UNRELEASED
+- [NEW] Added database partition metadata fields for partitioned index count/limit.
+
 # 2.15.0 (2019-02-12)
 - [NEW] Added option for client to authenticate with IAM token server.
 - [NEW] Added partitioned database support.

--- a/cloudant-client/findbugs_excludes.xml
+++ b/cloudant-client/findbugs_excludes.xml
@@ -120,13 +120,17 @@ For example because it requires an API change
     </Match>
     <Match>
         <Bug code="UwF" pattern="UWF_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD"/>
-        <Class name="com.cloudant.client.api.model.PartitionInfo$Sizes"/>
-        <Field name="active"/>
+        <Class name="com.cloudant.client.api.model.DbInfo$PartitionedIndexes"/>
+
+    </Match>
+    <Match>
+        <Bug code="UwF" pattern="UWF_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD"/>
+        <Class name="com.cloudant.client.api.model.DbInfo$PartitionedIndexes$Indexes"/>
+
     </Match>
     <Match>
         <Bug code="UwF" pattern="UWF_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD"/>
         <Class name="com.cloudant.client.api.model.PartitionInfo$Sizes"/>
-        <Field name="external"/>
     </Match>
 
     <!-- This is likely a false positive in Findbugs, the IDE doesn't complain an unchecked cast.

--- a/cloudant-client/src/main/java/com/cloudant/client/api/model/DbInfo.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/model/DbInfo.java
@@ -27,6 +27,76 @@ import com.google.gson.annotations.SerializedName;
 public class DbInfo {
 
     /**
+     * Encapsulates partitioned index properties.
+     */
+    public static class PartitionedIndexes {
+
+        /**
+         * Encapsulates index properties.
+         */
+        public static class Indexes {
+
+            private long search;
+            private long view;
+
+
+            /**
+             * Get a count of the partitioned search indexes.
+             *
+             * @return The partitioned search index count.
+             */
+            public long getSearch() {
+                return search;
+            }
+
+
+            /**
+             * Get a count of the partitioned view indexes.
+             *
+             * @return The partitioned view index count.
+             */
+            public long getView() {
+                return view;
+            }
+
+        }
+
+        private long count;
+        private long limit;
+        private Indexes indexes;
+
+        /**
+         * Get a total count of the partitioned indexes.
+         *
+         * @return The total partitioned index count.
+         */
+        public long getCount() {
+            return count;
+        }
+
+        /**
+         * Get the partitioned index limit.
+         *
+         * @return The partitioned index limit.
+         */
+        public long getLimit() {
+            return limit;
+        }
+
+        /**
+         * Get the {@link com.cloudant.client.api.model.DbInfo.PartitionedIndexes.Indexes} object
+         * for this database.
+         *
+         * @return The {@link com.cloudant.client.api.model.DbInfo.PartitionedIndexes.Indexes}
+         * object, containing the count breakdown of partitioned indexes.
+         */
+        public Indexes getIndexes() {
+            return indexes;
+        }
+
+    }
+
+    /**
      * Encapsulates database properties.
      */
     public static class Props {
@@ -62,6 +132,8 @@ public class DbInfo {
     @SerializedName("disk_format_version")
     private int diskFormatVersion;
     private Props props;
+    @SerializedName("partitioned_indexes")
+    private PartitionedIndexes partitionedIndexes;
 
     public String getDbName() {
         return dbName;
@@ -137,15 +209,51 @@ public class DbInfo {
         return props;
     }
 
-    @Override
-    public String toString() {
-        return String
-                .format("CouchDbInfo [dbName=%s, docCount=%s, docDelCount=%s, updateSeq=%s, " +
-                                "purgeSeq=%s, compactRunning=%s, diskSize=%s, instanceStartTime=%s, diskFormatVersion=%s]",
-                        dbName, docCount, docDelCount, updateSeq, purgeSeq,
-                        compactRunning, diskSize, instanceStartTime,
-                        diskFormatVersion);
+    /**
+     * Get the {@link com.cloudant.client.api.model.DbInfo.PartitionedIndexes} object for
+     * this database.
+     *
+     * @return The {@link com.cloudant.client.api.model.DbInfo.PartitionedIndexes} object,
+     * containing metadata about partitioned indexes in this database.
+     */
+    public PartitionedIndexes getPartitionedIndexes() {
+        return partitionedIndexes;
     }
 
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb
+                .append("CouchDbInfo [")
+                .append("dbName=").append(dbName)
+                .append(", docCount=").append(docCount)
+                .append(", docDelCount=").append(docDelCount)
+                .append(", updateSeq=").append(updateSeq)
+                .append(", purgeSeq=").append(purgeSeq)
+                .append(", compactRunning=").append(compactRunning)
+                .append(", diskSize=").append(diskSize)
+                .append(", instanceStartTime=").append(instanceStartTime)
+                .append(", diskFormatVersion=").append(diskFormatVersion);
+
+        if (this.getProps() != null) {
+            sb.append(", props.partitioned=").append(this.getProps().getPartitioned());
+        }
+
+        if (this.getPartitionedIndexes() != null) {
+            sb
+                    .append(", partitionedIndexes.count=")
+                    .append(this.getPartitionedIndexes().getCount())
+                    .append(", partitionedIndexes.limit=")
+                    .append(this.getPartitionedIndexes().getLimit())
+                    .append(", partitionedIndexes.indexes.search=")
+                    .append(this.getPartitionedIndexes().getIndexes().getSearch())
+                    .append(", partitionedIndexes.indexes.view=")
+                    .append(this.getPartitionedIndexes().getIndexes().getView());
+        }
+
+        sb.append("]");
+
+        return sb.toString();
+    }
 
 }

--- a/cloudant-client/src/test/java/com/cloudant/tests/DbInfoMockTests.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/DbInfoMockTests.java
@@ -83,4 +83,57 @@ public class DbInfoMockTests extends TestWithMockedServer {
 
         assertEquals(mockPurgeSeq, db.info().getStringPurgeSeq());
     }
+
+    @Test
+    public void getDbPartitionPartitionedIndexesCount() {
+        CloudantClient c = CloudantClientHelper.newMockWebServerClientBuilder(server).build();
+        Database db = c.database("animaldb", false);
+
+        MockResponse response = new MockResponse()
+                .setResponseCode(200)
+                .setBody("{\"partitioned_indexes\":{\"count\":9}}");
+        server.enqueue(response);
+
+        assertEquals(9, db.info().getPartitionedIndexes().getCount());
+    }
+
+    @Test
+    public void getDbPartitionPartitionedIndexesLimit() {
+        CloudantClient c = CloudantClientHelper.newMockWebServerClientBuilder(server).build();
+        Database db = c.database("animaldb", false);
+
+        MockResponse response = new MockResponse()
+                .setResponseCode(200)
+                .setBody("{\"partitioned_indexes\":{\"limit\":10}}");
+        server.enqueue(response);
+
+        assertEquals(10, db.info().getPartitionedIndexes().getLimit());
+    }
+
+    @Test
+    public void getDbPartitionPartitionedIndexesIndexesSearch() {
+        CloudantClient c = CloudantClientHelper.newMockWebServerClientBuilder(server).build();
+        Database db = c.database("animaldb", false);
+
+        MockResponse response = new MockResponse()
+                .setResponseCode(200)
+                .setBody("{\"partitioned_indexes\":{\"indexes\":{\"search\":3}}}");
+        server.enqueue(response);
+
+        assertEquals(3, db.info().getPartitionedIndexes().getIndexes().getSearch());
+    }
+
+    @Test
+    public void getDbPartitionPartitionedIndexesIndexesView() {
+        CloudantClient c = CloudantClientHelper.newMockWebServerClientBuilder(server).build();
+        Database db = c.database("animaldb", false);
+
+        MockResponse response = new MockResponse()
+                .setResponseCode(200)
+                .setBody("{\"partitioned_indexes\":{\"indexes\":{\"view\":6}}}");
+        server.enqueue(response);
+
+        assertEquals(6, db.info().getPartitionedIndexes().getIndexes().getView());
+    }
+
 }


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description
This change adds the following fields to the db info response object for a partitioned database:

```json
"partitioned_indexes": {
  "count": 7,
 "indexes": {
    "search": 1,
    "view": 6
  },
  "limit": 10
}
```
See https://github.com/cloudant/showroom/pull/233.
<!--
Provide a short description; saving the detail for the `Approach` section

Also EITHER:
Link to issue this PR is resolving, use the Fixes #nnn form so that the
issue closes automatically when the PR merges e.g.:

Fixes #23

OR

For PRs without an associated issue and/or test/build issues

### 1. Steps to reproduce and the simplest code sample possible to demonstrate the issue
### 2. What you expected to happen
### 3. What actually happened
-->

## Approach
Add properties to the `PartitionInfo` class allowing the additional fields to be correctly deserialized.
<!--
Be brief: which component(s) of the code base does the fix focus on.

A place to note whether the part of the code base that is being worked is
particularly sensitive.
-->

## Schema & API Changes
Includes new getters on the `PartitionInfo` class (non-breaking).
<!--
EITHER:

- "No change"

OR

For public API (as opposed to internal) changes

- "Fixing bug in API, will change x in such-and-such way"
-->

## Security and Privacy
No change.
<!--
EITHER:

- "No change"

OR

"Making changes in e.g. auth|https|encryption|io
need to be careful about..."

-->

## Testing
Includes additional mock unit tests.
<!--
EITHER:

- Added new tests:
    - test x
    - test y
    - test z

OR

- Modified existing tests because ...

OR

- N/A build or packaging only changes

OR

In exceptional circumstances there may be a good reason we can't add automated
tests, for example if a specific device is required to reproduce a problem.

- No new tests because...
-->

## Monitoring and Logging
No change.
<!--
EITHER:

- "No change"

OR

- "Added new log line X..."
-->
