### PR TITLE
Type of `sinceSeq` can be also a String besides an Integer

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 # Unreleased
 - [DEPRECATED] This library is now deprecated and will be EOL on Dec 31 2021.
+- [FIXED] Type of `sinceSeq` can be also a String besides an Integer.
 
 # 2.19.2 (2021-04-07)
 - [NEW] Add migration guide to the newly supported cloudant-java-sdk (coordinates: com.ibm.cloud:cloudant).

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 # Unreleased
 - [DEPRECATED] This library is now deprecated and will be EOL on Dec 31 2021.
-- [FIXED] Type of `sinceSeq` can be also a String besides an Integer.
+- [FIXED] Type of `sinceSeq` can be also a `String` besides an `Integer`.
 
 # 2.19.2 (2021-04-07)
 - [NEW] Add migration guide to the newly supported cloudant-java-sdk (coordinates: com.ibm.cloud:cloudant).

--- a/cloudant-client/src/main/java/com/cloudant/client/api/Replication.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/Replication.java
@@ -177,7 +177,7 @@ public class Replication {
      * @param sinceSeq sequence number
      * @return this Replication instance to set more options or trigger the replication
      */
-    public Replication sinceSeq(Integer sinceSeq) {
+    public Replication sinceSeq(String sinceSeq) {
         this.replication = replication.sinceSeq(sinceSeq);
         return this;
     }

--- a/cloudant-client/src/main/java/com/cloudant/client/api/Replication.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/Replication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 IBM Corp. All rights reserved.
+ * Copyright (c) 2015, 2021 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -178,6 +178,9 @@ public class Replication {
      * @return this Replication instance to set more options or trigger the replication
      */
     public Replication sinceSeq(String sinceSeq) {
+        if (sinceSeq.startsWith("\"") && sinceSeq.endsWith("\"")) {
+            sinceSeq = sinceSeq.substring(1, sinceSeq.length() - 1);
+        }
         this.replication = replication.sinceSeq(sinceSeq);
         return this;
     }

--- a/cloudant-client/src/main/java/com/cloudant/client/api/Replication.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/Replication.java
@@ -17,6 +17,7 @@ package com.cloudant.client.api;
 import com.cloudant.client.org.lightcouch.ReplicationResult;
 import com.cloudant.client.org.lightcouch.ReplicationResult.ReplicationHistory;
 import com.cloudant.client.org.lightcouch.Replicator;
+import com.google.gson.JsonElement;
 
 import java.util.Map;
 
@@ -177,10 +178,7 @@ public class Replication {
      * @param sinceSeq sequence number
      * @return this Replication instance to set more options or trigger the replication
      */
-    public Replication sinceSeq(String sinceSeq) {
-        if (sinceSeq.startsWith("\"") && sinceSeq.endsWith("\"")) {
-            sinceSeq = sinceSeq.substring(1, sinceSeq.length() - 1);
-        }
+    public Replication sinceSeq(JsonElement sinceSeq) {
         this.replication = replication.sinceSeq(sinceSeq);
         return this;
     }

--- a/cloudant-client/src/main/java/com/cloudant/client/api/Replication.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/Replication.java
@@ -17,7 +17,10 @@ package com.cloudant.client.api;
 import com.cloudant.client.org.lightcouch.ReplicationResult;
 import com.cloudant.client.org.lightcouch.ReplicationResult.ReplicationHistory;
 import com.cloudant.client.org.lightcouch.Replicator;
+import com.google.gson.Gson;
 import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
+import com.google.gson.JsonPrimitive;
 
 import java.util.Map;
 
@@ -178,8 +181,19 @@ public class Replication {
      * @param sinceSeq sequence number
      * @return this Replication instance to set more options or trigger the replication
      */
-    public Replication sinceSeq(JsonElement sinceSeq) {
-        this.replication = replication.sinceSeq(sinceSeq);
+    public Replication sinceSeq(Integer sinceSeq) {
+        this.replication = replication.sinceSeq(new JsonParser().parse(sinceSeq.toString()));
+        return this;
+    }
+
+    /**
+     * Starts a replication since an update sequence.
+     *
+     * @param sinceSeq sequence number
+     * @return this Replication instance to set more options or trigger the replication
+     */
+    public Replication sinceSeq(String sinceSeq) {
+        this.replication = replication.sinceSeq(new JsonParser().parse(sinceSeq));
         return this;
     }
 

--- a/cloudant-client/src/main/java/com/cloudant/client/api/Replication.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/Replication.java
@@ -17,10 +17,7 @@ package com.cloudant.client.api;
 import com.cloudant.client.org.lightcouch.ReplicationResult;
 import com.cloudant.client.org.lightcouch.ReplicationResult.ReplicationHistory;
 import com.cloudant.client.org.lightcouch.Replicator;
-import com.google.gson.Gson;
-import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
-import com.google.gson.JsonPrimitive;
 
 import java.util.Map;
 

--- a/cloudant-client/src/main/java/com/cloudant/client/api/Replication.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/Replication.java
@@ -173,7 +173,7 @@ public class Replication {
     }
 
     /**
-     * Starts a replication since an update sequence.
+     * Create or modify a replication since an update sequence using a replication document.
      *
      * @param sinceSeq sequence number
      * @return this Replication instance to set more options or trigger the replication
@@ -184,9 +184,9 @@ public class Replication {
     }
 
     /**
-     * Starts a replication since an update sequence.
+     * Create or modify a replication since an update sequence using a replication document.
      *
-     * @param sinceSeq sequence number
+     * @param sinceSeq sequence string
      * @return this Replication instance to set more options or trigger the replication
      */
     public Replication sinceSeq(String sinceSeq) {

--- a/cloudant-client/src/main/java/com/cloudant/client/api/Replicator.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/Replicator.java
@@ -226,7 +226,7 @@ public class Replicator {
      * Create a transient replication since an update sequence.
      *
      * @param sinceSeq sequence number
-     * @return this Replication instance to set more options or trigger the replication
+     * @return this Replicator instance to set more options or trigger the replication
      */
     public Replicator sinceSeq(Integer sinceSeq) {
         this.replicator = replicator.sinceSeq(new JsonParser().parse(sinceSeq.toString()));
@@ -237,7 +237,7 @@ public class Replicator {
      * Create a transient replication since an update sequence.
      *
      * @param sinceSeq sequence string
-     * @return this Replication instance to set more options or trigger the replication
+     * @return this Replicator instance to set more options or trigger the replication
      */
     public Replicator sinceSeq(String sinceSeq) {
         this.replicator = replicator.sinceSeq(new JsonParser().parse(sinceSeq));

--- a/cloudant-client/src/main/java/com/cloudant/client/api/Replicator.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/Replicator.java
@@ -19,6 +19,7 @@ import com.cloudant.client.org.lightcouch.Replication;
 import com.cloudant.client.org.lightcouch.ReplicatorDocument;
 import com.cloudant.client.org.lightcouch.Response;
 import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -222,8 +223,25 @@ public class Replicator {
         return this;
     }
 
-    public Replicator sinceSeq(JsonElement sinceSeq) {
-        this.replicator = replicator.sinceSeq(sinceSeq);
+    /**
+     * Starts a replication since an update sequence.
+     *
+     * @param sinceSeq sequence number
+     * @return this Replication instance to set more options or trigger the replication
+     */
+    public Replicator sinceSeq(Integer sinceSeq) {
+        this.replicator = replicator.sinceSeq(new JsonParser().parse(sinceSeq.toString()));
+        return this;
+    }
+
+    /**
+     * Starts a replication since an update sequence.
+     *
+     * @param sinceSeq sequence number
+     * @return this Replication instance to set more options or trigger the replication
+     */
+    public Replicator sinceSeq(String sinceSeq) {
+        this.replicator = replicator.sinceSeq(new JsonParser().parse(sinceSeq));
         return this;
     }
 

--- a/cloudant-client/src/main/java/com/cloudant/client/api/Replicator.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/Replicator.java
@@ -18,6 +18,7 @@ import com.cloudant.client.api.query.Selector;
 import com.cloudant.client.org.lightcouch.Replication;
 import com.cloudant.client.org.lightcouch.ReplicatorDocument;
 import com.cloudant.client.org.lightcouch.Response;
+import com.google.gson.JsonElement;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -221,10 +222,7 @@ public class Replicator {
         return this;
     }
 
-    public Replicator sinceSeq(String sinceSeq) {
-        if (sinceSeq.startsWith("\"") && sinceSeq.endsWith("\"")) {
-            sinceSeq = sinceSeq.substring(1, sinceSeq.length() - 1);
-        }
+    public Replicator sinceSeq(JsonElement sinceSeq) {
         this.replicator = replicator.sinceSeq(sinceSeq);
         return this;
     }

--- a/cloudant-client/src/main/java/com/cloudant/client/api/Replicator.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/Replicator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019 IBM Corp. All rights reserved.
+ * Copyright (c) 2015, 2021 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -222,6 +222,9 @@ public class Replicator {
     }
 
     public Replicator sinceSeq(String sinceSeq) {
+        if (sinceSeq.startsWith("\"") && sinceSeq.endsWith("\"")) {
+            sinceSeq = sinceSeq.substring(1, sinceSeq.length() - 1);
+        }
         this.replicator = replicator.sinceSeq(sinceSeq);
         return this;
     }

--- a/cloudant-client/src/main/java/com/cloudant/client/api/Replicator.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/Replicator.java
@@ -223,7 +223,7 @@ public class Replicator {
     }
 
     /**
-     * Starts a replication since an update sequence.
+     * Create a transient replication since an update sequence.
      *
      * @param sinceSeq sequence number
      * @return this Replication instance to set more options or trigger the replication
@@ -234,9 +234,9 @@ public class Replicator {
     }
 
     /**
-     * Starts a replication since an update sequence.
+     * Create a transient replication since an update sequence.
      *
-     * @param sinceSeq sequence number
+     * @param sinceSeq sequence string
      * @return this Replication instance to set more options or trigger the replication
      */
     public Replicator sinceSeq(String sinceSeq) {

--- a/cloudant-client/src/main/java/com/cloudant/client/api/Replicator.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/Replicator.java
@@ -18,7 +18,6 @@ import com.cloudant.client.api.query.Selector;
 import com.cloudant.client.org.lightcouch.Replication;
 import com.cloudant.client.org.lightcouch.ReplicatorDocument;
 import com.cloudant.client.org.lightcouch.Response;
-import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
 
 import java.util.ArrayList;

--- a/cloudant-client/src/main/java/com/cloudant/client/api/Replicator.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/Replicator.java
@@ -221,7 +221,7 @@ public class Replicator {
         return this;
     }
 
-    public Replicator sinceSeq(Integer sinceSeq) {
+    public Replicator sinceSeq(String sinceSeq) {
         this.replicator = replicator.sinceSeq(sinceSeq);
         return this;
     }

--- a/cloudant-client/src/main/java/com/cloudant/client/api/model/ChangesResult.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/model/ChangesResult.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2011 lightcouch.org
- * Copyright (c) 2015 2016 IBM Corp. All rights reserved.
+ * Copyright (c) 2015, 2021 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -39,8 +39,8 @@ public class ChangesResult {
         return results;
     }
 
-    public String getLastSeq() {
-        return lastSeq.toString();
+    public JsonElement getLastSeq() {
+        return lastSeq;
     }
 
 
@@ -54,8 +54,8 @@ public class ChangesResult {
         private boolean deleted;
         private JsonObject doc;
 
-        public String getSeq() {
-            return seq.toString();
+        public JsonElement getSeq() {
+            return seq;
         }
 
         public String getId() {

--- a/cloudant-client/src/main/java/com/cloudant/client/api/model/ChangesResult.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/model/ChangesResult.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2011 lightcouch.org
- * Copyright (c) 2015, 2021 IBM Corp. All rights reserved.
+ * Copyright (c) 2015 2016 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -39,8 +39,8 @@ public class ChangesResult {
         return results;
     }
 
-    public JsonElement getLastSeq() {
-        return lastSeq;
+    public String getLastSeq() {
+        return lastSeq.toString();
     }
 
 
@@ -54,8 +54,8 @@ public class ChangesResult {
         private boolean deleted;
         private JsonObject doc;
 
-        public JsonElement getSeq() {
-            return seq;
+        public String getSeq() {
+            return seq.toString();
         }
 
         public String getId() {

--- a/cloudant-client/src/main/java/com/cloudant/client/api/model/ReplicatorDocument.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/model/ReplicatorDocument.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 IBM Corp. All rights reserved.
+ * Copyright (c) 2015, 2021 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at

--- a/cloudant-client/src/main/java/com/cloudant/client/api/model/ReplicatorDocument.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/model/ReplicatorDocument.java
@@ -16,6 +16,7 @@ package com.cloudant.client.api.model;
 
 import com.cloudant.client.org.lightcouch.Attachment;
 import com.cloudant.client.org.lightcouch.Replicator;
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 
 import java.util.HashMap;
@@ -227,11 +228,11 @@ public class ReplicatorDocument {
         replicatorDocument.setRetriesPerRequest(retriesPerRequest);
     }
 
-    public String getSinceSeq() {
+    public JsonElement getSinceSeq() {
         return replicatorDocument.getSinceSeq();
     }
 
-    public void setSinceSeq(String sinceSeq) {
+    public void setSinceSeq(JsonElement sinceSeq) {
         replicatorDocument.setSinceSeq(sinceSeq);
     }
 

--- a/cloudant-client/src/main/java/com/cloudant/client/api/model/ReplicatorDocument.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/model/ReplicatorDocument.java
@@ -227,11 +227,11 @@ public class ReplicatorDocument {
         replicatorDocument.setRetriesPerRequest(retriesPerRequest);
     }
 
-    public Integer getSinceSeq() {
+    public String getSinceSeq() {
         return replicatorDocument.getSinceSeq();
     }
 
-    public void setSinceSeq(Integer sinceSeq) {
+    public void setSinceSeq(String sinceSeq) {
         replicatorDocument.setSinceSeq(sinceSeq);
     }
 

--- a/cloudant-client/src/main/java/com/cloudant/client/api/model/ReplicatorDocument.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/model/ReplicatorDocument.java
@@ -229,8 +229,16 @@ public class ReplicatorDocument {
         replicatorDocument.setRetriesPerRequest(retriesPerRequest);
     }
 
-    public JsonElement getSinceSeq() {
-        return replicatorDocument.getSinceSeq();
+    public Integer getSinceSeq() {
+        try {
+            return replicatorDocument.getSinceSeq().getAsInt();
+        } catch (UnsupportedOperationException uoe) {
+            throw new IllegalStateException(uoe);
+        }
+    }
+
+    public String getSinceSeqString() {
+        return replicatorDocument.getSinceSeq().getAsString();
     }
 
     public void setSinceSeq(Integer sinceSeq) {

--- a/cloudant-client/src/main/java/com/cloudant/client/api/model/ReplicatorDocument.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/model/ReplicatorDocument.java
@@ -230,11 +230,7 @@ public class ReplicatorDocument {
     }
 
     public Integer getSinceSeq() {
-        try {
-            return replicatorDocument.getSinceSeq().getAsInt();
-        } catch (UnsupportedOperationException uoe) {
-            throw new IllegalStateException(uoe);
-        }
+        return replicatorDocument.getSinceSeq().getAsInt();
     }
 
     public String getSinceSeqString() {

--- a/cloudant-client/src/main/java/com/cloudant/client/api/model/ReplicatorDocument.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/model/ReplicatorDocument.java
@@ -18,6 +18,7 @@ import com.cloudant.client.org.lightcouch.Attachment;
 import com.cloudant.client.org.lightcouch.Replicator;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -232,8 +233,12 @@ public class ReplicatorDocument {
         return replicatorDocument.getSinceSeq();
     }
 
-    public void setSinceSeq(JsonElement sinceSeq) {
-        replicatorDocument.setSinceSeq(sinceSeq);
+    public void setSinceSeq(Integer sinceSeq) {
+        replicatorDocument.setSinceSeq(new JsonParser().parse(sinceSeq.toString()));
+    }
+
+    public void setSinceSeq(String sinceSeq) {
+        replicatorDocument.setSinceSeq(new JsonParser().parse(sinceSeq));
     }
 
     public void setSourceIamApiKey(String iamApiKey) {

--- a/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/Replication.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/Replication.java
@@ -77,7 +77,7 @@ public class Replication {
     private String[] docIds;
     private String proxy;
     private Boolean createTarget;
-    private Integer sinceSeq;
+    private String sinceSeq;
 
     // IAM
     private String sourceIamApiKey;
@@ -177,7 +177,7 @@ public class Replication {
     /**
      * Starts a replication since an update sequence.
      */
-    public Replication sinceSeq(Integer sinceSeq) {
+    public Replication sinceSeq(String sinceSeq) {
         this.sinceSeq = sinceSeq;
         return this;
     }

--- a/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/Replication.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/Replication.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2011 lightcouch.org
- * Copyright (c) 2015 IBM Corp. All rights reserved.
+ * Copyright (c) 2015, 2021 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -19,6 +19,7 @@ import static com.cloudant.client.org.lightcouch.internal.CouchDbUtil.assertNotE
 import static com.cloudant.client.org.lightcouch.internal.CouchDbUtil.close;
 
 import com.cloudant.client.internal.DatabaseURIHelper;
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 
 import java.io.InputStream;
@@ -77,7 +78,7 @@ public class Replication {
     private String[] docIds;
     private String proxy;
     private Boolean createTarget;
-    private String sinceSeq;
+    private JsonElement sinceSeq;
 
     // IAM
     private String sourceIamApiKey;
@@ -177,7 +178,7 @@ public class Replication {
     /**
      * Starts a replication since an update sequence.
      */
-    public Replication sinceSeq(String sinceSeq) {
+    public Replication sinceSeq(JsonElement sinceSeq) {
         this.sinceSeq = sinceSeq;
         return this;
     }

--- a/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/Replicator.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/Replicator.java
@@ -274,7 +274,7 @@ public class Replicator {
         return this;
     }
 
-    public Replicator sinceSeq(String sinceSeq) {
+    public Replicator sinceSeq(JsonElement sinceSeq) {
         replicatorDoc.setSinceSeq(sinceSeq);
         return this;
     }

--- a/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/Replicator.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/Replicator.java
@@ -274,7 +274,7 @@ public class Replicator {
         return this;
     }
 
-    public Replicator sinceSeq(Integer sinceSeq) {
+    public Replicator sinceSeq(String sinceSeq) {
         replicatorDoc.setSinceSeq(sinceSeq);
         return this;
     }

--- a/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/Replicator.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/Replicator.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2011 lightcouch.org
- * Copyright (c) 2015, 2019 IBM Corp. All rights reserved.
+ * Copyright (c) 2015, 2021 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at

--- a/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/ReplicatorDocument.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/ReplicatorDocument.java
@@ -68,7 +68,7 @@ public class ReplicatorDocument extends Document {
     @SerializedName("user_ctx")
     private UserCtx userCtx;
     @SerializedName("since_seq")
-    private Integer sinceSeq;
+    private String sinceSeq;
     private JsonElement selector;
 
     public String getSource() {
@@ -268,11 +268,11 @@ public class ReplicatorDocument extends Document {
         this.retriesPerRequest = retriesPerRequest;
     }
 
-    public Integer getSinceSeq() {
+    public String getSinceSeq() {
         return sinceSeq;
     }
 
-    public void setSinceSeq(Integer sinceSeq) {
+    public void setSinceSeq(String sinceSeq) {
         this.sinceSeq = sinceSeq;
     }
 

--- a/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/ReplicatorDocument.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/ReplicatorDocument.java
@@ -68,7 +68,7 @@ public class ReplicatorDocument extends Document {
     @SerializedName("user_ctx")
     private UserCtx userCtx;
     @SerializedName("since_seq")
-    private String sinceSeq;
+    private JsonElement sinceSeq;
     private JsonElement selector;
 
     public String getSource() {
@@ -268,11 +268,11 @@ public class ReplicatorDocument extends Document {
         this.retriesPerRequest = retriesPerRequest;
     }
 
-    public String getSinceSeq() {
+    public JsonElement getSinceSeq() {
         return sinceSeq;
     }
 
-    public void setSinceSeq(String sinceSeq) {
+    public void setSinceSeq(JsonElement sinceSeq) {
         this.sinceSeq = sinceSeq;
     }
 

--- a/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/ReplicatorDocument.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/org/lightcouch/ReplicatorDocument.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2011 lightcouch.org
- * Copyright (c) 2015, 2019 IBM Corp. All rights reserved.
+ * Copyright (c) 2015, 2021 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at

--- a/cloudant-client/src/test/java/com/cloudant/tests/ReplicationTest.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/ReplicationTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2011 lightcouch.org
- * Copyright © 2015, 2019 IBM Corp. All rights reserved.
+ * Copyright © 2015, 2021 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -36,10 +36,13 @@ public class ReplicationTest extends TestWithReplication {
 
     @Test
     public void replication() {
+        String seq = db1.changes().getChanges().getResults().get(0).getSeq();
+
         ReplicationResult result = db1Resource.appendReplicationAuth(account.replication()
                 .createTarget(true)
                 .source(db1URI)
                 .target(db2URI)
+            .sinceSeq(seq)
         )
                 .trigger();
 
@@ -90,15 +93,18 @@ public class ReplicationTest extends TestWithReplication {
         Foo foodb1 = new Foo(docId, "titleX");
         Foo foodb2 = new Foo(docId, "titleY");
 
+        String lastSeq = db1Resource.get().changes().getChanges().getLastSeq();
         //save Foo(X) in DB1
         db1.save(foodb1);
         //save Foo(Y) in DB2
         db2.save(foodb2);
 
         //replicate with DB1 with DB2
-        ReplicationResult result =
-                db1Resource.appendReplicationAuth(account.replication().source(db1URI)
-                .target(db2URI)).trigger();
+        ReplicationResult result = db1Resource.appendReplicationAuth(account.replication()
+            .source(db1URI)
+            .target(db2URI)
+            .sinceSeq(lastSeq)
+        ).trigger();
 
         assertTrue(result.isOk(), "The replication should complete ok");
 

--- a/cloudant-client/src/test/java/com/cloudant/tests/ReplicationTest.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/ReplicationTest.java
@@ -101,8 +101,8 @@ public class ReplicationTest extends TestWithReplication {
 
         //replicate with DB1 with DB2
         ReplicationResult result =
-            db1Resource.appendReplicationAuth(account.replication().source(db1URI)
-            .target(db2URI).sinceSeq(lastSeq)).trigger();
+                db1Resource.appendReplicationAuth(account.replication().source(db1URI)
+                .target(db2URI).sinceSeq(lastSeq)).trigger();
 
         assertTrue(result.isOk(), "The replication should complete ok");
 

--- a/cloudant-client/src/test/java/com/cloudant/tests/ReplicationTest.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/ReplicationTest.java
@@ -37,7 +37,7 @@ public class ReplicationTest extends TestWithReplication {
 
     @Test
     public void replication() {
-        JsonElement seq = db1.changes().getChanges().getResults().get(0).getSeq();
+        String seq = db1.changes().getChanges().getResults().get(0).getSeq();
 
         ReplicationResult result = db1Resource.appendReplicationAuth(account.replication()
                 .createTarget(true)
@@ -94,7 +94,7 @@ public class ReplicationTest extends TestWithReplication {
         Foo foodb1 = new Foo(docId, "titleX");
         Foo foodb2 = new Foo(docId, "titleY");
 
-        JsonElement lastSeq = db1Resource.get().changes().getChanges().getLastSeq();
+        String lastSeq = db1Resource.get().changes().getChanges().getLastSeq();
         //save Foo(X) in DB1
         db1.save(foodb1);
         //save Foo(Y) in DB2

--- a/cloudant-client/src/test/java/com/cloudant/tests/ReplicationTest.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/ReplicationTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2011 lightcouch.org
- * Copyright © 2015, 2019 IBM Corp. All rights reserved.
+ * Copyright © 2015, 2021 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at

--- a/cloudant-client/src/test/java/com/cloudant/tests/ReplicationTest.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/ReplicationTest.java
@@ -25,7 +25,6 @@ import com.cloudant.test.main.RequiresDB;
 import com.cloudant.tests.base.TestWithReplication;
 import com.cloudant.tests.util.Utils;
 
-import com.google.gson.JsonElement;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
@@ -43,7 +42,7 @@ public class ReplicationTest extends TestWithReplication {
                 .createTarget(true)
                 .source(db1URI)
                 .target(db2URI)
-            .sinceSeq(seq)
+                .sinceSeq(seq)
         )
                 .trigger();
 
@@ -101,11 +100,9 @@ public class ReplicationTest extends TestWithReplication {
         db2.save(foodb2);
 
         //replicate with DB1 with DB2
-        ReplicationResult result = db1Resource.appendReplicationAuth(account.replication()
-            .source(db1URI)
-            .target(db2URI)
-            .sinceSeq(lastSeq)
-        ).trigger();
+        ReplicationResult result =
+            db1Resource.appendReplicationAuth(account.replication().source(db1URI)
+            .target(db2URI).sinceSeq(lastSeq)).trigger();
 
         assertTrue(result.isOk(), "The replication should complete ok");
 

--- a/cloudant-client/src/test/java/com/cloudant/tests/ReplicationTest.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/ReplicationTest.java
@@ -25,6 +25,7 @@ import com.cloudant.test.main.RequiresDB;
 import com.cloudant.tests.base.TestWithReplication;
 import com.cloudant.tests.util.Utils;
 
+import com.google.gson.JsonElement;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
@@ -36,7 +37,7 @@ public class ReplicationTest extends TestWithReplication {
 
     @Test
     public void replication() {
-        String seq = db1.changes().getChanges().getResults().get(0).getSeq();
+        JsonElement seq = db1.changes().getChanges().getResults().get(0).getSeq();
 
         ReplicationResult result = db1Resource.appendReplicationAuth(account.replication()
                 .createTarget(true)
@@ -93,7 +94,7 @@ public class ReplicationTest extends TestWithReplication {
         Foo foodb1 = new Foo(docId, "titleX");
         Foo foodb2 = new Foo(docId, "titleY");
 
-        String lastSeq = db1Resource.get().changes().getChanges().getLastSeq();
+        JsonElement lastSeq = db1Resource.get().changes().getChanges().getLastSeq();
         //save Foo(X) in DB1
         db1.save(foodb1);
         //save Foo(Y) in DB2

--- a/cloudant-client/src/test/java/com/cloudant/tests/ReplicatorTest.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/ReplicatorTest.java
@@ -51,7 +51,7 @@ public class ReplicatorTest extends TestWithReplication {
 
     @Test
     public void replication() throws Exception {
-        JsonElement seq = db1.changes().getChanges().getResults().get(0).getSeq();
+        String seq = db1.changes().getChanges().getResults().get(0).getSeq();
         Response response = db1Resource.appendReplicatorAuth(account.replicator()
                 .replicatorDocId(repDocId)
                 .createTarget(true)
@@ -116,7 +116,7 @@ public class ReplicatorTest extends TestWithReplication {
         Foo foodb1 = new Foo(docId, "titleX");
         Foo foodb2 = new Foo(docId, "titleY");
 
-        JsonElement lastSeq = db1Resource.get().changes().getChanges().getLastSeq();
+        String lastSeq = db1Resource.get().changes().getChanges().getLastSeq();
 
         //save Foo(X) in DB1
         db1.save(foodb1);

--- a/cloudant-client/src/test/java/com/cloudant/tests/ReplicatorTest.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/ReplicatorTest.java
@@ -50,13 +50,13 @@ public class ReplicatorTest extends TestWithReplication {
 
     @Test
     public void replication() throws Exception {
-        String lastSeq = db1Resource.get().changes().getChanges().getLastSeq();
+        String seq = db1.changes().getChanges().getResults().get(0).getSeq();
         Response response = db1Resource.appendReplicatorAuth(account.replicator()
                 .replicatorDocId(repDocId)
                 .createTarget(true)
                 .source(db1URI)
                 .target(db2URI)
-                .sinceSeq(lastSeq)
+                .sinceSeq(seq)
         )
                 .save();
 
@@ -115,18 +115,18 @@ public class ReplicatorTest extends TestWithReplication {
         Foo foodb1 = new Foo(docId, "titleX");
         Foo foodb2 = new Foo(docId, "titleY");
 
+        String lastSeq = db1Resource.get().changes().getChanges().getLastSeq();
+
         //save Foo(X) in DB1
         db1.save(foodb1);
         //save Foo(Y) in DB2
         db2.save(foodb2);
 
-        String seq = db1.changes().getChanges().getResults().get(0).getSeq();
-
         //replicate with DB1 with DB2
         Response response = db1Resource.appendReplicatorAuth(account.replicator().source(db1URI)
                 .target(db2URI)
                 .replicatorDocId(repDocId)
-                .sinceSeq(seq)
+                .sinceSeq(lastSeq)
         )
                 .save();
 

--- a/cloudant-client/src/test/java/com/cloudant/tests/ReplicatorTest.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/ReplicatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015, 2019 IBM Corp. All rights reserved.
+ * Copyright © 2015, 2021 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -50,11 +50,13 @@ public class ReplicatorTest extends TestWithReplication {
 
     @Test
     public void replication() throws Exception {
+        String lastSeq = db1Resource.get().changes().getChanges().getLastSeq();
         Response response = db1Resource.appendReplicatorAuth(account.replicator()
                 .replicatorDocId(repDocId)
                 .createTarget(true)
                 .source(db1URI)
                 .target(db2URI)
+                .sinceSeq(lastSeq)
         )
                 .save();
 
@@ -118,9 +120,13 @@ public class ReplicatorTest extends TestWithReplication {
         //save Foo(Y) in DB2
         db2.save(foodb2);
 
+        String seq = db1.changes().getChanges().getResults().get(0).getSeq();
+
         //replicate with DB1 with DB2
         Response response = db1Resource.appendReplicatorAuth(account.replicator().source(db1URI)
-                .target(db2URI).replicatorDocId(repDocId)
+                .target(db2URI)
+                .replicatorDocId(repDocId)
+                .sinceSeq(seq)
         )
                 .save();
 

--- a/cloudant-client/src/test/java/com/cloudant/tests/ReplicatorTest.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/ReplicatorTest.java
@@ -25,6 +25,7 @@ import com.cloudant.test.main.RequiresDB;
 import com.cloudant.tests.base.TestWithReplication;
 import com.cloudant.tests.util.Utils;
 
+import com.google.gson.JsonElement;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -50,7 +51,7 @@ public class ReplicatorTest extends TestWithReplication {
 
     @Test
     public void replication() throws Exception {
-        String seq = db1.changes().getChanges().getResults().get(0).getSeq();
+        JsonElement seq = db1.changes().getChanges().getResults().get(0).getSeq();
         Response response = db1Resource.appendReplicatorAuth(account.replicator()
                 .replicatorDocId(repDocId)
                 .createTarget(true)
@@ -115,7 +116,7 @@ public class ReplicatorTest extends TestWithReplication {
         Foo foodb1 = new Foo(docId, "titleX");
         Foo foodb2 = new Foo(docId, "titleY");
 
-        String lastSeq = db1Resource.get().changes().getChanges().getLastSeq();
+        JsonElement lastSeq = db1Resource.get().changes().getChanges().getLastSeq();
 
         //save Foo(X) in DB1
         db1.save(foodb1);

--- a/cloudant-client/src/test/java/com/cloudant/tests/ReplicatorTest.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/ReplicatorTest.java
@@ -25,7 +25,6 @@ import com.cloudant.test.main.RequiresDB;
 import com.cloudant.tests.base.TestWithReplication;
 import com.cloudant.tests.util.Utils;
 
-import com.google.gson.JsonElement;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -125,9 +124,7 @@ public class ReplicatorTest extends TestWithReplication {
 
         //replicate with DB1 with DB2
         Response response = db1Resource.appendReplicatorAuth(account.replicator().source(db1URI)
-                .target(db2URI)
-                .replicatorDocId(repDocId)
-                .sinceSeq(lastSeq)
+                .target(db2URI).replicatorDocId(repDocId).sinceSeq(lastSeq)
         )
                 .save();
 

--- a/cloudant-client/src/test/java/com/cloudant/tests/ReplicatorTest.java
+++ b/cloudant-client/src/test/java/com/cloudant/tests/ReplicatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015, 2019 IBM Corp. All rights reserved.
+ * Copyright © 2015, 2021 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description

Fixes #526

## Approach

`seqs` could be `Integer`s in CouchDB 1.x and `String`s in 2.x, so I changed all the places where they remained `Integer`s to `JsonElement`. With this, both `Integer` and `String` can be used.

## Security and Privacy

- No change


## Testing

- This behavior can be tested with ITs well, so I just extended ITs with a plus `.sinceSeq(...)` call which is going to use a `seq` from a `{source_db}/_changes` request.


## Monitoring and Logging

- No change
