### PR TITLE
481 deleted count

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+# Unreleased
+- [NEW] Added `com.cloudant.client.api.model.DbInfo#getDocDelCountLong()` to return
+  deleted document count as a `long` instead of a `String`.
+- [DEPRECATED] `com.cloudant.client.api.model.DbInfo#getDocDelCount()`.
+
 # 2.16.0 (2019-04-01)
 - [NEW] Added database partition metadata fields for partitioned index count/limit.
 - [NEW] Added replication selector support.

--- a/cloudant-client/src/main/java/com/cloudant/client/api/model/DbInfo.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/model/DbInfo.java
@@ -118,7 +118,7 @@ public class DbInfo {
     @SerializedName("doc_count")
     private long docCount;
     @SerializedName("doc_del_count")
-    private String docDelCount;
+    private long docDelCount;
     @SerializedName("update_seq")
     private JsonElement updateSeq;
     @SerializedName("purge_seq")
@@ -143,7 +143,22 @@ public class DbInfo {
         return docCount;
     }
 
+    /**
+     *
+     * @return string form of the number of deleted documents in the database
+     *
+     * @see DbInfo#getDocDelCountLong
+     */
+    @Deprecated
     public String getDocDelCount() {
+        return Long.toString(docDelCount);
+    }
+
+    /**
+     *
+     * @return number of deleted documents in the database
+     */
+    public long getDocDelCountLong() {
         return docDelCount;
     }
 

--- a/cloudant-client/src/test/java/com/cloudant/tests/DbInfoMockTests.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/DbInfoMockTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 IBM Corp. All rights reserved.
+ * Copyright © 2018, 2019 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -18,6 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.cloudant.client.api.CloudantClient;
 import com.cloudant.client.api.Database;
+import com.cloudant.client.api.model.DbInfo;
 import com.cloudant.tests.base.TestWithMockedServer;
 
 import org.junit.jupiter.api.Test;
@@ -134,6 +135,21 @@ public class DbInfoMockTests extends TestWithMockedServer {
         server.enqueue(response);
 
         assertEquals(6, db.info().getPartitionedIndexes().getIndexes().getView());
+    }
+
+    @Test
+    public void getDbInfoDocDelCount() {
+        CloudantClient c = CloudantClientHelper.newMockWebServerClientBuilder(server).build();
+        Database db = c.database("animaldb", false);
+
+        MockResponse response = new MockResponse()
+                .setResponseCode(200)
+                .setBody("{\"doc_del_count\":7}");
+        server.enqueue(response);
+
+        DbInfo info = db.info();
+        assertEquals("7", info.getDocDelCount());
+        assertEquals(7l, info.getDocDelCountLong());
     }
 
 }

--- a/cloudant-client/src/test/java/com/cloudant/tests/extensions/MultiExtension.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/extensions/MultiExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 IBM Corp. All rights reserved.
+ * Copyright © 2018, 2019 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -22,19 +22,29 @@ import org.junit.jupiter.api.extension.BeforeTestExecutionCallback;
 import org.junit.jupiter.api.extension.Extension;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
 public class MultiExtension implements Extension, AfterAllCallback, AfterEachCallback,
         AfterTestExecutionCallback, BeforeAllCallback, BeforeEachCallback,
         BeforeTestExecutionCallback {
 
-    private final Extension[] extensions;
+    private final List<Extension> extensions;
+    private final List<Extension> reversedExtensions;
 
     public MultiExtension(Extension... extensions) {
-        this.extensions = extensions;
+        this.extensions = Arrays.asList(extensions);
+        // After tests we need to call extensions in the reverse order
+        this.reversedExtensions = new ArrayList<>(this.extensions.size());
+        this.reversedExtensions.addAll(this.extensions);
+        Collections.reverse(reversedExtensions);
     }
 
     @Override
     public void afterAll(ExtensionContext extensionContext) throws Exception {
-        for (Extension extension : extensions) {
+        for (Extension extension : reversedExtensions) {
             if (extension instanceof AfterAllCallback) {
                 ((AfterAllCallback) extension).afterAll(extensionContext);
             }
@@ -43,7 +53,7 @@ public class MultiExtension implements Extension, AfterAllCallback, AfterEachCal
 
     @Override
     public void afterEach(ExtensionContext extensionContext) throws Exception {
-        for (Extension extension : extensions) {
+        for (Extension extension : reversedExtensions) {
             if (extension instanceof AfterEachCallback) {
                 ((AfterEachCallback) extension).afterEach(extensionContext);
             }
@@ -52,7 +62,7 @@ public class MultiExtension implements Extension, AfterAllCallback, AfterEachCal
 
     @Override
     public void afterTestExecution(ExtensionContext extensionContext) throws Exception {
-        for (Extension extension : extensions) {
+        for (Extension extension : reversedExtensions) {
             if (extension instanceof AfterTestExecutionCallback) {
                 ((AfterTestExecutionCallback) extension).afterTestExecution(extensionContext);
             }


### PR DESCRIPTION
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description

Added `long` return of `doc_del_count` to `DbInfo`.

Fixes #481

## Approach

For some reason the deleted doc count was deserialized into a `String` instead of a `long` and exposed in the API as a `String`.

## Schema & API Changes

- Deprecated existing `String com.cloudant.client.api.model.DbInfo#getDocDelCount`
- Added `long com.cloudant.client.api.model.DbInfo#getDocDelCountLong`

## Security and Privacy

- "No change"

## Testing

- Added new mocked test:
    - `com.cloudant.tests.DbInfoMockTests#getDbInfoDocDelCount`

I also noticed a problem with the execution order of our JUnit 5 `MultiExtension`, where the registered extensions were run in the same order before and _after_, but the extensions should be run in reverse order after tests.

## Monitoring and Logging

- "No change"
