### PR TITLE
Multiview request changes to support Couch3

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 # Unreleased
 - [NEW] Add getter for total row count to AllDocsResponse
+- [FIXED] `ViewMultipleRequest` updated to preferentially use view `queries` format URL instead of
+  deprecated format.
 
 # 2.18.0 (2019-10-02)
 - [FIXED] Create an array of strings for QueryBuilder.fields() when a single field is provided.


### PR DESCRIPTION
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description

Updated view multi-query to work with CouchDB 3

For PRs without an associated issue and/or test/build issues

### 1. Steps to reproduce and the simplest code sample possible to demonstrate the issue

Run `com.cloudant.tests.ViewsTest#multiRequest` against CouchDB 3.

### 2. What you expected to happen

Test to pass.

### 3. What actually happened

Test fails because POST to `{db}/_design/{ddoc}/_view/{viewname}` with `queries` was deprecated since CouchDB 2.2 and is removed in CouchDB 3.

## Approach

Replace `POST` of `{ "queries": [...]}` body to `{db}/_design/{ddoc}/_view/{viewname}` with `POST` to `{db}/_design/{ddoc}/_view/{viewname}/queries`.
On `badmatch` failure fallback to original `POST` to maintain compatibility with CouchDB versions < 2.2.

## Schema & API Changes

- "No change"

## Security and Privacy

- "No change"

## Testing

- No new tests because existing tests cover this functionality and test matrix ensures coverage of new and old endpoints.

## Monitoring and Logging

- "No change"
