### PR TITLE
Disable testing matrix

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -78,15 +78,15 @@ stage('QA') {
     // and Cloudant Local
     if (env.BRANCH_NAME == "master") {
         axes.putAll(
-                Couch1_6: {
-                    runTests(COUCH1_6_ENV, false)
-                },
-                Couch2_0: {
-                    runTests(COUCH2_0_ENV, false)
-                },
-                CloudantLocal: {
-                    runTests(CLOUDANT_LOCAL_ENV, false)
-                },
+//                Couch1_6: {
+//                    runTests(COUCH1_6_ENV, false)
+//                },
+//                Couch2_0: {
+//                    runTests(COUCH2_0_ENV, false)
+//                },
+//                CloudantLocal: {
+//                    runTests(CLOUDANT_LOCAL_ENV, false)
+//                },
                 CloudantIam: {
                     runTests(CLOUDANT_IAM_ENV, true)
                 }


### PR DESCRIPTION
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description

Temporarily disable the Jenkins test matrix while our matrix test environment is unavailable.

## Approach

Comment out test matrix axes that we can't currently run. Otherwise the automated release process is gated by the failures.

## Schema & API Changes

- "No change"

## Security and Privacy

- "No change"

## Testing

- Disabled `Jenkinsfile` test matrix

## Monitoring and Logging

- "No change"

