### PR TITLE
Update test server config

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -50,7 +50,7 @@ stage('Build') {
 stage('QA') {
     // Define the matrix environments
     def CLOUDANT_ENV = ['DB_HTTP=https', 'DB_HOST=clientlibs-test.cloudant.com', 'DB_PORT=443', 'DB_IGNORE_COMPACTION=true', 'CREDS_ID=clientlibs-test']
-    def CLOUDANT_IAM_ENV = ['DB_HTTP=https', 'DB_HOST=clientlibs-test.cloudant.com', 'DB_PORT=443', 'DB_IGNORE_COMPACTION=true', 'CREDS_ID=clientlibs-test-iam']
+    def CLOUDANT_IAM_ENV = ['DB_HTTP=https', 'DB_HOST=clientlibs-test.cloudant.com', 'DB_PORT=443', 'DB_IGNORE_COMPACTION=true', 'CREDS_ID=clientlibs-test-iam', "TEST_IAM_TOKEN_URL=${SDKS_TEST_IAM_URL}"]
     def COUCH1_6_ENV = ['DB_HTTP=http', 'DB_HOST=cloudantsync002.bristol-victoria.uk.ibm.com', 'DB_PORT=5984', 'DB_IGNORE_COMPACTION=false', 'CREDS_ID=couchdb']
     def COUCH2_0_ENV = ['DB_HTTP=http', 'DB_HOST=cloudantsync002.bristol-victoria.uk.ibm.com', 'DB_PORT=5985', 'DB_IGNORE_COMPACTION=true', 'CREDS_ID=couchdb']
     def CLOUDANT_LOCAL_ENV = ['DB_HTTP=http', 'DB_HOST=cloudantsync002.bristol-victoria.uk.ibm.com', 'DB_PORT=8081', 'DB_IGNORE_COMPACTION=true', 'CREDS_ID=couchdb']

--- a/cloudant-client/build.gradle
+++ b/cloudant-client/build.gradle
@@ -53,6 +53,17 @@ tasks.withType(Test) {
         }
         jvmArgs "-javaagent:${jMockit}"
     }
+    // Special environment variables for integration tests
+    [SERVER_URL:'test.server.url',
+     SERVER_USER:'test.server.user',
+     SERVER_PASSWORD:'test.server.password',
+     TEST_REPLICATION_SOURCE_URL:'test.replication.source.url',
+     TEST_IAM_TOKEN_URL:'com.cloudant.client.iamserver'].each { k,v ->
+        def e = System.getenv(k)
+        if (e) {
+            systemProperty v, e
+        }
+    }
 }
 
 // Run tests which are compatible with all versions of Couch or
