### PR TITLE
Dbinfo sizes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 # Unreleased
 - [NEW] Add getter for total row count to AllDocsResponse
+- [NEW] Added `DbInfo#getSizes()` for access to improved sizes information.
+- [FIXED] Corrected `DbInfo#getDiskSize()` to work with `sizes` object if `disk_size` is unavailable.
 - [FIXED] `ViewMultipleRequest` updated to preferentially use view `queries` format URL instead of
   deprecated format.
 

--- a/cloudant-client/src/main/java/com/cloudant/client/api/model/DbInfo.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/model/DbInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015, 2019 IBM Corp. All rights reserved.
+ * Copyright © 2015, 2020 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -113,6 +113,25 @@ public class DbInfo {
         }
     }
 
+    public static class Sizes {
+
+        private long active = 0;
+        private long external = 0;
+        private long file = 0;
+
+        public long getActive() {
+            return this.active;
+        }
+
+        public long getExternal() {
+            return this.external;
+        }
+
+        public long getFile() {
+            return this.file;
+        }
+    }
+
     @SerializedName("db_name")
     private String dbName;
     @SerializedName("doc_count")
@@ -134,6 +153,8 @@ public class DbInfo {
     private Props props;
     @SerializedName("partitioned_indexes")
     private PartitionedIndexes partitionedIndexes;
+    @SerializedName("sizes")
+    private Sizes sizes;
 
     public String getDbName() {
         return dbName;
@@ -204,6 +225,12 @@ public class DbInfo {
     }
 
     public long getDiskSize() {
+        if (diskSize == 0) {
+            Sizes s = getSizes();
+            if (s != null) {
+                return s.getFile();
+            }
+        }
         return diskSize;
     }
 
@@ -233,6 +260,10 @@ public class DbInfo {
      */
     public PartitionedIndexes getPartitionedIndexes() {
         return partitionedIndexes;
+    }
+
+    public Sizes getSizes() {
+        return sizes;
     }
 
     @Override
@@ -270,5 +301,4 @@ public class DbInfo {
 
         return sb.toString();
     }
-
 }

--- a/cloudant-client/src/test/java/com/cloudant/tests/DbInfoMockTests.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/DbInfoMockTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018, 2019 IBM Corp. All rights reserved.
+ * Copyright © 2018, 2020 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -152,4 +152,73 @@ public class DbInfoMockTests extends TestWithMockedServer {
         assertEquals(7l, info.getDocDelCountLong());
     }
 
+    /**
+     * Make sure the fallback caused by disk_size 0, doesn't cause an exception
+     */
+    @Test
+    public void getDbInfoDiskSizeZeroWithoutException() {
+        CloudantClient c = CloudantClientHelper.newMockWebServerClientBuilder(server).build();
+        Database db = c.database("animaldb", false);
+
+        MockResponse response = new MockResponse()
+                .setResponseCode(200)
+                .setBody("{\"disk_size\":0}");
+        server.enqueue(response);
+
+        DbInfo info = db.info();
+        assertEquals(0L, info.getDiskSize(), "The mock disk size should be 0");
+    }
+
+    /**
+     * Make sure disk_size still works
+     */
+    @Test
+    public void getDbInfoDiskSize() {
+        CloudantClient c = CloudantClientHelper.newMockWebServerClientBuilder(server).build();
+        Database db = c.database("animaldb", false);
+
+        MockResponse response = new MockResponse()
+                .setResponseCode(200)
+                .setBody("{\"disk_size\":17}");
+        server.enqueue(response);
+
+        DbInfo info = db.info();
+        assertEquals(17L, info.getDiskSize(), "The mock disk size should be 17");
+    }
+
+    /**
+     * Make sure disk_size using sizes works
+     */
+    @Test
+    public void getDbInfoDiskSizeFromSizes() {
+        CloudantClient c = CloudantClientHelper.newMockWebServerClientBuilder(server).build();
+        Database db = c.database("animaldb", false);
+
+        MockResponse response = new MockResponse()
+                .setResponseCode(200)
+                .setBody("{\"sizes\": {\"active\": 21, \"external\":22, \"file\": 23}}");
+        server.enqueue(response);
+
+        DbInfo info = db.info();
+        assertEquals(23L, info.getDiskSize(), "The mock disk size should be 23");
+    }
+
+    /**
+     * Make sure disk_size using sizes works
+     */
+    @Test
+    public void getDbInfoSizes() {
+        CloudantClient c = CloudantClientHelper.newMockWebServerClientBuilder(server).build();
+        Database db = c.database("animaldb", false);
+
+        MockResponse response = new MockResponse()
+                .setResponseCode(200)
+                .setBody("{\"sizes\": {\"active\": 21, \"external\":22, \"file\": 23}}");
+        server.enqueue(response);
+
+        DbInfo info = db.info();
+        assertEquals(21L, info.getSizes().getActive(), "The mock active disk size should be 21");
+        assertEquals(22L, info.getSizes().getExternal(), "The mock external disk size should be 22");
+        assertEquals(23L, info.getSizes().getFile(), "The mock file disk size should be 23");
+    }
 }


### PR DESCRIPTION
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description

Updated `DbInfo` sizes functionality.

### 1. Steps to reproduce and the simplest code sample possible to demonstrate the issue
Call `db.info().getDiskSize()` on CouchDB 3

### 2. What you expected to happen
Expected to get the actual disk size.

### 3. What actually happened
Got `0`.

## Approach

* Added `DbInfo#getSizes()` for access to improved sizes information from newer Couch releases.
* Corrected existing `DbInfo#getDiskSize()` to work with `sizes` object if `disk_size` is unavailable.

## Schema & API Changes

- Added new API model `DbInfo.Sizes`

## Security and Privacy

- "No change"

## Testing

- Added new tests to `DbInfoMockTests`:
    - `getDbInfoDiskSizeZeroWithoutException`
    - `getDbInfoDiskSize`
    - `getDbInfoDiskSizeFromSizes`
    - `getDbInfoSizes`

## Monitoring and Logging

- "No change"
