### PR TITLE
Closed successful session response body stream

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# Unreleased
+- [FIXED] Connection leak regression introduced in 2.18.0 caused by not closing streams from
+  successful session response bodies.
+
 # 2.19.0 (2020-03-02)
 - [NEW] Add getter for total row count to `AllDocsResponse`
 - [NEW] Added `DbInfo#getSizes()` for access to improved sizes information.


### PR DESCRIPTION
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description

Consume and close response body stream for successful session requests.

Fixes #507 

## Approach

This was regressed by #491 - we used to consume the response body for `_session` requests prior to those changes.

* Added a call to `Utils.collectAndCloseStream` with the response body input stream.
* Allow the potential `IOException` to propagate to the existing `wrapIOException` handler for errors reading response status code or body.

## Schema & API Changes

- "No change"

## Security and Privacy

- "No change"

## Testing

Existing tests are passing.
Added new test `com.cloudant.tests.HttpTest#successfulSessionStreamClose` to assert the response stream is consumed/closed.

## Monitoring and Logging

- Corrected typo in exception message `reponse` -> `response`
