### PR TITLE
QueryBuilder.fields() formatting fix

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 # Unreleased
 - [UPGRADED] Optional OkHttp dependency to version 3.12.2.
+- [FIXED] Create an array of strings for QueryBuilder.fields() when a single field is provided.
 
 # 2.17.0 (2019-05-23)
 - [NEW] Added `com.cloudant.client.api.model.DbInfo#getDocDelCountLong()` to return

--- a/cloudant-client/src/main/java/com/cloudant/client/api/query/QueryBuilder.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/query/QueryBuilder.java
@@ -191,7 +191,7 @@ public class QueryBuilder {
      * @return String representation of query.
      */
     public String build() {
-        String fieldsString = this.fields == null ? null : Helpers.quote(this.fields);
+        String fieldsString = this.fields == null ? null : Helpers.quote(this.fields, true);
         String sortString = this.sort == null ? null : quoteSort(this.sort);
         String limitString = this.limit == null ? null : Helpers.quote(this.limit);
         String skipString = this.skip == null ? null : Helpers.quote(this.skip);

--- a/cloudant-client/src/test/java/com/cloudant/tests/QueryTests.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/QueryTests.java
@@ -251,6 +251,14 @@ public class QueryTests {
                 "{\"$eq\": \"de Vito\"}}, {\"Year\": {\"$eq\": 2001}}]}]}}", qb.build());
     }
 
+    // fields must always be an array of strings, even with a single field provided
+    @Test
+    public void basicSelector1WithField() {
+        QueryBuilder qb = new QueryBuilder(eq("director", "Lars von Trier")).fields("_id");
+        Assertions.assertEquals("{\"selector\": {\"director\": {\"$eq\": \"Lars von Trier\"}}, " +
+                                        "\"fields\": [\"_id\"]}", qb.build());
+    }
+
     // "Selector basics"
     @Test
     public void basicSelector1WithFields() {


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description
<!--
Provide a short description; saving the detail for the `Approach` section

Also EITHER:
Link to issue this PR is resolving, use the Fixes #nnn form so that the
issue closes automatically when the PR merges e.g.:

Fixes #23

OR

For PRs without an associated issue and/or test/build issues

### 1. Steps to reproduce and the simplest code sample possible to demonstrate the issue
### 2. What you expected to happen
### 3. What actually happened
-->
`QueryBuilder ` will produce an invalid JSON query when providing a single string to the `QueryBuilder.fields()` method. The [CouchDB spec](https://docs.couchdb.org/en/2.3.1/api/database/find.html) specifies that `fields` must be an array, but the `QueryBuilder` creates JSON where `fields` is of type string instead when only a single field is specified.

To Reproduce:
```
String build = new QueryBuilder(eq("director", "Lars von Trier")).fields("age").build();
System.out.println(build);
```
Pre-patch JSON output: `{"selector": {"director": {"$eq": "Lars von Trier"}}, "fields": "age"}`

Trying to run this query in either the Cloudant UI or the CouchBD UI results in an error message stating that fields must be an array:
<img width="780" alt="Screen Shot 2019-06-07 at 11 49 01 AM" src="https://user-images.githubusercontent.com/4838272/59116818-66e5c500-891a-11e9-8e7d-8d953dbe089a.png">

You can get the same error by submitting this query with the `Database.query()` call.

## Approach

<!--
Be brief: which component(s) of the code base does the fix focus on.

A place to note whether the part of the code base that is being worked is
particularly sensitive.
-->
I changed the version of the `Helpers.quote()` method the `QueryBuilder` uses in its `build()` method to the version that always creates an array of strings no matter the number of arguments provided for the `fields` portion of the query. I added a test to verify that the correct JSON will be produced (a similar test already existed, but only covered the multi-field case).

## Schema & API Changes

<!--
EITHER:

- "No change"

OR

For public API (as opposed to internal) changes

- "Fixing bug in API, will change x in such-and-such way"
-->
No change.

## Security and Privacy

<!--
EITHER:

- "No change"

OR

"Making changes in e.g. auth|https|encryption|io
need to be careful about..."

-->
No change.
## Testing

<!--
EITHER:

- Added new tests:
    - test x
    - test y
    - test z

OR

- Modified existing tests because ...

OR

- N/A build or packaging only changes

OR

In exceptional circumstances there may be a good reason we can't add automated
tests, for example if a specific device is required to reproduce a problem.

- No new tests because...
-->
- Added new test:
    - QueryTests.basicSelector1WithField

## Monitoring and Logging
<!--
EITHER:

- "No change"

OR

- "Added new log line X..."
-->
No change.
