### PR TITLE
Add total row count getter to AllDocsResponse

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+# Unreleased
+- [NEW] Add getter for total row count to AllDocsResponse
+
 # 2.18.0 (2019-10-02)
 - [FIXED] Create an array of strings for QueryBuilder.fields() when a single field is provided.
 - [FIXED] Potential NPE creating exception messages.

--- a/cloudant-client/src/main/java/com/cloudant/client/api/views/AllDocsResponse.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/views/AllDocsResponse.java
@@ -93,4 +93,9 @@ public interface AllDocsResponse {
      */
     Map<String, String> getErrors();
 
+    /**
+     * @return the total number of rows in the _all_docs view, before any filtering has taken place
+     * @since 2.19.0
+     */
+    Long getTotalRowCount();
 }

--- a/cloudant-client/src/main/java/com/cloudant/client/internal/views/AllDocsRequestResponse.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/internal/views/AllDocsRequestResponse.java
@@ -82,6 +82,11 @@ public class AllDocsRequestResponse implements AllDocsRequest, AllDocsResponse {
         return errors;
     }
 
+    @Override
+    public Long getTotalRowCount() {
+        return response.getTotalRowCount();
+    }
+
     /*
          * Object representation of rev field from a JSON object.
          * <P>

--- a/cloudant-client/src/test/java/com/cloudant/tests/ViewsTest.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/ViewsTest.java
@@ -732,6 +732,7 @@ public class ViewsTest extends TestWithDbPerTest {
         assertThat(response.getDocs().get(1).isDeleted(), is(true));
         assertThat(response.getDocs().get(1).getId(), is(response2.getId()));
         assertThat(response.getDocs().get(1).getRevision(), is(removeResponse.getRev()));
+        assertThat(response.getTotalRowCount(), is(8L));
     }
 
     // all docs with given keys, one document deleted:


### PR DESCRIPTION
## Checklist
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description
I need to be able to make paginated requests to the primary index. This can be done using the `skip` and `limit` parameters and checking the `total_rows` property from the response. However the Java API states `Do not use skip/limit for pagination, instead use ViewRequestBuilder.newPaginatedRequest(Key.Type, Class) .` but it doesn't seem to be possible to use a `ViewRequestBuilder` with the primary index.
I expected the Java API would be a Java wrapper around the underlying REST API and should expose the same data, so I think it is correct to make the `total_rows` property available in the `AllDocsResponse` interface.

## Approach
The total row count is available in the REST API response but the Java API doesn't provide access. This PR adds total row count getter to `AllDocsResponse` interface and implements this new method. 

## Schema & API Changes
Add total row count getter to AllDocsResponse

## Security and Privacy
No change

## Testing
Added new assert

## Monitoring and Logging
No change