### PR TITLE
proxy support for cookie session and IAM authentication

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+# UNRELEASED
+- [FIXED] Enable proxy support for session cookie and IAM authentication.
+
 # 2.20.0 (2021-08-26)
 - [FIXED] Type of `sinceSeq` can be also a `String` besides an `Integer`.
 - [DEPRECATED] This library is now deprecated and will be EOL on Dec 31 2021.

--- a/cloudant-client/src/main/java/com/cloudant/client/api/ClientBuilder.java
+++ b/cloudant-client/src/main/java/com/cloudant/client/api/ClientBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015, 2020 IBM Corp. All rights reserved.
+ * Copyright © 2015, 2021 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -257,7 +257,7 @@ public class ClientBuilder {
 
             // Create IAM cookie interceptor and set in HttpConnection interceptors
             IamCookieInterceptor cookieInterceptor = new IamCookieInterceptor(this.iamApiKey,
-                    this.url.toString());
+                    this.url.toString(), this.proxyURL);
 
             props.addRequestInterceptors(cookieInterceptor);
             props.addResponseInterceptors(cookieInterceptor);
@@ -274,7 +274,9 @@ public class ClientBuilder {
             //make interceptor if both username and password are not null
 
             //Create cookie interceptor and set in HttpConnection interceptors
-            CookieInterceptor cookieInterceptor = new CookieInterceptor(username, password, this.url.toString());
+            CookieInterceptor cookieInterceptor = new CookieInterceptor(username, password,
+                    this.url.toString(), this.proxyURL);
+
 
             props.addRequestInterceptors(cookieInterceptor);
             props.addResponseInterceptors(cookieInterceptor);

--- a/cloudant-http/src/main/java/com/cloudant/http/internal/interceptors/CookieInterceptor.java
+++ b/cloudant-http/src/main/java/com/cloudant/http/internal/interceptors/CookieInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015, 2019 IBM Corp. All rights reserved.
+ * Copyright © 2015, 2021 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.HttpURLConnection;
+import java.net.URL;
 import java.net.URLEncoder;
 import java.util.Locale;
 import java.util.logging.Level;
@@ -41,13 +42,26 @@ public class CookieInterceptor extends CookieInterceptorBase {
      * @param baseURL  The base URL to use when constructing an `_session` request.
      */
     public CookieInterceptor(String username, String password, String baseURL) {
+        this(username, password, baseURL, null);
+    }
+
+    /**
+     * Constructs a cookie interceptor with proxy url.
+     * Credentials should be supplied not URL encoded, this class
+     * will perform the necessary URL encoding.
+     *
+     * @param username The username to use when getting the cookie (not URL encoded)
+     * @param password The password to use when getting the cookie (not URL encoded)
+     * @param baseURL  The base URL to use when constructing an `_session` request.
+     * @param proxyURL The URL of the proxy server
+     */
+    public CookieInterceptor(String username, String password, String baseURL, URL proxyURL) {
         // Use form encoding for the user/pass submission
-        super(baseURL, "/_session", "application/x-www-form-urlencoded");
+        super(baseURL, "/_session", "application/x-www-form-urlencoded", proxyURL);
         try {
             this.auth = String.format("name=%s&password=%s", URLEncoder.encode(username, "UTF-8")
-                    , URLEncoder.encode(password, "UTF-8"))
+                            , URLEncoder.encode(password, "UTF-8"))
                     .getBytes("UTF-8");
-            ;
         } catch (UnsupportedEncodingException e) {
             //all JVMs should support UTF-8, so this should not happen
             throw new RuntimeException(e);

--- a/cloudant-http/src/main/java/com/cloudant/http/internal/interceptors/IamCookieInterceptor.java
+++ b/cloudant-http/src/main/java/com/cloudant/http/internal/interceptors/IamCookieInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 IBM Corp. All rights reserved.
+ * Copyright © 2019, 2021 IBM Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -34,7 +34,11 @@ public class IamCookieInterceptor extends CookieInterceptorBase {
     private final byte[] tokenRequestPayload;
 
     public IamCookieInterceptor(String apiKey, String baseUrl) {
-        super(baseUrl, "/_iam_session", null);
+        this(apiKey, baseUrl, null);
+    }
+
+    public IamCookieInterceptor(String apiKey, String baseUrl, URL proxyURL) {
+        super(baseUrl, "/_iam_session", null, proxyURL);
 
         // Read iamServer from system property, or set default
         try {


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [ ] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description
Enable proxy support for cookie session and IAM authentication.
fixes #528 
<!--
Provide a short description; saving the detail for the `Approach` section

Also EITHER:
Link to issue this PR is resolving, use the Fixes #nnn form so that the
issue closes automatically when the PR merges e.g.:

Fixes #23

OR

For PRs without an associated issue and/or test/build issues

### 1. Steps to reproduce and the simplest code sample possible to demonstrate the issue
### 2. What you expected to happen
### 3. What actually happened
-->

## Approach
Extend the `CookieInterceptorBase` constructor with a proxy url parameter.
Update both `IamCookieInterceptor` and `CookieInterceptor` to support new proxy url parameter during initialization.
<!--
Be brief: which component(s) of the code base does the fix focus on.

A place to note whether the part of the code base that is being worked is
particularly sensitive.
-->

## Schema & API Changes

<!--
EITHER:

- "No change"

OR

For public API (as opposed to internal) changes

- "Fixing bug in API, will change x in such-and-such way"
-->

## Security and Privacy

<!--
EITHER:

- "No change"

OR

"Making changes in e.g. auth|https|encryption|io
need to be careful about..."

-->

## Testing
Manual testing against a local mock server.  The following tests passed:
1) Proxy enabled with request + session auth against local couchdb
2) Proxy enabled with request + session auth against Cloudant
3) Proxy enabled with request + IAM (only with built-in `HttpUrlConnection`) against Cloudant
<!--
EITHER:

- Added new tests:
    - test x
    - test y
    - test z

OR

- Modified existing tests because ...

OR

- N/A build or packaging only changes

OR

In exceptional circumstances there may be a good reason we can't add automated
tests, for example if a specific device is required to reproduce a problem.

- No new tests because...
-->

## Monitoring and Logging
<!--
EITHER:

- "No change"

OR

- "Added new log line X..."
-->