@@ -91,16 +102,6 @@ task cloudantServiceTest(type: Test) {
 }
 
 task integrationTest(type: Test) {
-    // Special environment variables for integration tests
-    [SERVER_URL:'test.server.url',
-     SERVER_USER:'test.server.user',
-     SERVER_PASSWORD:'test.server.password',
-     TEST_REPLICATION_SOURCE_URL:'test.replication.source.url'].each { k,v ->
-        def e = System.getenv(k)
-        if (e) {
-            systemProperty v, e
-        }
-    }
     // Run all tests that need a running DB and those for Cloudant, but not unit tests
     useJUnitPlatform {
         includeEngines 'junit-jupiter'

--- a/cloudant-client/src/test/java/com/cloudant/tests/CloudFoundryServiceTest.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/CloudFoundryServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016, 2020 IBM Corp. All rights reserved.
+ * Copyright © 2016, 2021 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -14,7 +14,6 @@
 
 package com.cloudant.tests;
 
-import static com.cloudant.http.internal.interceptors.IamCookieInterceptor.IAM_TOKEN_SERVER_URL_PROPERTY_KEY;
 import static com.cloudant.tests.util.MockWebServerResources.IAM_API_KEY;
 import static com.cloudant.tests.util.MockWebServerResources.IAM_TOKEN;
 import static com.cloudant.tests.util.MockWebServerResources.OK_IAM_COOKIE;
@@ -23,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.cloudant.client.api.ClientBuilder;
 import com.cloudant.client.api.CloudantClient;
+import com.cloudant.tests.extensions.MockIamWebServerExtension;
 import com.cloudant.tests.extensions.MockWebServerExtension;
 import com.cloudant.tests.util.HttpFactoryParameterizedTest;
 import com.cloudant.tests.util.MockWebServerResources;
@@ -57,7 +57,7 @@ public class CloudFoundryServiceTest {
     public MockWebServerExtension mockWebServerExt = new MockWebServerExtension();
 
     @RegisterExtension
-    public MockWebServerExtension mockIamServerExt = new MockWebServerExtension();
+    public MockWebServerExtension mockIamServerExt = new MockIamWebServerExtension();
 
     public MockWebServer server;
     public MockWebServer mockIamServer;
@@ -74,14 +74,6 @@ public class CloudFoundryServiceTest {
         mockServerHostPort = String.format("%s:%s/", server.getHostName(), server.getPort());
         //setup mock IAM server
         mockIamServer = mockIamServerExt.get();
-        // Override the default IAM token server with our test mock server
-        System.setProperty(IAM_TOKEN_SERVER_URL_PROPERTY_KEY, mockIamServer.url(iamTokenEndpoint)
-                .toString());
-    }
-
-    @AfterEach
-    public void clearIAMMock() {
-        System.clearProperty(IAM_TOKEN_SERVER_URL_PROPERTY_KEY);
     }
 
     private static class VCAPGenerator {
@@ -98,7 +90,7 @@ public class CloudFoundryServiceTest {
             cloudantServices = new ArrayList<HashMap<String, Object>>();
             vcap.put(serviceName, cloudantServices);
         }
-        
+
         private void addService(String name, String username, String password,
                                 String host, String apikey) {
             HashMap<String, Object> cloudantService = new HashMap<String, Object>();

--- a/cloudant-client/src/test/java/com/cloudant/tests/CloudantClientHelper.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/CloudantClientHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015, 2019 IBM Corp. All rights reserved.
+ * Copyright © 2015, 2021 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -36,12 +36,13 @@ public abstract class CloudantClientHelper {
     static final String SERVER_USER;
     static final String SERVER_PASSWORD;
     static final String SERVER_HOST;
+    //some tests need access to the URL
+    static final URL SERVER_URL;
 
     private static final CloudantClient CLIENT_INSTANCE;
 
     private static final String SERVER_PORT;
     private static final String SERVER_PROTOCOL;
-    private static final URL SERVER_URL;
 
     static {
 

--- a/cloudant-client/src/test/java/com/cloudant/tests/CloudantClientTests.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/CloudantClientTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015, 2019 IBM Corp. All rights reserved.
+ * Copyright © 2015, 2021 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -500,7 +500,7 @@ public class CloudantClientTests extends TestWithDbPerClass {
                 new BasicAuthInterceptor(CloudantClientHelper.SERVER_USER
                         + ":" + CloudantClientHelper.SERVER_PASSWORD);
 
-        CloudantClient client = ClientBuilder.account(CloudantClientHelper.SERVER_USER)
+        CloudantClient client = ClientBuilder.url(CloudantClientHelper.SERVER_URL)
                 .interceptors(interceptor).build();
 
         // Test passes if there are no exceptions

--- a/cloudant-client/src/test/java/com/cloudant/tests/HttpIamTest.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/HttpIamTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017, 2019 IBM Corp. All rights reserved.
+ * Copyright © 2017, 2021 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -14,7 +14,6 @@
 
 package com.cloudant.tests;
 
-import static com.cloudant.http.internal.interceptors.IamCookieInterceptor.IAM_TOKEN_SERVER_URL_PROPERTY_KEY;
 import static com.cloudant.tests.HttpTest.takeN;
 import static com.cloudant.tests.util.MockWebServerResources.EXPECTED_OK_COOKIE;
 import static com.cloudant.tests.util.MockWebServerResources.EXPECTED_OK_COOKIE_2;
@@ -40,6 +39,7 @@ import com.cloudant.client.api.CloudantClient;
 import com.cloudant.client.org.lightcouch.CouchDbException;
 import com.cloudant.http.Http;
 import com.cloudant.http.interceptors.Replay429Interceptor;
+import com.cloudant.tests.extensions.MockIamWebServerExtension;
 import com.cloudant.tests.extensions.MockWebServerExtension;
 import com.cloudant.tests.util.MockWebServerResources;
 
@@ -64,7 +64,7 @@ public class HttpIamTest {
     public MockWebServerExtension mockWebServerExt = new MockWebServerExtension();
 
     @RegisterExtension
-    public MockWebServerExtension mockIamServerExt = new MockWebServerExtension();
+    public MockWebServerExtension mockIamServerExt = new MockIamWebServerExtension();
 
     public MockWebServer mockWebServer;
     public MockWebServer mockIamServer;
@@ -76,14 +76,6 @@ public class HttpIamTest {
     public void setIAMMockEndpoint() {
         mockWebServer = mockWebServerExt.get();
         mockIamServer = mockIamServerExt.get();
-        // Override the default IAM token server with our test mock server
-        System.setProperty(IAM_TOKEN_SERVER_URL_PROPERTY_KEY, mockIamServer.url(iamTokenEndpoint)
-                .toString());
-    }
-
-    @AfterEach
-    public void clearIAMMock() {
-        System.clearProperty(IAM_TOKEN_SERVER_URL_PROPERTY_KEY);
     }
 
     /**

--- a/cloudant-client/src/test/java/com/cloudant/tests/SessionInterceptorExpiryTests.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/SessionInterceptorExpiryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017, 2018 IBM Corp. All rights reserved.
+ * Copyright © 2017, 2021 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -14,7 +14,6 @@
 
 package com.cloudant.tests;
 
-import static com.cloudant.http.internal.interceptors.IamCookieInterceptor.IAM_TOKEN_SERVER_URL_PROPERTY_KEY;
 import static com.cloudant.tests.util.MockWebServerResources.iamTokenEndpoint;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -30,6 +29,7 @@ import com.cloudant.http.internal.DefaultHttpUrlConnectionFactory;
 import com.cloudant.http.internal.interceptors.CookieInterceptor;
 import com.cloudant.http.internal.interceptors.IamCookieInterceptor;
 import com.cloudant.http.internal.ok.OkHttpClientHttpUrlConnectionFactory;
+import com.cloudant.tests.extensions.MockIamWebServerExtension;
 import com.cloudant.tests.extensions.MockWebServerExtension;
 import com.cloudant.tests.util.HttpFactoryParameterizedTest;
 import com.cloudant.tests.util.MockWebServerResources;
@@ -120,7 +120,7 @@ public class SessionInterceptorExpiryTests extends HttpFactoryParameterizedTest 
     public MockWebServerExtension mockWebServerExt = new MockWebServerExtension();
     public MockWebServer mockWebServer;
     @RegisterExtension
-    public MockWebServerExtension mockIamServerExt = new MockWebServerExtension();
+    public MockWebServerExtension mockIamServerExt = new MockIamWebServerExtension();
     public MockWebServer mockIamServer;
 
     private HttpConnectionRequestInterceptor rqInterceptor;
@@ -139,20 +139,12 @@ public class SessionInterceptorExpiryTests extends HttpFactoryParameterizedTest 
             rpInterceptor = ci;
         } else if (sessionPath.equals("/_iam_session")) {
             // Set the endpoint value before each test
-            // Override the default IAM token server with our test mock server
-            System.setProperty(IAM_TOKEN_SERVER_URL_PROPERTY_KEY, mockIamServer.url(iamTokenEndpoint)
-                    .toString());
             IamCookieInterceptor ici = new IamCookieInterceptor("apikey", baseUrl);
             rqInterceptor = ici;
             rpInterceptor = ici;
         } else {
             fail("Invalid sessionPath " + sessionPath);
         }
-    }
-
-    @AfterEach
-    public void clearIAMMock() {
-        System.clearProperty(IAM_TOKEN_SERVER_URL_PROPERTY_KEY);
     }
 
     private void queueResponses(boolean okUsable,


### PR DESCRIPTION
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description

Change the test server configuration and allow for overriding the token server used by tests.

### 1. Steps to reproduce and the simplest code sample possible to demonstrate the issue

Run Jenkins tests with a custom IAM token server.

### 2. What you expected to happen

Tests to pass.

### 3. What actually happened

Test failures.

## Approach

1. Add `TEST_IAM_TOKEN_URL` environment variable
    - Update `Jenkinsfile`
    - Update `cloudant-client/build.gradle` 
2. Fix tests to work with above (see "Testing" below)
3. Added new env vars and cred IDs to `Jenkinsfile`

## Schema & API Changes

- "No change"

## Security and Privacy

- "No change"

## Testing

- Modified existing tests to support changing IAM token server.
    - Map `TEST_IAM_TOKEN_URL` env var into `com.cloudant.client.iamserver` system property for test JVM
    - Move test env var mapping to apply to all gradle tasks of type `Test`
    - Add `MockIamWebServerExtension` to temporarily change `com.cloudant.client.iamserver` system property during tests using a mock IAM server, replacing the configured value after tests. Consume this extension in these tests:
        - cloudant-client/src/test/java/com/cloudant/tests/CloudFoundryServiceTest.java
        - cloudant-client/src/test/java/com/cloudant/tests/HttpIamTest.java
        - cloudant-client/src/test/java/com/cloudant/tests/SessionInterceptorExpiryTests.java

IAM testing normally only runs on the `master` branch - I temporarily enabled it for this branch and observed 7 failures relating to the tuning configuration of the new test server. They should resolve when the server configuration is updated.

## Monitoring and Logging

- "No change"
