### PR TITLE
Allow query operators to be used with ONE query expression element

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# Unreleased
+- [FIXED] Allow $and, $or, and $nor operator selectors
+  to be used with only one expression selector
+
 # 2.19.1 (2020-07-03)
 - [FIXED] Connection leak regression introduced in 2.18.0 caused by not closing streams from
   successful session response bodies.
@@ -296,7 +300,7 @@
 - [FIXED] `NullPointerException` when parsing `{doc: null}` JSON in search or view results.
 - [FIXED] Fixed issue with pagination numbering when using `queryPage` with
   a clustered DB.
-- [FIXED] Fixed issue where `queryPage` could not handle JSON values emitted from views.  
+- [FIXED] Fixed issue where `queryPage` could not handle JSON values emitted from views.
 - [IMPROVED] Various documentation updates.
 - [DEPRECATED] `com.cloudant.client.api.model.Page` setter methods.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 # Unreleased
-- [FIXED] Allow $and, $or, and $nor operator selectors
-  to be used with only one expression selector
+- [FIXED] Allow `$and`, `$or`, and `$nor` operator selectors
+  to be used with only one expression selector.
 
 # 2.19.1 (2020-07-03)
 - [FIXED] Connection leak regression introduced in 2.18.0 caused by not closing streams from

--- a/cloudant-client/src/main/java/com/cloudant/client/api/query/Operation.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/query/Operation.java
@@ -80,7 +80,7 @@ public class Operation implements Selector {
     @Override
     public String toString() {
         // op rhs format ($and etc)
-        return String.format("\"%s\": %s", this.op, quoteCurly(this.rhs));
+        return String.format("\"%s\": %s", this.op, quoteCurly(this.rhs, this.op));
     }
 
 }

--- a/cloudant-client/src/main/java/com/cloudant/client/internal/query/Helpers.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/internal/query/Helpers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017, 2018, 2020 IBM Corp. All rights reserved.
+ * Copyright © 2017, 2020 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -61,6 +61,14 @@ public class Helpers {
 
     public static String quoteCurly(Object[] os, String op) {
         if (op.equals("$not")) {
+            // the operation "not" only takes one argument, so we don't need to make an array
+            return String.format("%s%s%s", "{", quote(os[0]), "}");
+        }
+        return quoteInternal(os, ", ", "{", "}", "[", "]");
+    }
+
+    public static String quoteCurly(Object[] os) {
+        if (os.length == 1) {
             // the operation "not" only takes one argument, so we don't need to make an array
             return String.format("%s%s%s", "{", quote(os[0]), "}");
         }

--- a/cloudant-client/src/main/java/com/cloudant/client/internal/query/Helpers.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/internal/query/Helpers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017, 2018 IBM Corp. All rights reserved.
+ * Copyright © 2017, 2018, 2020 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -59,8 +59,8 @@ public class Helpers {
         return quoteInternal(os, ", ", "", "", "", "");
     }
 
-    public static String quoteCurly(Object[] os) {
-        if (os.length == 1) {
+    public static String quoteCurly(Object[] os, String op) {
+        if (op.equals("$not")) {
             // the operation "not" only takes one argument, so we don't need to make an array
             return String.format("%s%s%s", "{", quote(os[0]), "}");
         }

--- a/cloudant-client/src/test/java/com/cloudant/tests/QueryTests.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/QueryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017, 2018, 2020 IBM Corp. All rights reserved.
+ * Copyright © 2017, 2020 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at

--- a/cloudant-client/src/test/java/com/cloudant/tests/QueryTests.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/QueryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017, 2018 IBM Corp. All rights reserved.
+ * Copyright © 2017, 2018, 2020 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -55,6 +55,15 @@ public class QueryTests {
                 eq("location", "Boston")));
         Assertions.assertEquals("{\"selector\": {\"$and\": [{\"name\": {\"$eq\": \"Paul\"}}, " +
                 "{\"location\": {\"$eq\": \"Boston\"}}]}}", qb.build());
+    }
+
+    // "And selector with only one field"
+    @Test
+    public void basicSelector2WithOneField() {
+        QueryBuilder qb = new QueryBuilder(and(
+                eq("name", "Paul")));
+        Assertions.assertEquals("{\"selector\": " +
+                "{\"$and\": [{\"name\": {\"$eq\": \"Paul\"}}]}}", qb.build());
     }
 
     // "SUBFIELDS"


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description
Fixes #515

## Approach

I passed the operator to the `quoteCurly` method and used the array for all the operators except `not`.

## Schema & API Changes

- "No change"


## Security and Privacy

- "No change"


## Testing

- Added new tests:
    - `basicSelector2WithOneField` in `QueryTests` for an `$and` operator passed with only one `$eq` expression element

## Monitoring and Logging
- "No change"