### PR TITLE
Limitations of customSSLSocketFactory and disableSSLAuthentication

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # Unreleased
 - [FIXED] Connection leak regression introduced in 2.18.0 caused by not closing streams from
   successful session response bodies.
+- [UPGRADED] Optional OkHttp dependency to version 3.12.12.
 
 # 2.19.0 (2020-03-02)
 - [NEW] Add getter for total row count to `AllDocsResponse`

--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ The main use case that is supported by this optional dependency is configuration
 ([see the javadoc](http://www.javadoc.io/doc/com.cloudant/cloudant-client/) for ClientBuilder.maxConnections). If the OkHttp dependency is
 available at runtime it will be used automatically. Not using OkHttp will result in a smaller application size.
 
+**Note:** The configuration options `ClientBuilder.customSSLSocketFactory` and
+`ClientBuilder.disableSSLAuthentication` are not usable with the combination of the optional OkHttp
+dependency and Java versions of 8u252 or newer.
+
 ## Getting Started
 
 This section contains a simple example of creating a `com.cloudant.client.api.CloudantClient` instance and interacting with Cloudant.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Gradle with [optional `okhttp-urlconnection` dependency](#optional-okhttp-depend
 ```groovy
 dependencies {
     compile group: 'com.cloudant', name: 'cloudant-client', version: '2.19.0'
-    compile group: 'com.squareup.okhttp3', name: 'okhttp-urlconnection', version: '3.12.5'
+    compile group: 'com.squareup.okhttp3', name: 'okhttp-urlconnection', version: '3.12.12'
 }
 ```
 
@@ -55,7 +55,7 @@ Maven with [optional `okhttp-urlconnection` dependency](#optional-okhttp-depende
 <dependency>
   <groupId>com.squareup.okhttp3</groupId>
   <artifactId>okhttp-urlconnection</artifactId>
-  <version>3.12.5</version>
+  <version>3.12.12</version>
 </dependency>
 ~~~
 

--- a/cloudant-client/build.gradle
+++ b/cloudant-client/build.gradle
@@ -20,7 +20,7 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.1.0'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.1.0'
     testCompile group: 'org.hamcrest', name: 'hamcrest-library', version: '1.3'
-    testCompile group: 'com.squareup.okhttp3', name: 'mockwebserver', version: '3.12.5'
+    testCompile group: 'com.squareup.okhttp3', name: 'mockwebserver', version: '3.12.12'
     testCompile group: 'org.jmockit', name: 'jmockit', version: '1.34'
     testCompile group: 'org.littleshoot', name: 'littleproxy', version: '1.1.0'
 }

--- a/cloudant-client/src/main/java/com/cloudant/client/api/ClientBuilder.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/ClientBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015, 2019 IBM Corp. All rights reserved.
+ * Copyright © 2015, 2020 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -514,6 +514,9 @@ public class ClientBuilder {
      * The SSL authentication is enabled by default meaning that hostname verification
      * and certificate chain validation is done using the JVM default settings.
      * </P>
+     * <P>
+     * <B>Not supported with Java 8u252 or newer and the optional OkHttp dependency.</B>
+     * </P>
      *
      * @return this ClientBuilder object for setting additional options
      * @throws IllegalStateException if {@link #customSSLSocketFactory(SSLSocketFactory)}
@@ -534,6 +537,9 @@ public class ClientBuilder {
     /**
      * Specifies the custom SSLSocketFactory to use when connecting to Cloudant over a
      * <code>https</code> URL, when SSL authentication is enabled.
+     * <P>
+     * <B>Not supported with Java 8u252 or newer and the optional OkHttp dependency.</B>
+     * </P>
      *
      * @param factory An SSLSocketFactory, or <code>null</code> for the
      *                default SSLSocketFactory of the JRE.

--- a/cloudant-client/src/test/java/com/cloudant/tests/CloudFoundryServiceTest.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/CloudFoundryServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016, 2019 IBM Corp. All rights reserved.
+ * Copyright © 2016, 2020 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -24,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import com.cloudant.client.api.ClientBuilder;
 import com.cloudant.client.api.CloudantClient;
 import com.cloudant.tests.extensions.MockWebServerExtension;
+import com.cloudant.tests.util.HttpFactoryParameterizedTest;
 import com.cloudant.tests.util.MockWebServerResources;
 import com.google.gson.GsonBuilder;
 
@@ -63,6 +64,11 @@ public class CloudFoundryServiceTest {
 
     @BeforeEach
     public void beforeEach() {
+        // Default test running uses OkHttp because it is in the classpath
+        // These tests need to use disableSSLAuthentication because the mock server https does not
+        // have a trusted certificate. That option is not valid with OkHttp and Java 8_252 or newer
+        // but we want to run these tests, so use the OkHelperMock to disable OkHttp.
+        new HttpFactoryParameterizedTest.OkHelperMock();
         server = mockWebServerExt.get();
         server.useHttps(MockWebServerResources.getSSLSocketFactory(), false);
         mockServerHostPort = String.format("%s:%s/", server.getHostName(), server.getPort());

--- a/cloudant-client/src/test/java/com/cloudant/tests/HttpProxyTest.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/HttpProxyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015, 2018 IBM Corp. All rights reserved.
+ * Copyright © 2015, 2020 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -23,6 +23,7 @@ import com.cloudant.http.Http;
 import com.cloudant.tests.extensions.MockWebServerExtension;
 import com.cloudant.tests.util.HttpFactoryParameterizedTest;
 import com.cloudant.tests.util.MockWebServerResources;
+import com.cloudant.tests.util.Utils;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -299,6 +300,10 @@ public class HttpProxyTest extends HttpFactoryParameterizedTest {
                                final boolean useSecureProxy,
                                final boolean useHttpsServer,
                                final boolean useProxyAuth) throws Exception {
+
+        // Test uses disableSSLAuthentication because the mock server doesn't have a trusted cert
+        // - need to disable the test for OkHttp and Java 8_252 or newer
+        Utils.assumeCustomSslAuthUsable(okUsable);
 
         //mock a 200 OK
         server.setDispatcher(new Dispatcher() {

--- a/cloudant-client/src/test/java/com/cloudant/tests/SslAuthenticationTest.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/SslAuthenticationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015, 2019 IBM Corp. All rights reserved.
+ * Copyright © 2015, 2020 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -24,6 +24,7 @@ import com.cloudant.test.main.RequiresCloudantService;
 import com.cloudant.tests.extensions.MockWebServerExtension;
 import com.cloudant.tests.util.HttpFactoryParameterizedTest;
 import com.cloudant.tests.util.MockWebServerResources;
+import com.cloudant.tests.util.Utils;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
@@ -136,7 +137,8 @@ public class SslAuthenticationTest extends HttpFactoryParameterizedTest {
      */
     @TestTemplate
     public void localSslAuthenticationDisabled() throws Exception {
-
+        // disableSSLAuthentication not usable with OkHttp and 8_252 or newer
+        Utils.assumeCustomSslAuthUsable(isOkUsable);
         // Build a client that connects to the mock server with SSL authentication disabled
         CloudantClient dbClient = CloudantClientHelper.newMockWebServerClientBuilder(server)
                 .disableSSLAuthentication()
@@ -251,7 +253,8 @@ public class SslAuthenticationTest extends HttpFactoryParameterizedTest {
      */
     @TestTemplate
     public void localSSLAuthenticationDisabledWithCookieAuth() throws Exception {
-
+        // disableSSLAuthentication not usable with OkHttp and 8_252 or newer
+        Utils.assumeCustomSslAuthUsable(isOkUsable);
         // Mock up an OK cookie response then an OK response for the getAllDbs()
         server.enqueue(MockWebServerResources.OK_COOKIE);
         server.enqueue(new MockResponse()); //OK 200

--- a/cloudant-client/src/test/java/com/cloudant/tests/util/HttpFactoryParameterizedTest.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/util/HttpFactoryParameterizedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016, 2018 IBM Corp. All rights reserved.
+ * Copyright © 2016, 2020 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -37,7 +37,7 @@ public abstract class HttpFactoryParameterizedTest extends TestWithDbPerClass {
      * A mock OkHelper that always returns false to force use of the JVM HttpURLConnection
      * via the {@link DefaultHttpUrlConnectionFactory}
      */
-    static class OkHelperMock extends MockUp<OkHelper> {
+    public static class OkHelperMock extends MockUp<OkHelper> {
         @Mock
         public static boolean isOkUsable() {
             return false;

--- a/cloudant-http/build.gradle
+++ b/cloudant-http/build.gradle
@@ -15,7 +15,7 @@
 dependencies {
     compile group: 'commons-io', name: 'commons-io', version: '2.4'
     //needed to compile, but optional for consumers of java-cloudant
-    compile(group: 'com.squareup.okhttp3', name: 'okhttp-urlconnection', version: '3.12.5') {
+    compile(group: 'com.squareup.okhttp3', name: 'okhttp-urlconnection', version: '3.12.12') {
         ext.optional = true
     }
 }


### PR DESCRIPTION
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description

Document the limitations of the options `customSSLSocketFactory` and `disableSSLAuthentication` when using the optional OkHttp dependency and Java 8_252 or newer and ignore certain tests in that environment.

### 1. Steps to reproduce and the simplest code sample possible to demonstrate the issue

Run `com.cloudant.tests.SslAuthenticationTest#localSslAuthenticationDisabled`

### 2. What you expected to happen

Test to pass.

### 3. What actually happened

Test (and 9 similar) failed with:
```
com.cloudant.tests.SslAuthenticationTest > localSslAuthenticationDisabled()[2] FAILED
    java.lang.UnsupportedOperationException: clientBuilder.sslSocketFactory(SSLSocketFactory) not supported on JDK 9+
        at okhttp3.internal.platform.Jdk9Platform.trustManager(Jdk9Platform.java:81)
        at okhttp3.internal.platform.Platform.buildCertificateChainCleaner(Platform.java:176)
        at okhttp3.OkHttpClient$Builder.sslSocketFactory(OkHttpClient.java:768)
        at okhttp3.internal.huc.OkHttpsURLConnection.setSSLSocketFactory(OkHttpsURLConnection.java:66)
        at com.cloudant.http.internal.interceptors.SSLCustomizerInterceptor.interceptRequest(SSLCustomizerInterceptor.java:71)
        at com.cloudant.http.HttpConnection.execute(HttpConnection.java:291)
        at com.cloudant.client.org.lightcouch.CouchDbClient.execute(CouchDbClient.java:552)
        at com.cloudant.client.org.lightcouch.CouchDbClient.executeToInputStream(CouchDbClient.java:648)
        at com.cloudant.client.org.lightcouch.CouchDbClient.get(CouchDbClient.java:389)
        at com.cloudant.client.org.lightcouch.CouchDbClient.getAllDbs(CouchDbClient.java:243)
        at com.cloudant.client.api.CloudantClient.getAllDbs(CloudantClient.java:292)
        at com.cloudant.tests.SslAuthenticationTest.localSslAuthenticationDisabled(SslAuthenticationTest.java:149)
```

## Approach

As per https://github.com/square/okhttp/issues/5970 OkHttp platform detection for 9+ versions was confused by the back-porting of some content to 8_252. The platform detection was fixed in OkHttp 3.12.12 for some paths, but not for deprecated methods. This blocks the route we currently use to supply custom `SslSocketFactory` via the deprecated OkHttp `OkUrlFactory` path via Ok's implementation of javax.net.ssl.HttpsURLConnection#setSSLSocketFactory(javax.net.ssl.SSLSocketFactory).

The workaround if using newer Java versions and requiring to set `customSSLSocketFactory` or `disableSSLAuthentication` options is to not use the optional OkHttp dependency.


## Schema & API Changes

- Document limitation of `customSSLSocketFactory` and `disableSSLAuthentication` options with combination of OkHttp and Java 8_252 or newer.

## Security and Privacy

- "No change"

## Testing

Modified existing tests as follows:

* For parameterized tests that run using both OkHttp and the default then skip tests that need `disableSSLAuthentication` or `customSSLSocketFactory` options when using OkHttp and Java 8_252 or newer:
    * `com.cloudant.tests.SslAuthenticationTest#localSslAuthenticationDisabled`
    * `com.cloudant.tests.SslAuthenticationTest#localSSLAuthenticationDisabledWithCookieAuth`
    * `com.cloudant.tests.HttpProxyTest`
* Make `com.cloudant.tests.CloudFoundryServiceTest` run without using OkHttp

## Monitoring and Logging

- "No change"