### PR TITLE
Enabled IAM auth for testing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,11 +112,11 @@ CouchDB. To run tests with a remote CouchDB or Cloudant, you need set the
 details of this CouchDB server, including access credentials:
 
 ```
-systemProp.test.couch.username=yourUsername
-systemProp.test.couch.password=yourPassword
-systemProp.test.couch.host=couchdbHost # default localhost
-systemProp.test.couch.port=couchdbPort # default 5984
-systemProp.test.couch.http=[http|https] # default http
+systemProp.test.server.user=yourUsername
+systemProp.test.server.password=yourPassword
+systemProp.test.server.host=couchdborcloudanthost # default localhost
+systemProp.test.server.port=5984 # default 5984
+systemProp.test.server.protocol=[http|https] # default http
 ```
 Alternatively, provide a URL containing all the above information:
 ```

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,7 +29,7 @@ def runTests(testEnv, isServiceTests) {
         withEnv(testEnv) {
             withCredentials([(env.CREDS_ID.contains('iam')) ? string(credentialsId: env.CREDS_ID, variable: 'IAM_API_KEY') : usernamePassword(credentialsId: env.CREDS_ID, usernameVariable: 'DB_USER', passwordVariable: 'DB_PASSWORD')]) {
                 try {
-                    sh "./gradlew ${(env.DB_USER?.trim()) ? '-Dtest.couch.username=$DB_USER -Dtest.couch.password=$DB_PASSWORD' : ''} -Dtest.couch.host=\$DB_HOST -Dtest.couch.port=\$DB_PORT -Dtest.couch.http=\$DB_HTTP \$GRADLE_TARGET"
+                    sh "./gradlew ${(env.DB_USER?.trim()) ? '-Dtest.server.user=$DB_USER -Dtest.server.password=$DB_PASSWORD' : ''} -Dtest.server.host=\$DB_HOST -Dtest.server.port=\$DB_PORT -Dtest.server.protocol=\$DB_HTTP \$GRADLE_TARGET"
                 } finally {
                     junit '**/build/test-results/**/*.xml'
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,10 +27,9 @@ def runTests(testEnv, isServiceTests) {
 
         //Set up the environment and run the tests
         withEnv(testEnv) {
-            withCredentials([usernamePassword(credentialsId: env.CREDS_ID, usernameVariable: 'DB_USER', passwordVariable: 'DB_PASSWORD'),
-                string(credentialsId: 'clientlibs-test-iam', variable: 'DB_IAM_API_KEY')]) {
+            withCredentials([(env.CREDS_ID.contains('iam')) ? string(credentialsId: env.CREDS_ID, variable: 'IAM_API_KEY') : usernamePassword(credentialsId: env.CREDS_ID, usernameVariable: 'DB_USER', passwordVariable: 'DB_PASSWORD')]) {
                 try {
-                    sh './gradlew -Dtest.couch.username=$DB_USER -Dtest.couch.password=$DB_PASSWORD -Dtest.couch.host=$DB_HOST -Dtest.couch.port=$DB_PORT -Dtest.couch.http=$DB_HTTP $GRADLE_TARGET'
+                    sh "./gradlew ${(env.DB_USER?.trim()) ? '-Dtest.couch.username=$DB_USER -Dtest.couch.password=$DB_PASSWORD' : ''} -Dtest.couch.host=\$DB_HOST -Dtest.couch.port=\$DB_PORT -Dtest.couch.http=\$DB_HTTP \$GRADLE_TARGET"
                 } finally {
                     junit '**/build/test-results/**/*.xml'
                 }
@@ -51,6 +50,7 @@ stage('Build') {
 stage('QA') {
     // Define the matrix environments
     def CLOUDANT_ENV = ['DB_HTTP=https', 'DB_HOST=clientlibs-test.cloudant.com', 'DB_PORT=443', 'DB_IGNORE_COMPACTION=true', 'CREDS_ID=clientlibs-test']
+    def CLOUDANT_IAM_ENV = ['DB_HTTP=https', 'DB_HOST=clientlibs-test.cloudant.com', 'DB_PORT=443', 'DB_IGNORE_COMPACTION=true', 'CREDS_ID=clientlibs-test-iam']
     def COUCH1_6_ENV = ['DB_HTTP=http', 'DB_HOST=cloudantsync002.bristol.uk.ibm.com', 'DB_PORT=5984', 'DB_IGNORE_COMPACTION=false', 'CREDS_ID=couchdb']
     def COUCH2_0_ENV = ['DB_HTTP=http', 'DB_HOST=cloudantsync002.bristol.uk.ibm.com', 'DB_PORT=5985', 'DB_IGNORE_COMPACTION=true', 'CREDS_ID=couchdb']
     def CLOUDANT_LOCAL_ENV = ['DB_HTTP=http', 'DB_HOST=cloudantsync002.bristol.uk.ibm.com', 'DB_PORT=8081', 'DB_IGNORE_COMPACTION=true', 'CREDS_ID=couchdb']
@@ -86,6 +86,9 @@ stage('QA') {
                 },
                 CloudantLocal: {
                     runTests(CLOUDANT_LOCAL_ENV, false)
+                },
+                CloudantIam: {
+                    runTests(CLOUDANT_IAM_ENV, true)
                 }
         )
     }

--- a/cloudant-client/build.gradle
+++ b/cloudant-client/build.gradle
@@ -110,9 +110,9 @@ task cloudantServiceTest(type: Test) {
 
 task integrationTest(type: Test) {
     // Special environment variables for integration tests
-    [SERVER_URL:'test.couch.url',
-     SERVER_USER:'test.couch.username',
-     SERVER_PASSWORD:'test.couch.password',
+    [SERVER_URL:'test.server.url',
+     SERVER_USER:'test.server.user',
+     SERVER_PASSWORD:'test.server.password',
      TEST_REPLICATION_SOURCE_URL:'test.replication.source.url'].each { k,v ->
         def e = System.getenv(k)
         if (e) {

--- a/cloudant-client/src/test/java/com/cloudant/tests/CloudFoundryServiceTest.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/CloudFoundryServiceTest.java
@@ -252,7 +252,7 @@ public class CloudFoundryServiceTest {
             public void execute() throws Throwable {
                 VCAPGenerator vcap = new CloudFoundryServiceTest.VCAPGenerator();
                 vcap.createNewLegacyServiceWithEmptyCredentials("test_bluemix_service_1",
-                        CloudantClientHelper.COUCH_HOST);
+                        CloudantClientHelper.SERVER_HOST);
                 ClientBuilder.bluemix(vcap.toJson(), "test_bluemix_service_1");
             }
         });
@@ -277,7 +277,7 @@ public class CloudFoundryServiceTest {
             public void execute() throws Throwable {
                 VCAPGenerator vcap = new CloudFoundryServiceTest.VCAPGenerator();
                 vcap.createNewServiceWithEmptyIAM("test_bluemix_service_1",
-                        CloudantClientHelper.COUCH_HOST);
+                        CloudantClientHelper.SERVER_HOST);
                 ClientBuilder.bluemix(vcap.toJson(), "test_bluemix_service_1");
             }
         });
@@ -382,7 +382,7 @@ public class CloudFoundryServiceTest {
                 vcap.createNewLegacyService("test_bluemix_service_2", "foo2.bar", "admin2",
                         "pass2");
                 vcap.createNewLegacyServiceWithEmptyCredentials("test_bluemix_service_3",
-                        CloudantClientHelper.COUCH_HOST);
+                        CloudantClientHelper.SERVER_HOST);
                 ClientBuilder.bluemix(vcap.toJson(), "test_bluemix_service_3");
             }
         });
@@ -397,7 +397,7 @@ public class CloudFoundryServiceTest {
                 vcap.createNewService("test_bluemix_service_1", "admin1", "apikey1");
                 vcap.createNewService("test_bluemix_service_2", "admin2", "apikey2");
                 vcap.createNewServiceWithEmptyIAM("test_bluemix_service_3",
-                        CloudantClientHelper.COUCH_HOST);
+                        CloudantClientHelper.SERVER_HOST);
                 ClientBuilder.bluemix(vcap.toJson(), "test_bluemix_service_3");
             }
         });

--- a/cloudant-client/src/test/java/com/cloudant/tests/CloudFoundryServiceTest.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/CloudFoundryServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016, 2018 IBM Corp. All rights reserved.
+ * Copyright © 2016, 2019 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -14,18 +14,14 @@
 
 package com.cloudant.tests;
 
+import static com.cloudant.tests.util.MockWebServerResources.IAM_API_KEY;
 import static com.cloudant.tests.util.MockWebServerResources.IAM_TOKEN;
 import static com.cloudant.tests.util.MockWebServerResources.OK_IAM_COOKIE;
-import static com.cloudant.tests.util.MockWebServerResources.IAM_API_KEY;
 import static com.cloudant.tests.util.MockWebServerResources.iamTokenEndpoint;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.cloudant.client.api.ClientBuilder;
 import com.cloudant.client.api.CloudantClient;
-import com.cloudant.http.Http;
-import com.cloudant.http.HttpConnection;
 import com.cloudant.tests.extensions.MockWebServerExtension;
 import com.cloudant.tests.util.IamSystemPropertyMock;
 import com.cloudant.tests.util.MockWebServerResources;
@@ -51,6 +47,10 @@ import java.util.Map;
 public class CloudFoundryServiceTest {
 
     public static IamSystemPropertyMock iamSystemPropertyMock;
+
+    private static String TEST_HOST = "https://cloudant.example";
+    private static String TEST_USER = "user";
+    private static String TEST_PASSWORD = "pass";
 
     private String mockServerHostPort;
 
@@ -167,8 +167,7 @@ public class CloudFoundryServiceTest {
             public void execute() throws Throwable {
                 VCAPGenerator vcap = new CloudFoundryServiceTest.VCAPGenerator();
                 vcap.createNewLegacyService("test_bluemix_service_1",
-                        CloudantClientHelper.COUCH_HOST,
-                        CloudantClientHelper.COUCH_USERNAME, CloudantClientHelper.COUCH_PASSWORD);
+                        TEST_HOST, TEST_USER, TEST_PASSWORD);
                 ClientBuilder.bluemix(vcap.toJson(), "missingService", "test_bluemix_service_1")
                         .build();
             }
@@ -182,8 +181,7 @@ public class CloudFoundryServiceTest {
             public void execute() throws Throwable {
                 VCAPGenerator vcap = new CloudFoundryServiceTest.VCAPGenerator();
                 vcap.createNewLegacyService("test_bluemix_service_1",
-                        CloudantClientHelper.COUCH_HOST,
-                        CloudantClientHelper.COUCH_USERNAME, CloudantClientHelper.COUCH_PASSWORD);
+                        TEST_HOST, TEST_USER, TEST_PASSWORD);
                 ClientBuilder.bluemix(vcap.toJson(), null, "test_bluemix_service_1").build();
             }
         });

--- a/cloudant-client/src/test/java/com/cloudant/tests/CloudantClientHelper.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/CloudantClientHelper.java
@@ -33,54 +33,54 @@ public abstract class CloudantClientHelper {
     //some tests need access to the URI with user info (e.g. replication)
     public static final String SERVER_URI_WITH_USER_INFO;
     //some tests need access to the credentials (e.g. auth interceptors, vcap)
-    static final String COUCH_USERNAME;
-    static final String COUCH_PASSWORD;
-    static final String COUCH_HOST;
+    static final String SERVER_USER;
+    static final String SERVER_PASSWORD;
+    static final String SERVER_HOST;
 
     private static final CloudantClient CLIENT_INSTANCE;
 
-    private static final String COUCH_PORT;
-    private static final String HTTP_PROTOCOL;
+    private static final String SERVER_PORT;
+    private static final String SERVER_PROTOCOL;
     private static final URL SERVER_URL;
 
     static {
 
         try {
             //a URL might be supplied, otherwise use the separate properties
-            String URL = System.getProperty("test.couch.url");
+            String URL = System.getProperty("test.server.url");
             if (URL != null) {
                 URL couch = new URL(URL);
-                HTTP_PROTOCOL = couch.getProtocol();
-                COUCH_HOST = couch.getHost();
-                COUCH_PORT = (couch.getPort() < 0) ? null : Integer.toString(couch.getPort());
+                SERVER_PROTOCOL = couch.getProtocol();
+                SERVER_HOST = couch.getHost();
+                SERVER_PORT = (couch.getPort() < 0) ? null : Integer.toString(couch.getPort());
                 String userInfo = couch.getUserInfo();
                 if (userInfo != null) {
-                    COUCH_USERNAME = userInfo.substring(0, userInfo.indexOf(":"));
-                    COUCH_PASSWORD = userInfo.substring(userInfo.indexOf(":") + 1);
+                    SERVER_USER = userInfo.substring(0, userInfo.indexOf(":"));
+                    SERVER_PASSWORD = userInfo.substring(userInfo.indexOf(":") + 1);
                 } else {
-                    COUCH_USERNAME = System.getProperty("test.couch.username");
-                    COUCH_PASSWORD = System.getProperty("test.couch.password");
+                    SERVER_USER = System.getProperty("test.server.user");
+                    SERVER_PASSWORD = System.getProperty("test.server.password");
                 }
             } else {
-                COUCH_USERNAME = System.getProperty("test.couch.username");
-                COUCH_PASSWORD = System.getProperty("test.couch.password");
-                COUCH_HOST = System.getProperty("test.couch.host", "localhost");
-                COUCH_PORT = System.getProperty("test.couch.port", "5984");
-                HTTP_PROTOCOL = System.getProperty("test.couch.http", "http"); //should either be
+                SERVER_USER = System.getProperty("test.server.user");
+                SERVER_PASSWORD = System.getProperty("test.server.password");
+                SERVER_HOST = System.getProperty("test.server.host", "localhost");
+                SERVER_PORT = System.getProperty("test.server.port", "5984");
+                SERVER_PROTOCOL = System.getProperty("test.server.protocol", "http"); //should either be
                 // http or https
             }
 
             //now build the URLs
-            SERVER_URL = new URL(HTTP_PROTOCOL + "://"
-                    + COUCH_HOST
-                    + ((COUCH_PORT != null) ? ":" + COUCH_PORT : "")); //port if supplied
+            SERVER_URL = new URL(SERVER_PROTOCOL + "://"
+                    + SERVER_HOST
+                    + ((SERVER_PORT != null) ? ":" + SERVER_PORT : "")); //port if supplied
 
             // Ensure username and password are correctly URL encoded when included in the URI
-            SERVER_URI_WITH_USER_INFO = HTTP_PROTOCOL + "://"
-                    + ((!IamAuthCondition.IS_IAM_ENABLED && COUCH_USERNAME != null) ?
-                    URLEncoder.encode(COUCH_USERNAME, "UTF-8") +
-                    ":" + URLEncoder.encode(COUCH_PASSWORD, "UTF-8") + "@" : "") + COUCH_HOST + (
-                    (COUCH_PORT != null) ? ":" + COUCH_PORT : ""); //port if supplied
+            SERVER_URI_WITH_USER_INFO = SERVER_PROTOCOL + "://"
+                    + ((!IamAuthCondition.IS_IAM_ENABLED && SERVER_USER != null) ?
+                    URLEncoder.encode(SERVER_USER, "UTF-8") +
+                    ":" + URLEncoder.encode(SERVER_PASSWORD, "UTF-8") + "@" : "") + SERVER_HOST + (
+                    (SERVER_PORT != null) ? ":" + SERVER_PORT : ""); //port if supplied
         } catch (Throwable t) {
             throw new RuntimeException(t);
         }
@@ -122,8 +122,8 @@ public abstract class CloudantClientHelper {
         if (IamAuthCondition.IS_IAM_ENABLED) {
             builder.iamApiKey(IamAuthCondition.IAM_API_KEY);
         } else {
-            builder.username(COUCH_USERNAME)
-                    .password(COUCH_PASSWORD);
+            builder.username(SERVER_USER)
+                    .password(SERVER_PASSWORD);
         }
         return builder;
     }

--- a/cloudant-client/src/test/java/com/cloudant/tests/CloudantClientTests.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/CloudantClientTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015, 2018 IBM Corp. All rights reserved.
+ * Copyright © 2015, 2019 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -37,6 +37,7 @@ import com.cloudant.test.main.RequiresCloudant;
 import com.cloudant.test.main.RequiresCloudantService;
 import com.cloudant.test.main.RequiresDB;
 import com.cloudant.tests.base.TestWithDbPerClass;
+import com.cloudant.tests.extensions.DisabledWithIam;
 import com.cloudant.tests.extensions.MockWebServerExtension;
 import com.cloudant.tests.util.MockWebServerResources;
 import com.cloudant.tests.util.Utils;
@@ -88,6 +89,7 @@ public class CloudantClientTests extends TestWithDbPerClass {
     }
 
     @Test
+    @DisabledWithIam
     @RequiresCloudantService
     public void apiKey() {
         ApiKey key = account.generateApiKey();
@@ -491,6 +493,7 @@ public class CloudantClientTests extends TestWithDbPerClass {
      * Test that adding the Basic Authentication interceptor to CloudantClient works.
      */
     @Test
+    @DisabledWithIam
     @RequiresCloudant
     public void testBasicAuth() throws IOException {
         BasicAuthInterceptor interceptor =

--- a/cloudant-client/src/test/java/com/cloudant/tests/CloudantClientTests.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/CloudantClientTests.java
@@ -497,10 +497,10 @@ public class CloudantClientTests extends TestWithDbPerClass {
     @RequiresCloudant
     public void testBasicAuth() throws IOException {
         BasicAuthInterceptor interceptor =
-                new BasicAuthInterceptor(CloudantClientHelper.COUCH_USERNAME
-                        + ":" + CloudantClientHelper.COUCH_PASSWORD);
+                new BasicAuthInterceptor(CloudantClientHelper.SERVER_USER
+                        + ":" + CloudantClientHelper.SERVER_PASSWORD);
 
-        CloudantClient client = ClientBuilder.account(CloudantClientHelper.COUCH_USERNAME)
+        CloudantClient client = ClientBuilder.account(CloudantClientHelper.SERVER_USER)
                 .interceptors(interceptor).build();
 
         // Test passes if there are no exceptions

--- a/cloudant-client/src/test/java/com/cloudant/tests/DatabaseTest.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/DatabaseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015, 2018 IBM Corp. All rights reserved.
+ * Copyright © 2015, 2019 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -31,6 +31,7 @@ import com.cloudant.test.main.RequiresCloudantService;
 import com.cloudant.test.main.RequiresCouch;
 import com.cloudant.test.main.RequiresDB;
 import com.cloudant.tests.base.TestWithDbPerClass;
+import com.cloudant.tests.extensions.DisabledWithIam;
 import com.cloudant.tests.extensions.MockWebServerExtension;
 import com.cloudant.tests.util.MockWebServerResources;
 import com.google.gson.GsonBuilder;
@@ -70,10 +71,12 @@ public class DatabaseTest extends TestWithDbPerClass {
         r.source(getReplicationSourceUrl("animaldb"));
         r.createTarget(true);
         r.target(dbResource.getDbURIWithUserInfo());
+        dbResource.appendReplicationAuth(r);
         r.trigger();
     }
 
     @Test
+    @DisabledWithIam
     @RequiresCloudantService
     public void permissions() {
         Map<String, EnumSet<Permissions>> userPerms = db.getPermissions();

--- a/cloudant-client/src/test/java/com/cloudant/tests/HttpTest.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/HttpTest.java
@@ -226,8 +226,8 @@ public class HttpTest extends HttpFactoryParameterizedTest {
     @DisabledWithIam
     @RequiresCloudant
     public void testCookieAuthWithoutRetry() throws IOException {
-        CookieInterceptor interceptor = new CookieInterceptor(CloudantClientHelper.COUCH_USERNAME,
-                CloudantClientHelper.COUCH_PASSWORD, clientResource.get().getBaseUri().toString());
+        CookieInterceptor interceptor = new CookieInterceptor(CloudantClientHelper.SERVER_USER,
+                CloudantClientHelper.SERVER_PASSWORD, clientResource.get().getBaseUri().toString());
 
         HttpConnection conn = new HttpConnection("POST", dbResource.get().getDBUri().toURL(),
                 "application/json");
@@ -285,8 +285,8 @@ public class HttpTest extends HttpFactoryParameterizedTest {
     @RequiresCloudant
     public void testBasicAuth() throws IOException {
         BasicAuthInterceptor interceptor =
-                new BasicAuthInterceptor(CloudantClientHelper.COUCH_USERNAME
-                        + ":" + CloudantClientHelper.COUCH_PASSWORD);
+                new BasicAuthInterceptor(CloudantClientHelper.SERVER_USER
+                        + ":" + CloudantClientHelper.SERVER_PASSWORD);
 
         HttpConnection conn = new HttpConnection("POST", dbResource.get().getDBUri().toURL(),
                 "application/json");

--- a/cloudant-client/src/test/java/com/cloudant/tests/HttpTest.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/HttpTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017, 2018 IBM Corp. All rights reserved.
+ * Copyright © 2017, 2019 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -41,6 +41,7 @@ import com.cloudant.http.internal.interceptors.CookieInterceptor;
 import com.cloudant.test.main.RequiresCloudant;
 import com.cloudant.tests.extensions.CloudantClientExtension;
 import com.cloudant.tests.extensions.DatabaseExtension;
+import com.cloudant.tests.extensions.DisabledWithIam;
 import com.cloudant.tests.extensions.MockWebServerExtension;
 import com.cloudant.tests.extensions.MultiExtension;
 import com.cloudant.tests.util.HttpFactoryParameterizedTest;
@@ -163,6 +164,7 @@ public class HttpTest extends HttpFactoryParameterizedTest {
      * Basic test that we can write a document body by POSTing to a known database
      */
     @TestTemplate
+    @DisabledWithIam
     public void testWriteToServerOk() throws Exception {
         HttpConnection conn = new HttpConnection("POST", new URL(dbResource.getDbURIWithUserInfo()),
                 "application/json");
@@ -221,6 +223,7 @@ public class HttpTest extends HttpFactoryParameterizedTest {
     // be named cookie_test
     //
     @TestTemplate
+    @DisabledWithIam
     @RequiresCloudant
     public void testCookieAuthWithoutRetry() throws IOException {
         CookieInterceptor interceptor = new CookieInterceptor(CloudantClientHelper.COUCH_USERNAME,
@@ -278,6 +281,7 @@ public class HttpTest extends HttpFactoryParameterizedTest {
      * is expected to hold the newly created document's id and rev.
      */
     @TestTemplate
+    @DisabledWithIam
     @RequiresCloudant
     public void testBasicAuth() throws IOException {
         BasicAuthInterceptor interceptor =

--- a/cloudant-client/src/test/java/com/cloudant/tests/IndexTests.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/IndexTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015, 2018 IBM Corp. All rights reserved.
+ * Copyright © 2015, 2019 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -64,6 +64,7 @@ public class IndexTests extends TestWithDbPerClass {
         r.source(getReplicationSourceUrl("movies-demo"));
         r.createTarget(true);
         r.target(dbResource.getDbURIWithUserInfo());
+        dbResource.appendReplicationAuth(r);
         r.trigger();
 
         //Create indexes

--- a/cloudant-client/src/test/java/com/cloudant/tests/ReplicationTest.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/ReplicationTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2011 lightcouch.org
- * Copyright © 2015, 2018 IBM Corp. All rights reserved.
+ * Copyright © 2015, 2019 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -36,10 +36,11 @@ public class ReplicationTest extends TestWithReplication {
 
     @Test
     public void replication() {
-        ReplicationResult result = account.replication()
+        ReplicationResult result = db1Resource.appendReplicationAuth(account.replication()
                 .createTarget(true)
                 .source(db1URI)
                 .target(db2URI)
+        )
                 .trigger();
 
         assertTrue(result.isOk(), "The replication should complete ok");
@@ -53,12 +54,13 @@ public class ReplicationTest extends TestWithReplication {
         Map<String, Object> queryParams = new HashMap<String, Object>();
         queryParams.put("somekey1", "value 1");
 
-        ReplicationResult result = account.replication()
+        ReplicationResult result = db1Resource.appendReplicationAuth(account.replication()
                 .createTarget(true)
                 .source(db1URI)
                 .target(db2URI)
                 .filter("example/example_filter")
                 .queryParams(queryParams)
+        )
                 .trigger();
 
         assertTrue(result.isOk(), "The replication should complete ok");
@@ -72,8 +74,9 @@ public class ReplicationTest extends TestWithReplication {
         db1.save(fooOnDb1);
 
         // trigger a replication
-        ReplicationResult result = account.replication().source(db1URI)
-                .target(db2URI).createTarget(true).trigger();
+        ReplicationResult result =
+                db1Resource.appendReplicationAuth(account.replication().source(db1URI)
+                .target(db2URI).createTarget(true)).trigger();
 
         assertTrue(result.isOk(), "The replication should complete ok");
 
@@ -93,8 +96,9 @@ public class ReplicationTest extends TestWithReplication {
         db2.save(foodb2);
 
         //replicate with DB1 with DB2
-        ReplicationResult result = account.replication().source(db1URI)
-                .target(db2URI).trigger();
+        ReplicationResult result =
+                db1Resource.appendReplicationAuth(account.replication().source(db1URI)
+                .target(db2URI)).trigger();
 
         assertTrue(result.isOk(), "The replication should complete ok");
 

--- a/cloudant-client/src/test/java/com/cloudant/tests/ReplicatorTest.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/ReplicatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015, 2018 IBM Corp. All rights reserved.
+ * Copyright © 2015, 2019 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -50,11 +50,12 @@ public class ReplicatorTest extends TestWithReplication {
 
     @Test
     public void replication() throws Exception {
-        Response response = account.replicator()
+        Response response = db1Resource.appendReplicatorAuth(account.replicator()
                 .replicatorDocId(repDocId)
                 .createTarget(true)
                 .source(db1URI)
                 .target(db2URI)
+        )
                 .save();
 
         // find and remove replicator doc
@@ -68,13 +69,14 @@ public class ReplicatorTest extends TestWithReplication {
         Map<String, Object> queryParams = new HashMap<String, Object>();
         queryParams.put("somekey1", "value 1");
 
-        Response response = account.replicator()
+        Response response = db1Resource.appendReplicatorAuth(account.replicator()
                 .createTarget(true)
                 .replicatorDocId(repDocId)
                 .source(db1URI)
                 .target(db2URI)
                 .filter("example/example_filter")
                 .queryParams(queryParams)
+        )
                 .save();
 
         // find and remove replicator doc
@@ -87,11 +89,12 @@ public class ReplicatorTest extends TestWithReplication {
     public void replicatorDB() throws Exception {
 
         // trigger a replication
-        Response response = account.replicator()
+        Response response = db1Resource.appendReplicatorAuth(account.replicator()
                 .replicatorDocId(repDocId)
                 .source(db1URI)
                 .target(db2URI).continuous(true)
                 .createTarget(true)
+        )
                 .save();
 
         // we need the replication to start before continuing
@@ -116,8 +119,9 @@ public class ReplicatorTest extends TestWithReplication {
         db2.save(foodb2);
 
         //replicate with DB1 with DB2
-        Response response = account.replicator().source(db1URI)
+        Response response = db1Resource.appendReplicatorAuth(account.replicator().source(db1URI)
                 .target(db2URI).replicatorDocId(repDocId)
+        )
                 .save();
 
         // we need the replication to finish before continuing

--- a/cloudant-client/src/test/java/com/cloudant/tests/SearchTests.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/SearchTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015, 2018 IBM Corp. All rights reserved.
+ * Copyright © 2015, 2019 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -50,6 +50,7 @@ public class SearchTests extends TestWithDbPerClass {
         r.source(getReplicationSourceUrl("animaldb"));
         r.createTarget(true);
         r.target(dbResource.getDbURIWithUserInfo());
+        dbResource.appendReplicationAuth(r);
         r.trigger();
 
         // sync the design doc for faceted search

--- a/cloudant-client/src/test/java/com/cloudant/tests/UpdateHandlerTest.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/UpdateHandlerTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2011 lightcouch.org
- * Copyright © 2015, 2018 IBM Corp. All rights reserved.
+ * Copyright © 2015, 2019 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -22,12 +22,14 @@ import com.cloudant.client.api.model.Params;
 import com.cloudant.client.api.model.Response;
 import com.cloudant.test.main.RequiresDB;
 import com.cloudant.tests.base.TestWithDbPerClass;
+import com.cloudant.tests.extensions.DisabledWithIam;
 import com.cloudant.tests.util.Utils;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 @RequiresDB
+@DisabledWithIam
 public class UpdateHandlerTest extends TestWithDbPerClass {
 
     @BeforeAll

--- a/cloudant-client/src/test/java/com/cloudant/tests/extensions/DatabaseExtension.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/extensions/DatabaseExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015, 2018 IBM Corp. All rights reserved.
+ * Copyright © 2015, 2019 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -16,6 +16,8 @@ package com.cloudant.tests.extensions;
 
 import com.cloudant.client.api.CloudantClient;
 import com.cloudant.client.api.Database;
+import com.cloudant.client.api.Replication;
+import com.cloudant.client.api.Replicator;
 import com.cloudant.tests.util.Utils;
 
 import org.junit.jupiter.api.extension.AfterAllCallback;
@@ -133,9 +135,24 @@ public class DatabaseExtension {
      *
      * @return the URI for the DB with creds
      */
-    public String getDbURIWithUserInfo() throws Exception {
+    public String getDbURIWithUserInfo() {
         String info = clientResource.getBaseURIWithUserInfo() + "/" + getDatabaseName();
         return info;
+    }
+
+    public Replication appendReplicationAuth(Replication r) {
+        if (IamAuthCondition.IS_IAM_ENABLED) {
+            r.sourceIamApiKey(IamAuthCondition.IAM_API_KEY);
+            r.targetIamApiKey(IamAuthCondition.IAM_API_KEY);
+        }
+        return r;
+    }
+    public Replicator appendReplicatorAuth(Replicator r) {
+        if (IamAuthCondition.IS_IAM_ENABLED) {
+            r.sourceIamApiKey(IamAuthCondition.IAM_API_KEY);
+            r.targetIamApiKey(IamAuthCondition.IAM_API_KEY);
+        }
+        return r;
     }
 
     public static class PerClass extends DatabaseExtension implements BeforeAllCallback,

--- a/cloudant-client/src/test/java/com/cloudant/tests/extensions/DisabledWithIam.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/extensions/DisabledWithIam.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2019 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.tests.extensions;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@ExtendWith(IamAuthCondition.class)
+public @interface DisabledWithIam {
+
+}

--- a/cloudant-client/src/test/java/com/cloudant/tests/extensions/IamAuthCondition.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/extensions/IamAuthCondition.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2019 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.cloudant.tests.extensions;
+
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+/**
+ * JUnit execution condition for checking whether an IAM API key is being used for auth during
+ * testing. The environment variable takes precedence over the system property. The values are
+ * exposed for use in other helpers and extensions.
+ */
+public class IamAuthCondition implements ExecutionCondition {
+
+    private static final String IAM_API_KEY_PROP_NAME = "test.iam.api.key";
+    private static final String IAM_API_KEY_ENV_VAR_NAME = "IAM_API_KEY";
+    public static final String IAM_API_KEY;
+    public static final boolean IS_IAM_ENABLED;
+
+    static {
+        String key = System.getenv(IAM_API_KEY_ENV_VAR_NAME);
+        if (key == null) {
+            key = System.getProperty(IAM_API_KEY_PROP_NAME);
+        }
+        IAM_API_KEY = key;
+        IS_IAM_ENABLED = IAM_API_KEY != null;
+    }
+
+    @Override
+    public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
+        if (IS_IAM_ENABLED) {
+            return ConditionEvaluationResult.disabled("Test is not supported when using IAM.");
+        } else {
+            return ConditionEvaluationResult.enabled("Test enabled.");
+        }
+    }
+}


### PR DESCRIPTION
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description

### 1. Steps to reproduce and the simplest code sample possible to demonstrate the issue

Try to run the tests with IAM auth credentials.

### 2. What you expected to happen

Tests to pass.

### 3. What actually happened

Tests fail.

## Approach

* Add `IAM_API_KEY` env var and `test.iam.api.key` property for setting an IAM API key.
* Add a JUnit `ExecutionCondition` and `DisabledWithIam` annotation for skipping tests that cannot work with IAM because they rely on other auth methods (e.g. checking basic or cookie auth).
* Updated replication tests to add IAM auth credentials to replications where necessary, when it is not possible to embed the user info in the URL.

## Schema & API Changes

- "No change"

## Security and Privacy

- "No change"

## Testing

- Modified existing tests because to support IAM auth.
- Used a temp commit to run tests with IAM auth for this branch and they [passed](https://cloudant-sdks-jenkins.swg-devops.com:8443/job/java-cloudant/job/iam-testing/6/testReport/).

## Monitoring and Logging

- "No change"
