### PR TITLE
474 476 exceptions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 # Unreleased
 - [FIXED] Create an array of strings for QueryBuilder.fields() when a single field is provided.
+- [FIXED] Potential NPE creating exception messages.
 - [IMPROVED] Return exceptions directly from IAM token request failures instead of logging and
   deferring the request to the service with no credentials. The exception type is the same, but
   the message and cause are more clear and a round trip is avoided.

--- a/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/CouchDbClient.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/CouchDbClient.java
@@ -564,7 +564,7 @@ public class CouchDbClient {
                         exception.error = e.error;
                     }
                 } else {
-                    exception = new CouchDbException(e.getMessage(), e);
+                    exception = new CouchDbException(e.getMessage(), e, e.statusCode);
                     exception.error = e.error;
                     exception.reason = e.reason;
                 }

--- a/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/CouchDbException.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/CouchDbException.java
@@ -77,7 +77,7 @@ public class CouchDbException extends RuntimeException {
     public String getMessage() {
         String msg = super.getMessage();
         // trim trailing full stop
-        msg = (msg.endsWith(".")) ? msg.substring(0, msg.length() - 1) : msg;
+        msg = (msg != null && msg.endsWith(".")) ? msg.substring(0, msg.length() - 1) : msg;
 
         // include the status code, URL, error and reason (if available)
         return ((getStatusCode() > 0) ? getStatusCode() + " " : "") + msg

--- a/cloudant-client/src/test/java/com/cloudant/tests/HttpIamTest.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/HttpIamTest.java
@@ -319,7 +319,7 @@ public class HttpIamTest {
                 assertThrows(CouchDbException.class,
                         () -> c.executeRequest(Http.GET(c.getBaseUri())).responseAsString(),
                         "Failure to get a token should throw a CouchDbException.");
-        assertTrue(re.getMessage().startsWith("HTTP response error getting session"), "The " +
+        assertTrue(re.getMessage().startsWith("500 HTTP response error getting session"), "The " +
                 "exception should have been for a HTTP response error.");
 
         // cloudant mock server
@@ -570,10 +570,8 @@ public class HttpIamTest {
                 assertThrows(CouchDbException.class,
                         () -> c.executeRequest(Http.GET(c.getBaseUri())).responseAsString(),
                         "Failure to get a token should throw a CouchDbException.");
-        assertTrue(re.getMessage().startsWith("HTTP response error getting session"), "The " +
-                "exception should have been for a HTTP response error.");
-        assertTrue(re.getMessage().contains("response code 429"), "The exception should report a " +
-                "429 response code");
+        assertTrue(re.getMessage().startsWith("429 HTTP response error getting session"), "The " +
+                "exception should have been for a 429 HTTP response error.");
 
         // iam mock server
 

--- a/cloudant-client/src/test/java/com/cloudant/tests/HttpTest.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/HttpTest.java
@@ -1050,7 +1050,7 @@ public class HttpTest extends HttpFactoryParameterizedTest {
                         () -> c.executeRequest(Http.GET(c.getBaseUri())).responseAsString(),
                         "Bad credentials should throw a CouchDbException.");
 
-        assertTrue(re.getMessage().startsWith("Credentials are incorrect for server"), "The " +
+        assertTrue(re.getMessage().startsWith("401 Credentials are incorrect for server"), "The " +
                 "exception should have been for bad creds.");
     }
 

--- a/cloudant-http/src/main/java/com/cloudant/http/internal/interceptors/CookieInterceptorBase.java
+++ b/cloudant-http/src/main/java/com/cloudant/http/internal/interceptors/CookieInterceptorBase.java
@@ -141,14 +141,17 @@ public abstract class CookieInterceptorBase implements HttpConnectionRequestInte
                         .getErrorStream());
                 // Log the error stream content
                 logger.fine(error);
+                HttpConnectionInterceptorException e;
                 if (responseCode == 401) {
-                    throw new HttpConnectionInterceptorException(String.format("Credentials are " +
+                     e = new HttpConnectionInterceptorException(String.format("Credentials are " +
                             "incorrect for server %s", url));
                 } else {
                     // catch any other response code
-                    throw new HttpConnectionInterceptorException(String.format("HTTP response " +
-                            "error getting session at %s, response code %s", url, responseCode));
+                    e = new HttpConnectionInterceptorException(String.format("HTTP response " +
+                            "error getting session at %s.", url));
                 }
+                e.statusCode = responseCode;
+                throw e;
             }
         } catch (IOException e) {
             throw wrapIOException("Failed to read server response from ", conn.getConnection(), e);

--- a/cloudant-http/src/main/java/com/cloudant/http/internal/interceptors/HttpConnectionInterceptorException.java
+++ b/cloudant-http/src/main/java/com/cloudant/http/internal/interceptors/HttpConnectionInterceptorException.java
@@ -19,6 +19,7 @@ public class HttpConnectionInterceptorException extends RuntimeException {
     public boolean deserialize = false;
     public final String error;
     public final String reason;
+    public int statusCode;
 
     public HttpConnectionInterceptorException(Throwable cause) {
         this.initCause(cause);


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description
Improved CouchDBException messages and meta information.

Fixes #476
Slight correction to #491 

## Approach

* Null check before calling `.endsWith` in `CouchDBException#getMessage()`.
* Ensured HTTP status code is set on `CouchDBException` where possible when created from `HttpConnectionInterceptorException` to satisfy application checks such as those described in #474 


## Schema & API Changes

- Corrected unreleased change introduced by #491 where CouchDBException would no longer contain status code in `_session` failure cases.

## Security and Privacy

- "No change"

## Testing

- Modified existing tests to correct message assertions

## Monitoring and Logging

- "No change"
